### PR TITLE
refactor: convert sequential independent awaits to Promise.all

### DIFF
--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -216,17 +216,13 @@ export const ingestCommand = new Command("ingest")
         // ── Directory-based sources ──────────────────────────────────
         const dirOpts = { dryRun: opts.dryRun, existingSet, typeOverride };
 
-        const claudeResult = await runDirectoryIngest("claude-rules", cwd, dirOpts);
-        totalImported += claudeResult.imported;
-        totalSkipped += claudeResult.skipped;
-
-        const cursorResult = await runDirectoryIngest("cursor-rules", cwd, dirOpts);
-        totalImported += cursorResult.imported;
-        totalSkipped += cursorResult.skipped;
-
-        const skillsResult = await runDirectoryIngest("skills", cwd, dirOpts);
-        totalImported += skillsResult.imported;
-        totalSkipped += skillsResult.skipped;
+        const [claudeResult, cursorResult, skillsResult] = await Promise.all([
+          runDirectoryIngest("claude-rules", cwd, dirOpts),
+          runDirectoryIngest("cursor-rules", cwd, dirOpts),
+          runDirectoryIngest("skills", cwd, dirOpts),
+        ]);
+        totalImported += claudeResult.imported + cursorResult.imported + skillsResult.imported;
+        totalSkipped += claudeResult.skipped + cursorResult.skipped + skillsResult.skipped;
 
         if (totalImported === 0 && totalSkipped === 0 && filesToProcess.length === 0) {
           console.log(chalk.dim("No IDE rule files found."));


### PR DESCRIPTION
## Summary
- **queries.ts**: Parallelize `getGraphRolloutConfig` and `evaluateGraphRolloutQuality` using `Promise.allSettled` — these are independent calls in the context retrieval hot path, each with individual error handling preserved
- **ingest.ts**: Parallelize three `runDirectoryIngest` calls (claude-rules, cursor-rules, skills) using `Promise.all` — independent directory scans during `--all` ingestion

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (552 tests)

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that only changes async scheduling/aggregation; main risk is subtle behavior changes around timing or error surfaces, but fallbacks are preserved.
> 
> **Overview**
> Speeds up two hot paths by running independent async operations in parallel.
> 
> In `packages/cli` ingest `--all`, the three directory ingests (`claude-rules`, `cursor-rules`, `skills`) now run via `Promise.all`, then their imported/skipped counts are aggregated.
> 
> In `packages/web` context retrieval (`getContextPayload`), `getGraphRolloutConfig` and `evaluateGraphRolloutQuality` now run concurrently via `Promise.allSettled`, preserving per-call fallback/error logging while avoiding one failure blocking the other.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee913ea24b3dd831d82be4679a267305b5bc1df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->