### PR TITLE
fix: add return types to remaining async pages and components

### DIFF
--- a/packages/web/src/app/app/billing/page.tsx
+++ b/packages/web/src/app/app/billing/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { createClient as createTurso } from "@libsql/client"
@@ -129,7 +130,7 @@ async function getTenantRoutingStatus(userId: string): Promise<TenantRoutingStat
   }
 }
 
-export default async function BillingPage() {
+export default async function BillingPage(): Promise<React.JSX.Element | null> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/app/graph-explorer/page.tsx
+++ b/packages/web/src/app/app/graph-explorer/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { createClient as createTurso } from "@libsql/client"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
@@ -10,7 +11,7 @@ export const metadata = {
   title: "Graph Explorer",
 }
 
-export default async function GraphExplorerPage() {
+export default async function GraphExplorerPage(): Promise<React.JSX.Element | null> {
   const supabase = await createClient()
   const {
     data: { user },

--- a/packages/web/src/app/app/layout.tsx
+++ b/packages/web/src/app/app/layout.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import { DashboardShell } from "@/components/dashboard/DashboardShell"
@@ -14,7 +15,7 @@ export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode
-}) {
+}): Promise<React.JSX.Element> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/app/page.tsx
+++ b/packages/web/src/app/app/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { createClient as createTurso } from "@libsql/client"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
@@ -31,7 +32,7 @@ async function listMemories(turso: ReturnType<typeof createTurso>) {
   }
 }
 
