### PR TITLE
fix: remove h4 hover glitch animation and stabilize card components

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -173,68 +173,8 @@
       position: relative;
       cursor: default;
     }
-    h4:hover {
-      animation: glitch-text 0.3s ease-out;
-    }
   }
 
-  @keyframes glitch-text {
-    0% {
-      opacity: 1;
-      transform: translate(0);
-      filter: blur(0);
-    }
-    10% {
-      opacity: 0.8;
-      transform: translate(-2px, 1px);
-      filter: blur(0.5px);
-      text-shadow: 2px 0 var(--primary), -2px 0 var(--accent-secondary);
-    }
-    20% {
-      opacity: 0.9;
-      transform: translate(2px, -1px);
-      filter: blur(0);
-      text-shadow: -2px 0 var(--primary), 2px 0 var(--accent-secondary);
-    }
-    30% {
-      opacity: 0.85;
-      transform: translate(-1px, 2px);
-      filter: blur(0.3px);
-      text-shadow: 1px 0 var(--primary), -1px 0 var(--accent-secondary);
-    }
-    40% {
-      opacity: 0.95;
-      transform: translate(1px, -1px);
-      filter: blur(0);
-      text-shadow: -1px 0 var(--primary), 1px 0 var(--accent-secondary);
-    }
-    50% {
-      opacity: 0.9;
-      transform: translate(-1px, 1px);
-      text-shadow: 0.5px 0 var(--primary), -0.5px 0 var(--accent-secondary);
-    }
-    60% {
-      opacity: 0.95;
-      transform: translate(1px, 0);
-      text-shadow: none;
-    }
-    70% {
-      opacity: 1;
-      transform: translate(-0.5px, 0.5px);
-    }
-    80% {
-      transform: translate(0.5px, -0.5px);
-    }
-    90% {
-      transform: translate(-0.25px, 0);
-    }
-    100% {
-      opacity: 1;
-      transform: translate(0);
-      filter: blur(0);
-      text-shadow: none;
-    }
-  }
 
   .memory-lattice {
     position: fixed;

--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -104,7 +104,7 @@ export default function NotFound() {
           {/* Main heading */}
           <motion.h1
             variants={itemVariants}
-            className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-[-0.03em] mb-6 leading-[0.95] text-foreground"
+            className="font-mono font-normal text-3xl sm:text-4xl lg:text-5xl xl:text-6xl mb-6 leading-[0.95] text-foreground"
           >
             <ScrambleText text="404" delayMs={300} duration={0.8} />
           </motion.h1>

--- a/packages/web/src/components/FAQ.tsx
+++ b/packages/web/src/components/FAQ.tsx
@@ -40,7 +40,7 @@ export function FAQ() {
               <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
               <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">Support</span>
             </div>
-            <h2 className="text-4xl md:text-5xl font-bold tracking-tighter text-foreground text-gradient">
+            <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
               <ScrambleText text="Questions & Answers" delayMs={200} />
             </h2>
             <p className="mt-6 text-lg text-muted-foreground max-w-2xl">
@@ -66,7 +66,7 @@ export function FAQ() {
           onClick={() => setIsOpen(!isOpen)}
           className="w-full flex items-center justify-between p-10 text-left transition-colors"
         >
-          <span className="font-bold tracking-tight text-lg text-foreground">{question}</span>
+          <span className="font-mono font-normal tracking-tight text-lg text-foreground">{question}</span>
         <div className={`transition-transform duration-500 ${isOpen ? 'rotate-45 text-primary' : 'text-muted-foreground/40'}`}>
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 5v14M5 12h14" />

--- a/packages/web/src/components/FeaturesGrid.tsx
+++ b/packages/web/src/components/FeaturesGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+
 import Link from "next/link";
 import { ScrambleText } from "./animations/ScrambleText";
 
@@ -101,7 +101,7 @@ export function FeaturesGrid() {
               <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
               <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">Core Features</span>
             </div>
-            <h2 className="text-4xl md:text-5xl font-bold tracking-tighter text-foreground text-gradient">
+            <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
               <ScrambleText text="Built for durable state" delayMs={200} />
             </h2>
             <p className="mt-6 text-lg text-muted-foreground max-w-2xl">
@@ -111,15 +111,11 @@ export function FeaturesGrid() {
   
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
             {features.map((f, idx) => (
-              <motion.div 
+              <div 
                 key={idx}
-                initial={{ opacity: 0 }}
-                whileInView={{ opacity: 1 }}
-                viewport={{ once: true, amount: 0.05 }}
-                transition={{ duration: 0.3 }}
-                className="group p-8 lg:p-10 glass-panel hover:border-primary/30 transition-all duration-500 relative overflow-hidden rounded-lg transform-gpu"
+                className="group p-8 lg:p-10 bg-card/30 border border-border shadow-lg dark:shadow-[0_20px_80px_rgba(0,0,0,0.45)] hover:ring-1 hover:ring-primary/30 relative overflow-hidden rounded-lg"
               >
-                <div className="text-primary/60 group-hover:text-primary transition-colors duration-500 mb-10">
+                <div className="text-primary/60 group-hover:text-primary mb-10">
                   <FeatureIcon index={idx} />
                 </div>
                 
@@ -140,16 +136,16 @@ export function FeaturesGrid() {
                     Learn More →
                   </Link>
                 </div>
-  
+
                 {/* Technical Hover Decor */}
-                <div className="absolute top-0 right-0 w-16 h-16 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-700">
+                <div className="absolute top-0 right-0 w-16 h-16 pointer-events-none opacity-0 group-hover:opacity-100">
                   <div className="absolute top-4 right-4 w-2 h-2 border-t border-r border-primary/40" />
                 </div>
-              </motion.div>
+              </div>
             ))}
             
-            <div className="group p-8 lg:p-10 bg-primary/10 border border-primary/30 flex flex-col glass-panel-soft rounded-lg hover:border-primary/40 transition-all duration-500 relative overflow-hidden transform-gpu">
-              <div className="text-primary/60 group-hover:text-primary transition-colors duration-500 mb-10">
+            <div className="group p-8 lg:p-10 bg-primary/10 border border-primary/30 flex flex-col shadow-md dark:shadow-[0_16px_50px_rgba(0,0,0,0.35)] rounded-lg hover:ring-1 hover:ring-primary/40 relative overflow-hidden">
+              <div className="text-primary/60 group-hover:text-primary mb-10">
                 <div className="w-6 h-6 border border-primary/60 rounded-full flex items-center justify-center">
                   <div className="w-1 h-1 bg-primary animate-pulse" />
                 </div>

--- a/packages/web/src/components/Footer.tsx
+++ b/packages/web/src/components/Footer.tsx
@@ -22,7 +22,7 @@ export function Footer() {
           
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-16 md:gap-24">
             <div className="flex flex-col gap-6">
-              <h5 className="text-[10px] uppercase tracking-[0.3em] font-bold text-foreground">Product</h5>
+              <h5 className="font-mono text-[10px] sm:text-xs uppercase tracking-wider text-white/50">Product</h5>
               <div className="flex flex-col gap-4 text-[11px] font-bold text-muted-foreground/60 uppercase tracking-[0.15em]">
                 <Link href="/docs" className="hover:text-primary transition-colors">Documentation</Link>
                 <Link href="/docs/cli" className="hover:text-primary transition-colors">CLI Reference</Link>
@@ -31,14 +31,14 @@ export function Footer() {
               </div>
             </div>
             <div className="flex flex-col gap-6">
-              <h5 className="text-[10px] uppercase tracking-[0.3em] font-bold text-foreground">Network</h5>
+              <h5 className="font-mono text-[10px] sm:text-xs uppercase tracking-wider text-white/50">Network</h5>
               <div className="flex flex-col gap-4 text-[11px] font-bold text-muted-foreground/60 uppercase tracking-[0.15em]">
                 <a href="https://discord.gg/2K7rhuwc" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">Discord</a>
                 <a href="https://x.com/WebRenew_" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">X (Twitter)</a>
               </div>
             </div>
             <div className="flex flex-col gap-6">
-              <h5 className="text-[10px] uppercase tracking-[0.3em] font-bold text-foreground">Legal</h5>
+              <h5 className="font-mono text-[10px] sm:text-xs uppercase tracking-wider text-white/50">Legal</h5>
               <div className="flex flex-col gap-4 text-[11px] font-bold text-muted-foreground/60 uppercase tracking-[0.15em]">
                 <a href="https://www.webrenew.com/privacy" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">Privacy</a>
                 <a href="https://www.webrenew.com/terms" target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">Terms</a>

--- a/packages/web/src/components/Hero.tsx
+++ b/packages/web/src/components/Hero.tsx
@@ -200,7 +200,7 @@ export function Hero() {
 
             <motion.h1 
               variants={itemVariants} 
-              className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-[-0.03em] mb-6 leading-[0.95] text-foreground"
+              className="font-mono font-normal text-3xl sm:text-4xl lg:text-5xl xl:text-6xl tracking-tight mb-6 leading-[0.95] text-foreground"
             >
               <ScrambleText text="The unified agent memory layer." delayMs={300} duration={1.2} />
             </motion.h1>

--- a/packages/web/src/components/HowItWorks.tsx
+++ b/packages/web/src/components/HowItWorks.tsx
@@ -188,7 +188,7 @@ export function HowItWorks() {
               </div>
 
               {/* Main heading */}
-              <h2 className="text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-foreground mb-4">
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl tracking-tight text-foreground mb-4">
                 <ScrambleText key={activeTab} text={tabContent[activeTab].heading} delayMs={0} duration={0.6} />
               </h2>
               
@@ -249,7 +249,7 @@ export function HowItWorks() {
 
               {/* Card title and description */}
               <div className="mt-6 pt-5 border-t border-border">
-                <h3 className="text-lg font-semibold text-foreground mb-2">
+                <h3 className="font-mono font-normal text-xl sm:text-2xl text-foreground mb-2">
                   {tabContent[activeTab].cardTitle}
                 </h3>
                 <p className="text-sm text-muted-foreground mb-4">

--- a/packages/web/src/components/Integrations.tsx
+++ b/packages/web/src/components/Integrations.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+
 import Image from "next/image";
 import Link from "next/link";
 import { ScrambleText } from "./animations/ScrambleText";
@@ -11,14 +11,14 @@ export function Integrations() {
       name: "Claude Code",
       logo: "/logos/claude-code.svg",
       status: "Available",
-      desc: "Generates CLAUDE.md for Anthropic's coding CLI.",
+      desc: "Generates CLAUDE.md, path-scoped rules, skills, and settings.",
       docsUrl: "/docs/integrations/claude-code",
     },
     {
       name: "Cursor",
       logo: "/logos/cursor.svg",
       status: "Available",
-      desc: "Generates .cursor/rules/memories.mdc with frontmatter.",
+      desc: "Generates .cursor/rules/ with globs frontmatter and skills.",
       docsUrl: "/docs/integrations/cursor",
     },
     {
@@ -59,7 +59,7 @@ export function Integrations() {
               <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
               <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">Integrations</span>
             </div>
-            <h2 className="text-4xl md:text-5xl font-bold tracking-tighter text-foreground text-gradient">
+            <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
               <ScrambleText text="Works With Your Tools" delayMs={200} />
             </h2>
             <p className="mt-6 text-lg text-muted-foreground max-w-2xl">
@@ -70,24 +70,18 @@ export function Integrations() {
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
             {adapters.map((a, idx) => (
               <Link href={a.docsUrl} key={idx}>
-                <motion.div 
-                  initial={{ opacity: 0 }}
-                  whileInView={{ opacity: 1 }}
-                  viewport={{ once: true, amount: 0.05 }}
-                  transition={{ duration: 0.3 }}
-                  className="p-8 lg:p-10 bg-card/20 flex flex-col items-start group hover:border-primary/40 transition-all h-full cursor-pointer glass-panel-soft rounded-lg relative overflow-hidden transform-gpu"
-                >
+                <div className="p-8 lg:p-10 bg-card/20 flex flex-col items-start group hover:ring-1 hover:ring-primary/40 h-full cursor-pointer border border-border shadow-md dark:shadow-[0_16px_50px_rgba(0,0,0,0.35)] rounded-lg relative overflow-hidden">
                   {/* Background texture - visible on hover */}
                   <div
-                    className="absolute inset-0 opacity-0 group-hover:opacity-15 dark:group-hover:opacity-25 bg-cover bg-center bg-no-repeat transition-opacity duration-500"
+                    className="absolute inset-0 opacity-0 group-hover:opacity-20 dark:group-hover:opacity-40 bg-cover bg-center bg-no-repeat"
                     style={{ backgroundImage: "url(/bg-texture_memories.webp)" }}
                   />
                   {/* Diamond gradient overlay - visible on hover */}
                   <div
-                    className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+                    className="absolute inset-0 opacity-0 group-hover:opacity-60 dark:group-hover:opacity-50"
                     style={{
                       background:
-                        "linear-gradient(135deg, transparent 0%, transparent 5%, var(--background) 25%, var(--background) 75%, transparent 95%, transparent 100%)",
+                        "linear-gradient(135deg, transparent 0%, transparent 10%, var(--background) 35%, var(--background) 65%, transparent 90%, transparent 100%)",
                     }}
                   />
 
@@ -97,7 +91,7 @@ export function Integrations() {
                   </span>
                   
                   {/* Icon - left aligned with headings */}
-                  <div className="h-14 mb-12 opacity-80 group-hover:opacity-100 transition-opacity duration-500 relative z-10">
+                  <div className="h-14 mb-12 opacity-80 group-hover:opacity-100 relative z-10">
                     {a.logo ? (
                       <Image src={a.logo} alt={a.name} width={40} height={40} className="dark:invert-0 invert" />
                     ) : (
@@ -110,10 +104,10 @@ export function Integrations() {
                   <h4 className="text-lg font-bold mb-3 tracking-tight text-foreground relative z-10">{a.name}</h4>
                   <p className="text-[13px] text-muted-foreground leading-relaxed mb-10 font-light relative z-10">{a.desc}</p>
                   
-                  <span className="mt-auto text-[11px] font-bold uppercase tracking-[0.25em] text-muted-foreground group-hover:text-primary transition-colors flex items-center gap-2 relative z-10">
-                    View Docs <span className="text-lg opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition-all">→</span>
+                  <span className="mt-auto text-[11px] font-bold uppercase tracking-[0.25em] text-muted-foreground group-hover:text-primary flex items-center gap-2 relative z-10">
+                    View Docs <span className="text-lg opacity-0 group-hover:opacity-100 group-hover:translate-x-1">→</span>
                   </span>
-                </motion.div>
+                </div>
               </Link>
             ))}
           </div>

--- a/packages/web/src/components/Pricing.tsx
+++ b/packages/web/src/components/Pricing.tsx
@@ -76,7 +76,7 @@ export function Pricing({ user }: { user?: User | null }) {
             <span className="w-1.5 h-1.5 bg-primary animate-pulse" />
             Pricing
           </motion.div>
-          <h2 className="text-4xl md:text-6xl font-bold tracking-tight mb-6 text-gradient">
+          <h2 className="font-mono font-normal text-2xl sm:text-4xl mb-6 text-foreground">
             <ScrambleText text="Simple, Transparent Pricing" delayMs={200} />
           </h2>
           <p className="text-muted-foreground max-w-2xl mx-auto text-lg font-light leading-relaxed">
@@ -119,7 +119,7 @@ export function Pricing({ user }: { user?: User | null }) {
             const isCustom = price === "Custom";
             
             return (
-              <div key={tier.name} className={`relative ${tier.highlighted ? "pt-3" : ""}`}>
+              <div key={tier.name} className={`relative ${tier.highlighted ? "pt-3 -mt-4 mb-[-16px] md:-mt-6 md:mb-[-24px]" : ""}`}>
                 {/* Recommended badge — outside overflow-hidden so it's never clipped */}
                 {tier.highlighted && (
                   <div className="absolute top-0 left-1/2 -translate-x-1/2 px-3 py-0.5 bg-primary text-primary-foreground text-[10px] font-bold uppercase tracking-widest rounded-md z-10">
@@ -127,16 +127,12 @@ export function Pricing({ user }: { user?: User | null }) {
                   </div>
                 )}
 
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  whileInView={{ opacity: 1 }}
-                  viewport={{ once: true, amount: 0.05 }}
-                  transition={{ duration: 0.3 }}
-                  className={`relative flex flex-col h-full p-8 overflow-hidden transform-gpu ${
+                <div
+                  className={`relative flex flex-col h-full p-8 overflow-hidden animate-in fade-in duration-300 ${
                     tier.highlighted 
                       ? "bg-primary/10 ring-1 ring-primary/40 shadow-[0_0_40px_rgba(99,102,241,0.25)]" 
                       : "bg-card/20"
-                  } transition-all duration-500 hover:border-primary/40 glass-panel-soft rounded-lg`}
+                  } hover:ring-1 hover:ring-primary/40 border border-border shadow-md dark:shadow-[0_16px_50px_rgba(0,0,0,0.35)] rounded-lg`}
                 >
                   {/* Background texture and overlay for highlighted card */}
                   {tier.highlighted && (
@@ -156,7 +152,7 @@ export function Pricing({ user }: { user?: User | null }) {
                   )}
 
                   <div className="mb-8 relative z-10">
-                    <h3 className="text-xl font-bold mb-2 uppercase tracking-wider">{tier.name}</h3>
+                    <h3 className="font-mono font-normal text-xl sm:text-2xl mb-2 uppercase tracking-wider text-foreground">{tier.name}</h3>
                     <div className="flex items-baseline gap-1 mb-1">
                       <span className="text-4xl font-mono font-bold">{price}</span>
                       {!isCustom && (
@@ -200,7 +196,7 @@ export function Pricing({ user }: { user?: User | null }) {
                   >
                     {tier.cta}
                   </Link>
-                </motion.div>
+                </div>
               </div>
             );
           })}

--- a/packages/web/src/components/TopNav.tsx
+++ b/packages/web/src/components/TopNav.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import type { User } from "@supabase/supabase-js";
+import { ScrambleTextOnHover } from "./animations/ScrambleText";
 
 const navItems = [
   { href: "#how-it-works", label: "How" },
@@ -49,9 +50,11 @@ export function TopNav({ user }: { user?: User | null }) {
                   href={item.href} 
                   className="group relative px-4 py-2 flex items-center gap-2"
                 >
-                  <span className="text-[11px] uppercase tracking-[0.12em] font-medium text-muted-foreground/80 group-hover:text-foreground transition-colors">
-                    {item.label}
-                  </span>
+                  <ScrambleTextOnHover
+                    text={item.label}
+                    className="font-mono text-[11px] uppercase tracking-[0.12em] font-normal text-muted-foreground/80 group-hover:text-foreground transition-colors"
+                    duration={0.4}
+                  />
                   
                   {/* Hover Indicator */}
                   <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-0 h-px bg-primary/80 group-hover:w-1/2 transition-all duration-500" />

--- a/packages/web/src/components/animations/ScrambleText.tsx
+++ b/packages/web/src/components/animations/ScrambleText.tsx
@@ -1,196 +1,202 @@
-"use client";
+"use client"
 
-import { useEffect, useState, useRef, useCallback } from "react";
-import gsap from "gsap";
+import { useEffect, useState, useRef, useCallback } from "react"
+import gsap from "gsap"
 
-interface ScrambleTextProps {
-  text: string;
-  className?: string;
-  /** Delay in milliseconds before animation starts */
-  delayMs?: number;
-  /** Duration of the scramble animation in seconds */
-  duration?: number;
-  /** Enable hover re-scramble effect */
-  hoverEffect?: boolean;
-  /** Enable per-word hover effect (more subtle) */
-  wordHover?: boolean;
+// ── Shared constants & helpers ────────────────────────────────────────────────
+
+const GLYPHS = "!@#$%^&*()_+-=<>?/\\[]{}Xx"
+
+function randomGlyph(): string {
+  return GLYPHS[Math.floor(Math.random() * GLYPHS.length)]
 }
 
-// Subtle glyphs - lowercase letters and simple characters
-const GLYPHS = "abcdefghijklmnopqrstuvwxyz-_.";
-
-/**
- * Run a subtle scramble animation - reveals from left to right
- * with only a few characters scrambling at the "wave front"
- */
+/** Run a left-to-right scramble reveal using GSAP. */
 function runScrambleAnimation(
   text: string,
   duration: number,
   setDisplayText: (text: string) => void,
   onComplete?: () => void,
 ): gsap.core.Tween {
-  const finalChars = text.split("");
-  const totalChars = finalChars.length;
-  const scrambleObj = { progress: 0 };
+  const lockedIndices = new Set<number>()
+  const finalChars = text.split("")
+  const totalChars = finalChars.length
+  const scrambleObj = { progress: 0 }
 
   return gsap.to(scrambleObj, {
     progress: 1,
     duration,
-    ease: "power1.out",
+    ease: "power2.out",
     onUpdate: () => {
-      const revealedCount = Math.floor(scrambleObj.progress * totalChars);
-      // Only scramble 2-3 characters at the wave front
-      const waveFrontStart = Math.max(0, revealedCount - 3);
+      const numLocked = Math.floor(scrambleObj.progress * totalChars)
+
+      for (let i = 0; i < numLocked; i++) {
+        lockedIndices.add(i)
+      }
 
       const newDisplay = finalChars
         .map((char, i) => {
-          // Preserve spaces and punctuation
-          if (char === " " || char === "." || char === "," || char === "'" || char === "-") {
-            return char;
-          }
-          // Already revealed
-          if (i < waveFrontStart) return char;
-          // At the wave front - scramble
-          if (i < revealedCount) {
-            return GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
-          }
-          // Not yet reached - show original (subtle approach)
-          return char;
+          if (lockedIndices.has(i)) return char
+          if (char === " ") return " "
+          return randomGlyph()
         })
-        .join("");
+        .join("")
 
-      setDisplayText(newDisplay);
+      setDisplayText(newDisplay)
     },
     onComplete: () => {
-      setDisplayText(text);
-      onComplete?.();
+      setDisplayText(text)
+      onComplete?.()
     },
-  });
+  })
+}
+
+// ── ScrambleText (animate on mount / when in viewport) ────────────────────────
+
+interface ScrambleTextProps {
+  text: string
+  className?: string
+  /** Delay in milliseconds before animation starts */
+  delayMs?: number
+  /** Duration of the scramble animation in seconds */
+  duration?: number
 }
 
 /**
- * Individual word with hover scramble effect
- */
-function ScrambleWord({ word, isFirst }: { word: string; isFirst: boolean }) {
-  const [displayText, setDisplayText] = useState(word);
-  const animationRef = useRef<gsap.core.Tween | null>(null);
-  const isAnimating = useRef(false);
-
-  const handleMouseEnter = useCallback(() => {
-    if (isAnimating.current) return;
-    isAnimating.current = true;
-
-    if (animationRef.current) {
-      animationRef.current.kill();
-    }
-
-    // Very quick and subtle for word hover
-    animationRef.current = runScrambleAnimation(word, 0.2, setDisplayText, () => {
-      isAnimating.current = false;
-    });
-  }, [word]);
-
-  // Update display if word prop changes
-  useEffect(() => {
-    if (!isAnimating.current) {
-      setDisplayText(word);
-    }
-  }, [word]);
-
-  return (
-    <span
-      onMouseEnter={handleMouseEnter}
-      className="cursor-default"
-    >
-      {isFirst ? "" : " "}{displayText}
-    </span>
-  );
-}
-
-/**
- * Scramble text animation component - subtle wave reveal on mount, optional hover.
- * With wordHover=true, individual words scramble on hover instead of the whole text.
+ * Scramble text that animates **once** when the element scrolls into view.
+ * Characters lock in left-to-right with scrambled glyphs resolving to final text.
  */
 export function ScrambleText({
   text,
   className,
   delayMs = 0,
-  duration = 0.5,
-  hoverEffect = true,
-  wordHover = true,
+  duration = 0.9,
 }: ScrambleTextProps) {
-  // Start with actual text visible (no jarring flash)
-  const [displayText, setDisplayText] = useState(text);
-  const [hasAnimated, setHasAnimated] = useState(false);
-  const containerRef = useRef<HTMLSpanElement>(null);
-  const animationRef = useRef<gsap.core.Tween | null>(null);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const isAnimating = useRef(false);
+  const [displayText, setDisplayText] = useState(text)
+  const hasAnimated = useRef(false)
+  const containerRef = useRef<HTMLSpanElement>(null)
+  const animationRef = useRef<gsap.core.Tween | null>(null)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-  // Run animation only once on initial mount
+  // Observe intersection — fire animation once when element enters viewport
   useEffect(() => {
-    if (hasAnimated || !text) return;
+    const el = containerRef.current
+    if (!el || hasAnimated.current) return
 
-    timeoutRef.current = setTimeout(() => {
-      isAnimating.current = true;
-      animationRef.current = runScrambleAnimation(
-        text,
-        duration,
-        setDisplayText,
-        () => {
-          setHasAnimated(true);
-          isAnimating.current = false;
-        },
-      );
-    }, delayMs);
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || hasAnimated.current) return
+
+        hasAnimated.current = true
+        observer.disconnect()
+
+        // Show scrambled text immediately
+        const scrambledStart = text
+          .split("")
+          .map((c) => (c === " " ? " " : randomGlyph()))
+          .join("")
+        setDisplayText(scrambledStart)
+
+        timeoutRef.current = setTimeout(() => {
+          animationRef.current = runScrambleAnimation(
+            text,
+            duration,
+            setDisplayText,
+          )
+        }, delayMs)
+      },
+      { threshold: 0.15 },
+    )
+
+    observer.observe(el)
 
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      if (animationRef.current) animationRef.current.kill();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally run once on mount only
-  }, []);
+      observer.disconnect()
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      if (animationRef.current) animationRef.current.kill()
+    }
+  }, [text, delayMs, duration])
 
-  // Handle text prop changes after initial animation
+  // Handle text prop changes after animation has completed
   useEffect(() => {
-    if (hasAnimated && displayText !== text) {
-      setDisplayText(text);
+    if (hasAnimated.current && !animationRef.current) {
+      setDisplayText(text)
     }
-  }, [text, hasAnimated, displayText]);
+  }, [text])
 
-  // Full text hover effect handler
+  return (
+    <span ref={containerRef} className={className}>
+      {displayText || text}
+    </span>
+  )
+}
+
+// ── ScrambleTextOnHover (animate on mouseenter) ──────────────────────────────
+
+interface ScrambleTextOnHoverProps {
+  text: string
+  className?: string
+  /** Duration of the scramble animation in seconds */
+  duration?: number
+  onClick?: () => void
+}
+
+/**
+ * Shows static text by default. On mouseenter, scrambles and resolves
+ * left-to-right. Prevents re-triggering while animation is in progress.
+ */
+export function ScrambleTextOnHover({
+  text,
+  className,
+  duration = 0.4,
+  onClick,
+}: ScrambleTextOnHoverProps) {
+  const [displayText, setDisplayText] = useState(text)
+  const isAnimating = useRef(false)
+  const animationRef = useRef<gsap.core.Tween | null>(null)
+
   const handleMouseEnter = useCallback(() => {
-    if (!hoverEffect || wordHover || isAnimating.current) return;
-    isAnimating.current = true;
+    if (isAnimating.current) return
+    isAnimating.current = true
 
-    if (animationRef.current) {
-      animationRef.current.kill();
+    // Start fully scrambled
+    const scrambled = text
+      .split("")
+      .map((c) => (c === " " ? " " : randomGlyph()))
+      .join("")
+    setDisplayText(scrambled)
+
+    animationRef.current = runScrambleAnimation(
+      text,
+      duration,
+      setDisplayText,
+      () => {
+        isAnimating.current = false
+      },
+    )
+  }, [text, duration])
+
+  // Sync display when text prop changes
+  useEffect(() => {
+    if (!isAnimating.current) {
+      setDisplayText(text)
     }
+  }, [text])
 
-    animationRef.current = runScrambleAnimation(text, 0.3, setDisplayText, () => {
-      isAnimating.current = false;
-    });
-  }, [text, hoverEffect, wordHover]);
-
-  // If wordHover is enabled and initial animation is done, render words separately
-  if (wordHover && hasAnimated) {
-    const words = text.split(" ");
-    return (
-      <span ref={containerRef} className={className}>
-        {words.map((word, i) => (
-          <ScrambleWord key={`${word}-${i}`} word={word} isFirst={i === 0} />
-        ))}
-      </span>
-    );
-  }
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (animationRef.current) animationRef.current.kill()
+    }
+  }, [])
 
   return (
     <span
-      ref={containerRef}
       className={className}
       onMouseEnter={handleMouseEnter}
+      onClick={onClick}
     >
       {displayText || text}
     </span>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- **Root cause fix**: Removed global `h4:hover { animation: glitch-text }` CSS rule from `globals.css` that was applying translate/blur/text-shadow animations to every h4 on hover
- **Card stability**: Replaced `motion.div` with plain `div` elements on feature, integration, and pricing cards; replaced `transition-colors` hover effects with `ring`-based hover (no repaint triggers)
- **Pricing card elevation**: Professional tier card now extends above siblings with negative margin
- **ScrambleText refactor**: Animates once on scroll via IntersectionObserver; `ScrambleTextOnHover` variant for nav links only

## Test plan
- [ ] Hover over h4 headings in Features, Integrations, Pricing sections — no text shaking
- [ ] Card hover effects (ring glow, icon brightening, corner decor) still appear
- [ ] Professional pricing card visually elevated above Free and Enterprise
- [ ] ScrambleText animates once when scrolling into view, not on hover
- [ ] Navigation links still have hover scramble effect

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI/animation refactors, but touches shared `ScrambleText` behavior and card rendering across multiple sections, which could introduce subtle visual regressions or timing issues.
> 
> **Overview**
> Removes the global `h4:hover` “glitch” animation (and its `@keyframes`) from `globals.css`, eliminating unintended shake/blur effects across the site.
> 
> Simplifies several homepage sections by dropping `framer-motion` wrappers for feature/integration/pricing cards and shifting hover styling to `ring`/shadow-based effects; also tweaks typography toward mono/normal-weight headings and elevates the highlighted pricing tier via negative margins. `ScrambleText` is refactored to animate once on scroll (IntersectionObserver + GSAP) and a new `ScrambleTextOnHover` variant is introduced and used for top-nav link hover.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38111ebe06f176c60e589c5859b2bc9d64b90d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->