### PR TITLE
refactor: add return types to ai-sdk and cli exported functions

### DIFF
--- a/packages/ai-sdk/src/middleware.ts
+++ b/packages/ai-sdk/src/middleware.ts
@@ -41,7 +41,7 @@ function emptyContext(): ContextResult {
   return { rules: [], memories: [], skillFiles: [], raw: "" }
 }
 
-export function memoriesMiddleware(options: MemoriesMiddlewareOptions = {}) {
+export function memoriesMiddleware(options: MemoriesMiddlewareOptions = {}): { transformParams: (input: unknown) => Promise<unknown> } {
   const client = resolveClient(options)
   const includeRules = options.includeRules ?? true
   const limit = options.limit ?? 10

--- a/packages/ai-sdk/src/on-finish.ts
+++ b/packages/ai-sdk/src/on-finish.ts
@@ -1,7 +1,7 @@
 import { resolveClient } from "./client"
 import type { CreateMemoriesOnFinishOptions } from "./types"
 
-export function createMemoriesOnFinish(options: CreateMemoriesOnFinishOptions = {}) {
+export function createMemoriesOnFinish(options: CreateMemoriesOnFinishOptions = {}): (payload: unknown) => Promise<void> {
   const mode = options.mode ?? "tool-calls-only"
   const client = resolveClient(options)
 

--- a/packages/ai-sdk/src/tools.ts
+++ b/packages/ai-sdk/src/tools.ts
@@ -2,7 +2,7 @@ import type { ContextGetInput, MemoryAddInput, MemoryEditInput, MemoryListOption
 import { resolveClient } from "./client"
 import type { MemoriesBaseOptions, MemoriesTools } from "./types"
 
-export function getContext(options: MemoriesBaseOptions = {}) {
+export function getContext(options: MemoriesBaseOptions = {}): MemoriesTools["getContext"] {
   const client = resolveClient(options)
   return async (input: ContextGetInput = {}) =>
     client.context.get({
@@ -19,7 +19,7 @@ export function getContext(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function storeMemory(options: MemoriesBaseOptions = {}) {
+export function storeMemory(options: MemoriesBaseOptions = {}): MemoriesTools["storeMemory"] {
   const client = resolveClient(options)
   return async (input: MemoryAddInput) =>
     client.memories.add({
@@ -28,7 +28,7 @@ export function storeMemory(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function searchMemories(options: MemoriesBaseOptions = {}) {
+export function searchMemories(options: MemoriesBaseOptions = {}): MemoriesTools["searchMemories"] {
   const client = resolveClient(options)
   return async (input: {
     query: string
@@ -45,7 +45,7 @@ export function searchMemories(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function listMemories(options: MemoriesBaseOptions = {}) {
+export function listMemories(options: MemoriesBaseOptions = {}): MemoriesTools["listMemories"] {
   const client = resolveClient(options)
   return async (input: {
     type?: MemoryType
@@ -63,18 +63,18 @@ export function listMemories(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function forgetMemory(options: MemoriesBaseOptions = {}) {
+export function forgetMemory(options: MemoriesBaseOptions = {}): MemoriesTools["forgetMemory"] {
   const client = resolveClient(options)
   return async (input: { id: string }) => client.memories.forget(input.id)
 }
 
-export function editMemory(options: MemoriesBaseOptions = {}) {
+export function editMemory(options: MemoriesBaseOptions = {}): MemoriesTools["editMemory"] {
   const client = resolveClient(options)
   return async (input: { id: string; updates: MemoryEditInput }) =>
     client.memories.edit(input.id, input.updates)
 }
 
-export function upsertSkillFile(options: MemoriesBaseOptions = {}) {
+export function upsertSkillFile(options: MemoriesBaseOptions = {}): MemoriesTools["upsertSkillFile"] {
   const client = resolveClient(options)
   return async (input: { path: string; content: string; projectId?: string; userId?: string; tenantId?: string }) =>
     client.skills.upsertFile({
@@ -85,7 +85,7 @@ export function upsertSkillFile(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function listSkillFiles(options: MemoriesBaseOptions = {}) {
+export function listSkillFiles(options: MemoriesBaseOptions = {}): MemoriesTools["listSkillFiles"] {
   const client = resolveClient(options)
   return async (input: { limit?: number; projectId?: string; userId?: string; tenantId?: string } = {}) =>
     client.skills.listFiles({
@@ -96,7 +96,7 @@ export function listSkillFiles(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function deleteSkillFile(options: MemoriesBaseOptions = {}) {
+export function deleteSkillFile(options: MemoriesBaseOptions = {}): MemoriesTools["deleteSkillFile"] {
   const client = resolveClient(options)
   return async (input: { path: string; projectId?: string; userId?: string; tenantId?: string }) =>
     client.skills.deleteFile({
@@ -107,7 +107,7 @@ export function deleteSkillFile(options: MemoriesBaseOptions = {}) {
     })
 }
 
-export function bulkForgetMemories(options: MemoriesBaseOptions = {}) {
+export function bulkForgetMemories(options: MemoriesBaseOptions = {}): MemoriesTools["bulkForgetMemories"] {
   const client = resolveClient(options)
   return async (input: { filters: BulkForgetFilter; dryRun?: boolean }) =>
     client.memories.bulkForget(
@@ -119,7 +119,7 @@ export function bulkForgetMemories(options: MemoriesBaseOptions = {}) {
     )
 }
 
-export function vacuumMemories(options: MemoriesBaseOptions = {}) {
+export function vacuumMemories(options: MemoriesBaseOptions = {}): MemoriesTools["vacuumMemories"] {
   const client = resolveClient(options)
   return async () => client.memories.vacuum()
 }

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -111,7 +111,7 @@ export async function clearAuth(): Promise<void> {
 /**
  * Creates a fetch wrapper that includes CLI auth headers.
  */
-export function getApiClient(auth: AuthConfig) {
+export function getApiClient(auth: AuthConfig): (path: string, opts?: RequestInit) => Promise<Response> {
   return async function apiFetch(
     path: string,
     opts?: RequestInit


### PR DESCRIPTION
## Summary
- Add explicit return types to all 11 tool factory functions in `packages/ai-sdk/src/tools.ts` using `MemoriesTools` indexed access types
- Add return type to `memoriesMiddleware` in `packages/ai-sdk/src/middleware.ts`
- Add return type to `createMemoriesOnFinish` in `packages/ai-sdk/src/on-finish.ts`
- Add return type to `getApiClient` in `packages/cli/src/lib/auth.ts`
- 14 functions total

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure TypeScript typing changes with no functional logic changes; risk is limited to potential downstream compile-time type incompatibilities.
> 
> **Overview**
> **Type-only refactor:** adds explicit return type annotations to several exported factory functions.
> 
> In `@memories.sh/ai-sdk`, `memoriesMiddleware`, `createMemoriesOnFinish`, and all tool factories in `tools.ts` now declare concrete return types (largely via `MemoriesTools["..."]`) to lock in their public API signatures. In the CLI, `getApiClient` now explicitly returns the `(path, opts) => Promise<Response>` fetch wrapper type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e12202956b9cf6109992c2f53c9f013e6bb19b85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->