### PR TITLE
refactor: replace new Promise constructors with native async APIs

### DIFF
--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { createInterface } from "node:readline";
+import { createInterface } from "node:readline/promises";
 import chalk from "chalk";
 import * as ui from "../lib/ui.js";
 import {
@@ -23,12 +23,9 @@ const TYPE_ICONS: Record<MemoryType, string> = {
 
 async function confirm(message: string): Promise<boolean> {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
-    rl.question(message, (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase().startsWith("y"));
-    });
-  });
+  const answer = await rl.question(message);
+  rl.close();
+  return answer.toLowerCase().startsWith("y");
 }
 
 export const forgetCommand = new Command("forget")

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -5,6 +5,7 @@ import { confirm } from "@inquirer/prompts";
 import { readAuth, saveAuth, clearAuth } from "../lib/auth.js";
 import { randomBytes } from "node:crypto";
 import { execFile } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import * as ui from "../lib/ui.js";
 
 const DEFAULT_API_URL = "https://memories.sh";
@@ -105,7 +106,7 @@ export const loginCommand = new Command("login")
     // Poll for the token
     const maxAttempts = 60; // 5 minutes at 5s intervals
     for (let i = 0; i < maxAttempts; i++) {
-      await new Promise((r) => setTimeout(r, 5000));
+      await delay(5000);
       spinner.text = `Waiting for authorization... (${Math.floor((maxAttempts - i) * 5 / 60)}m remaining)`;
 
       try {

--- a/packages/cli/src/commands/stale.ts
+++ b/packages/cli/src/commands/stale.ts
@@ -4,7 +4,7 @@ import * as ui from "../lib/ui.js";
 import { getDb } from "../lib/db.js";
 import { getProjectId } from "../lib/git.js";
 import { forgetMemory, type MemoryType } from "../lib/memory.js";
-import { createInterface } from "node:readline";
+import { createInterface } from "node:readline/promises";
 
 const TYPE_ICONS: Record<string, string> = {
   rule: "📌",
@@ -25,12 +25,9 @@ interface StaleMemory {
 
 async function prompt(message: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(message, (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase().trim());
-    });
-  });
+  const answer = await rl.question(message);
+  rl.close();
+  return answer.toLowerCase().trim();
 }
 
 export const staleCommand = new Command("stale")

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -5,6 +5,7 @@ import { saveSyncConfig, readSyncConfig, resetDb, syncDb } from "../lib/db.js";
 import { unlinkSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
 import { readAuth, getApiClient } from "../lib/auth.js";
 import * as ui from "../lib/ui.js";
 
@@ -81,7 +82,7 @@ syncCommand
             });
 
             spinner.text = "Waiting for database to be ready...";
-            await new Promise((r) => setTimeout(r, 3000));
+            await delay(3000);
 
             resetDb();
             await syncDb();
@@ -125,7 +126,7 @@ syncCommand
     });
 
     spinner.text = "Waiting for database to be ready...";
-    await new Promise((r) => setTimeout(r, 3000));
+    await delay(3000);
 
     resetDb();
     await syncDb();

--- a/packages/cli/src/lib/memory-stream.test.ts
+++ b/packages/cli/src/lib/memory-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
 
 // Use a temp directory so tests never hit sync
 process.env.MEMORIES_DATA_DIR = mkdtempSync(join(tmpdir(), "memories-stream-test-"));
