### PR TITLE
refactor: convert sequential independent awaits to Promise.all

### DIFF
--- a/packages/web/src/app/auth/callback/route.ts
+++ b/packages/web/src/app/auth/callback/route.ts
@@ -19,13 +19,14 @@ export async function GET(request: Request): Promise<Response> {
         } = await supabase.auth.getUser()
 
         if (user) {
-          await reconcileUserAccountByEmail(user)
+          const tasks: Promise<unknown>[] = [reconcileUserAccountByEmail(user)]
           if (process.env.SUPABASE_SERVICE_ROLE_KEY) {
-            await autoJoinOrganizationsForEmails({
+            tasks.push(autoJoinOrganizationsForEmails({
               userId: user.id,
               emails: extractUserEmails(user),
-            })
+            }))
           }
+          await Promise.all(tasks)
         }
       } catch (postLoginError) {
         // Do not block login on post-auth account hydration failures.


### PR DESCRIPTION
## Summary
- **Auth callback**: Parallelize `reconcileUserAccountByEmail` + `autoJoinOrganizationsForEmails` (independent post-login DB operations)
- **CLI link command**: Parallelize `getMemoryById(id1)` + `getMemoryById(id2)` (independent lookups)
- **CLI getLinkedMemories**: Parallelize outgoing + incoming link queries (independent SELECT queries)
- **Graph status**: Parallelize 7 independent COUNT/SELECT queries into a single `Promise.all` (biggest win — was 7 sequential DB roundtrips)
- **Graph retrieval**: Parallelize `nodeDetails` + `candidateLinks` queries (independent SELECTs)

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (552 tests across all packages)

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is intended to be unchanged, but parallel execution could surface previously hidden ordering/transaction assumptions or increase concurrent DB load.
> 
> **Overview**
> Reduces latency across CLI and web flows by converting several independent sequential awaits into `Promise.all` batches.
> 
> This parallelizes: outgoing+incoming link queries in `getLinkedMemories` and the two `getMemoryById` lookups in the CLI `link` command; post-login account hydration in the auth callback (`reconcileUserAccountByEmail` alongside optional `autoJoinOrganizationsForEmails`); and multiple Turso queries in graph code (node details + candidate links in retrieval, plus counts/top-n queries in status).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83e2bccbbba3da5da76cde7d33d3911599fbce4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->