-export default async function MemoriesPage() {
+export default async function MemoriesPage(): Promise<React.JSX.Element | null> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/app/settings/page.tsx
+++ b/packages/web/src/app/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { SettingsForm } from "./settings-form"
 
@@ -5,7 +6,7 @@ export const metadata = {
   title: "Settings",
 }
 
-export default async function SettingsPage() {
+export default async function SettingsPage(): Promise<React.JSX.Element | null> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/app/stats/page.tsx
+++ b/packages/web/src/app/app/stats/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { StatsCharts } from "./stats-charts"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
@@ -50,7 +51,7 @@ interface Stats {
   globalVsProject: { global: number; project: number }
 }
 
-export default async function StatsPage() {
+export default async function StatsPage(): Promise<React.JSX.Element | null> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/app/team/page.tsx
+++ b/packages/web/src/app/app/team/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import { TeamContent } from "./team-content"
@@ -6,7 +7,7 @@ export const metadata = {
   title: "Team",
 }
 
-export default async function TeamPage() {
+export default async function TeamPage(): Promise<React.JSX.Element> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/app/upgrade/page.tsx
+++ b/packages/web/src/app/app/upgrade/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import { UpgradeCard } from "./upgrade-card"
@@ -7,7 +8,7 @@ export const metadata = {
   title: "Upgrade to Pro",
 }
 
-export default async function UpgradePage() {
+export default async function UpgradePage(): Promise<React.JSX.Element | null> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 

--- a/packages/web/src/app/docs/[[...slug]]/page.tsx
+++ b/packages/web/src/app/docs/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { source } from '@/lib/source';
 import {
   DocsPage,
@@ -15,7 +16,7 @@ interface PageProps {
   params: Promise<{ slug?: string[] }>;
 }
 
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params }: PageProps): Promise<React.JSX.Element> {
   const { slug } = await params;
   const page = source.getPage(slug);
   if (!page) notFound();
@@ -38,7 +39,7 @@ export default async function Page({ params }: PageProps) {
   );
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ slug: string[] }[]> {
   return source.generateParams();
 }
 

--- a/packages/web/src/app/invite/accept/page.tsx
+++ b/packages/web/src/app/invite/accept/page.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { getInviteTokenCandidates } from "@/lib/team-invites"
@@ -12,7 +13,7 @@ export default async function AcceptInvitePage({
   searchParams,
 }: {
   searchParams: Promise<{ token?: string }>
-}) {
+}): Promise<React.JSX.Element> {
   const { token } = await searchParams
 
   if (!token) {

--- a/packages/web/src/components/dashboard/AddRuleForm.tsx
+++ b/packages/web/src/components/dashboard/AddRuleForm.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useState } from "react"
+import React, { useState } from "react"
 import { Plus } from "lucide-react"
 import type { Memory } from "@/types/memory"
 
-export function AddRuleForm({ onAdd }: { onAdd: (memory: Memory) => void }) {
+export function AddRuleForm({ onAdd }: { onAdd: (memory: Memory) => void }): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
   const [content, setContent] = useState("")
   const [scope, setScope] = useState<"global" | "project">("global")

--- a/packages/web/src/components/dashboard/MemoriesList.tsx
+++ b/packages/web/src/components/dashboard/MemoriesList.tsx
@@ -1,19 +1,20 @@
 "use client"
 
+import React from "react"
 import { MemoryCard } from "./MemoryCard"
 import type { Memory } from "@/types/memory"
 
-export function MemoriesList({ 
+export function MemoriesList({
   memories,
   onDeleteMemory,
   onUpdateMemory,
   onFilterByProject
-}: { 
+}: {
   memories: Memory[]
   onDeleteMemory?: (id: string) => void
   onUpdateMemory?: (id: string, content: string) => void
   onFilterByProject?: (scope: string) => void
-}) {
+}): React.JSX.Element | null {
   const handleDelete = (id: string) => {
     onDeleteMemory?.(id)
   }

--- a/packages/web/src/components/dashboard/MemoryCard.tsx
+++ b/packages/web/src/components/dashboard/MemoryCard.tsx
@@ -1,20 +1,20 @@
 "use client"
 
-import { useState } from "react"
+import React, { useState } from "react"
 import { Trash2, Pencil, Check, X } from "lucide-react"
 import type { Memory } from "@/types/memory"
 
-export function MemoryCard({ 
-  memory, 
+export function MemoryCard({
+  memory,
   onDelete,
   onUpdate,
   onFilterByProject
-}: { 
+}: {
   memory: Memory
   onDelete: (id: string) => void
   onUpdate: (id: string, content: string) => void
   onFilterByProject?: (scope: string) => void
-}) {
+}): React.JSX.Element {
   const [isDeleting, setIsDeleting] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
   const [isEditing, setIsEditing] = useState(false)


### PR DESCRIPTION
## Summary
- Add explicit return types to 14 remaining exported functions missed by PRs #22/#23
- 10 async server component pages → `Promise<React.JSX.Element>` or `Promise<React.JSX.Element | null>`
- 3 dashboard components with multi-line signatures → `React.JSX.Element`
- `generateStaticParams` → `Promise<{ slug: string[] }[]>`

## Files Changed
- `app/app/billing/page.tsx`, `graph-explorer/page.tsx`, `layout.tsx`, `page.tsx`, `settings/page.tsx`, `stats/page.tsx`, `team/page.tsx`, `upgrade/page.tsx`
- `app/docs/[[...slug]]/page.tsx` (Page + generateStaticParams)
- `app/invite/accept/page.tsx`
- `components/dashboard/AddRuleForm.tsx`, `MemoriesList.tsx`, `MemoryCard.tsx`

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Zero exported functions without return types remaining

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes that don’t alter runtime behavior; risk is limited to potential typing/import edge cases during build.
> 
> **Overview**
> Adds explicit return types to remaining exported async server pages/layouts (dashboard pages, docs page, invite accept page) and to `generateStaticParams`, standardizing on `Promise<React.JSX.Element>` or `Promise<React.JSX.Element | null>`.
> 
> Updates a few client dashboard components (`AddRuleForm`, `MemoriesList`, `MemoryCard`) to return `React.JSX.Element` (or `null`) and imports `React` where needed to support the new type annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea8bcca4321d5b993377ba09092e75361778c69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->