@@ -166,7 +167,7 @@ describe("streaming memory API", () => {
       const state1 = getStreamState(streamId);
       
       // Wait a bit
-      await new Promise(resolve => setTimeout(resolve, 50));
+      await delay(50);
       
       const state2 = getStreamState(streamId);
       expect(state2?.ageMs).toBeGreaterThan(state1?.ageMs ?? 0);

--- a/packages/web/src/app/api/db/provision/route.ts
+++ b/packages/web/src/app/api/db/provision/route.ts
@@ -2,6 +2,7 @@ import { authenticateRequest } from "@/lib/auth"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { createDatabase, createDatabaseToken, initSchema } from "@/lib/turso"
 import { NextResponse } from "next/server"
+import { setTimeout as delay } from "node:timers/promises"
 import { checkPreAuthApiRateLimit, checkRateLimit, strictRateLimit } from "@/lib/rate-limit"
 import { resolveWorkspaceContext } from "@/lib/workspace"
 
@@ -79,7 +80,7 @@ export async function POST(request: Request): Promise<Response> {
     const url = `libsql://${db.hostname}`
 
     // Wait for Turso to finish provisioning
-    await new Promise((r) => setTimeout(r, 3000))
+    await delay(3000)
 
     // Initialize the schema
     await initSchema(url, token)

--- a/packages/web/src/app/api/mcp/tenants/route.ts
+++ b/packages/web/src/app/api/mcp/tenants/route.ts
@@ -1,6 +1,7 @@
 import { createClient as createTurso } from "@libsql/client"
 import { NextResponse } from "next/server"
 import { z } from "zod"
+import { setTimeout as delay } from "node:timers/promises"
 import { authenticateRequest } from "@/lib/auth"
 import { apiRateLimit, checkRateLimit, strictRateLimit } from "@/lib/rate-limit"
 import { createAdminClient } from "@/lib/supabase/admin"
@@ -213,7 +214,7 @@ export async function POST(request: Request): Promise<Response> {
       const url = `libsql://${db.hostname}`
 
       // Give Turso a moment to finish provisioning before schema init.
-      await new Promise((resolve) => setTimeout(resolve, 3000))
+      await delay(3000)
       await initSchema(url, token)
 
       tursoDbUrl = url

--- a/packages/web/src/lib/memory-service/scope.ts
+++ b/packages/web/src/lib/memory-service/scope.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin"
 import { createDatabase, createDatabaseToken, initSchema } from "@/lib/turso"
 import { createClient as createTurso } from "@libsql/client"
+import { setTimeout as delay } from "node:timers/promises"
 import {
   apiError,
   MCP_WORKING_MEMORY_TTL_HOURS,
@@ -215,7 +216,7 @@ async function autoProvisionTenantDatabase(params: {
   const token = await createDatabaseToken(TURSO_ORG, db.name)
   const url = `libsql://${db.hostname}`
 
-  await new Promise((resolve) => setTimeout(resolve, 3000))
+  await delay(3000)
   await initSchema(url, token)
 
   const now = new Date().toISOString()


### PR DESCRIPTION
## Summary
- Replace 7x `new Promise(r => setTimeout(r, N))` wrappers with `import { setTimeout } from 'node:timers/promises'` across CLI and web packages
- Replace 2x `new Promise` readline wrappers with `node:readline/promises` `rl.question()` in `forget.ts` and `stale.ts`
- 4 intentional `new Promise` patterns preserved (infinite waits, test mocks, auth sleep for fake timer compat)

## Files changed
- `packages/cli/src/commands/sync.ts` — 2x delay
- `packages/cli/src/commands/login.ts` — 1x delay
- `packages/cli/src/commands/forget.ts` — readline/promises
- `packages/cli/src/commands/stale.ts` — readline/promises
- `packages/cli/src/lib/memory-stream.test.ts` — 1x test delay
- `packages/web/src/lib/memory-service/scope.ts` — 1x delay
- `packages/web/src/app/api/mcp/tenants/route.ts` — 1x delay
- `packages/web/src/app/api/db/provision/route.ts` — 1x delay

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (157 + 8 = 165 tests)

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior should be unchanged; this is a mechanical refactor of waiting/prompting code paths with minimal surface area beyond Node runtime compatibility.
> 
> **Overview**
> Replaces multiple ad-hoc `new Promise(...)` wrappers with native Node async APIs across CLI, web API routes, and tests.
> 
> CLI commands `login`/`sync` now use `node:timers/promises` for polling/provisioning delays, and `forget`/`stale` switch to `node:readline/promises` for simpler async prompts. Web Turso provisioning flows similarly swap to `delay()` before schema initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4926ae14ce25818524c2e55c756ebdcd5cbb1757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->