### PR TITLE
fix: replace v0 placeholder icon and remove doc link underlines

### DIFF
--- a/packages/web/src/components/MCPInstallButtons.tsx
+++ b/packages/web/src/components/MCPInstallButtons.tsx
@@ -190,7 +190,7 @@ export function MCPInstallButtons() {
           {/* Claude Desktop Button */}
           <a
             href="#claude-desktop"
-            className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card hover:bg-accent/50 hover:border-amber-600/50 transition-all group"
+            className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card hover:bg-accent/50 hover:border-amber-600/50 transition-all group no-underline"
           >
             <div className="p-2 rounded-lg bg-amber-600/10 group-hover:bg-amber-600/20 transition-colors">
               <AnthropicIcon className="w-5 h-5 text-amber-600" />
@@ -229,7 +229,7 @@ export function MCPInstallButtons() {
           {/* Windsurf */}
           <a
             href="#windsurf"
-            className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card hover:bg-accent/50 hover:border-cyan-500/50 transition-all group"
+            className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card hover:bg-accent/50 hover:border-cyan-500/50 transition-all group no-underline"
           >
             <div className="p-2 rounded-lg bg-cyan-500/10 group-hover:bg-cyan-500/20 transition-colors">
               <WindsurfIcon className="w-5 h-5 text-cyan-500" />
@@ -244,7 +244,7 @@ export function MCPInstallButtons() {
           {/* VS Code */}
           <a
             href="#vscode"
-            className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card hover:bg-accent/50 hover:border-blue-500/50 transition-all group"
+            className="flex items-center gap-3 p-4 rounded-lg border border-border bg-card hover:bg-accent/50 hover:border-blue-500/50 transition-all group no-underline"
           >
             <div className="p-2 rounded-lg bg-blue-500/10 group-hover:bg-blue-500/20 transition-colors">
               <svg className="w-5 h-5 text-blue-500" viewBox="0 0 24 24" fill="currentColor">
@@ -265,28 +265,28 @@ export function MCPInstallButtons() {
         <span className="text-muted-foreground">Jump to:</span>
         <a
           href="#cursor"
-          className="text-muted-foreground hover:text-primary transition-colors flex items-center gap-1.5"
+          className="text-muted-foreground hover:text-primary transition-colors flex items-center gap-1.5 no-underline"
         >
           <CursorIcon className="w-4 h-4" />
           Cursor
         </a>
         <a
           href="#claude-code"
-          className="text-muted-foreground hover:text-orange-500 transition-colors flex items-center gap-1.5"
+          className="text-muted-foreground hover:text-orange-500 transition-colors flex items-center gap-1.5 no-underline"
         >
           <ClaudeIcon className="w-4 h-4" />
           Claude Code
         </a>
         <a
           href="#claude-desktop"
-          className="text-muted-foreground hover:text-amber-600 transition-colors flex items-center gap-1.5"
+          className="text-muted-foreground hover:text-amber-600 transition-colors flex items-center gap-1.5 no-underline"
         >
           <AnthropicIcon className="w-4 h-4" />
           Claude Desktop
         </a>
         <a
           href="#windsurf"
-          className="text-muted-foreground hover:text-cyan-500 transition-colors flex items-center gap-1.5"
+          className="text-muted-foreground hover:text-cyan-500 transition-colors flex items-center gap-1.5 no-underline"
         >
           <WindsurfIcon className="w-4 h-4" />
           Windsurf

--- a/packages/web/src/components/icons/V0Icon.tsx
+++ b/packages/web/src/components/icons/V0Icon.tsx
@@ -1,41 +1,21 @@
 /**
- * v0 icon
+ * v0 icon (simple-icons)
  */
 
-interface IconProps {
-  className?: string;
-  size?: number;
-}
+import { SVGProps } from "react";
 
-export function V0Icon({ className, size = 24 }: IconProps) {
+export function V0Icon({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width={size}
-      height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      fill="currentColor"
       aria-hidden="true"
       focusable="false"
       className={className}
+      {...props}
     >
-      <text
-        x="50%"
-        y="50%"
-        dominantBaseline="central"
-        textAnchor="middle"
-        fill="currentColor"
-        stroke="none"
-        fontSize="14"
-        fontWeight="bold"
-        fontFamily="system-ui, sans-serif"
-      >
-        v0
-      </text>
+      <path d="M14.066 6.028v2.22h5.729q.075-.001.148.005l-5.853 5.752a2 2 0 0 1-.024-.309V8.247h-2.353v5.45c0 2.322 1.935 4.222 4.258 4.222h5.675v-2.22h-5.675q-.03 0-.059-.003l5.729-5.629q.006.082.006.166v5.465H24v-5.465a4.204 4.204 0 0 0-4.205-4.205zM0 8.245l8.28 9.266c.839.94 2.396.346 2.396-.914V8.245H8.19v5.44l-4.86-5.44Z" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

- Replace text-based v0 icon with actual simple-icons SVG path
- Add `no-underline` to Quick Install tool cards and jump-to links in docs


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational UI changes plus a small icon component update; no data flow, auth, or API behavior changes.
> 
> **Overview**
> Replaces the text-based placeholder `V0Icon` with a proper simple-icons SVG implementation, updating the component to accept standard `SVGProps` and render a `path`.
> 
> Updates `MCPInstallButtons` quick-install tool cards and “Jump to” anchor links to include `no-underline`, removing default link underlines while preserving existing hover/transition styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81301c9b226020787c4c3b9f6fc1771f438b8643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->