### PR TITLE
refactor: remove unused type exports across all packages

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -27,14 +27,14 @@ interface DoctorCheckOutcome {
   details?: Record<string, unknown>;
 }
 
-export interface DoctorCheckResult extends DoctorCheckOutcome {
+interface DoctorCheckResult extends DoctorCheckOutcome {
   id: string;
   code: string;
   category: DoctorCheckCategory;
   name: string;
 }
 
-export interface DoctorReport {
+interface DoctorReport {
   schemaVersion: "1.1";
   generatedAt: string;
   ok: boolean;
@@ -52,7 +52,7 @@ export interface DoctorReport {
   };
 }
 
-export interface RunDoctorChecksOptions {
+interface RunDoctorChecksOptions {
   fix?: boolean;
 }
 

--- a/packages/cli/src/lib/agents-generator.ts
+++ b/packages/cli/src/lib/agents-generator.ts
@@ -30,7 +30,7 @@ const HARNESS_HEADER = [
 
 // ── Result Types ─────────────────────────────────────────────────────
 
-export interface GenerateResult {
+interface GenerateResult {
   filesCreated: string[];
   filesCleaned: string[];
   counts: {

--- a/packages/cli/src/lib/db.ts
+++ b/packages/cli/src/lib/db.ts
@@ -64,7 +64,7 @@ function getSyncConfigPath(): string {
   return join(resolveConfigDir(), "sync.json");
 }
 
-export interface SyncConfig {
+interface SyncConfig {
   syncUrl: string;
   syncToken: string;
   org: string;

--- a/packages/cli/src/lib/ingest-helpers.ts
+++ b/packages/cli/src/lib/ingest-helpers.ts
@@ -9,7 +9,7 @@ import { MARKER } from "./markers.js";
 
 // ── Frontmatter Parsing ──────────────────────────────────────────────
 
-export interface ParsedFrontmatter {
+interface ParsedFrontmatter {
   frontmatter: Record<string, unknown>;
   body: string;
 }

--- a/packages/cli/src/lib/memory.ts
+++ b/packages/cli/src/lib/memory.ts
@@ -69,7 +69,7 @@ export interface AddMemoryOpts {
   metadata?: Record<string, unknown>; // Extended attributes (stored as JSON)
 }
 
-export interface QueryMemoryOpts {
+interface QueryMemoryOpts {
   limit?: number;
   tags?: string[];
   projectId?: string; // Override auto-detected project

--- a/packages/cli/src/lib/storage-health.ts
+++ b/packages/cli/src/lib/storage-health.ts
@@ -1,7 +1,7 @@
 import type { Client } from "@libsql/client";
 import { getDb } from "./db.js";
 
-export interface StorageMetrics {
+interface StorageMetrics {
   activeCount: number;
   deletedCount: number;
   totalCount: number;
@@ -14,7 +14,7 @@ export interface StorageWarning {
   remediation: string[];
 }
 
-export interface StorageWarningThresholds {
+interface StorageWarningThresholds {
   activeCountWarn: number;
   softDeletedCountWarn: number;
   softDeletedRatioWarn: number;

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -1,12 +1,12 @@
 import { input } from "@inquirer/prompts";
 
-export interface TemplateField {
+interface TemplateField {
   name: string;
   prompt: string;
   required: boolean;
 }
 
-export interface Template {
+interface Template {
   name: string;
   description: string;
   type: "rule" | "decision" | "fact" | "note" | "skill";

--- a/packages/cli/src/lib/tool-adapters.ts
+++ b/packages/cli/src/lib/tool-adapters.ts
@@ -7,7 +7,7 @@ import { success as uiSuccess, warn as uiWarn, error as uiError } from "./ui.js"
 
 // ── Types ────────────────────────────────────────────────────────────
 
-export interface AdaptResult {
+interface AdaptResult {
   filesCreated: string[];
   filesSkipped: string[];
   errors: string[];

--- a/packages/cli/src/mcp/scope.ts
+++ b/packages/cli/src/mcp/scope.ts
@@ -1,6 +1,6 @@
 import type { AddMemoryOpts } from "../lib/memory.js";
 
-export interface MemoryScopeInput {
+interface MemoryScopeInput {
   global?: boolean;
   project_id?: string | null;
 }

--- a/packages/web/src/components/ui/syntax.ts
+++ b/packages/web/src/components/ui/syntax.ts
@@ -1,4 +1,4 @@
-export type SyntaxTokenStyle =
+type SyntaxTokenStyle =
   | "default"
   | "keyword"
   | "string"

--- a/packages/web/src/lib/github-capture-settings.ts
+++ b/packages/web/src/lib/github-capture-settings.ts
@@ -2,7 +2,7 @@ import type { GithubCaptureCandidate, GithubCaptureEvent } from "@/lib/github-ca
 
 const GITHUB_CAPTURE_EVENT_VALUES = ["pull_request", "issues", "push", "release"] as const
 
-export type GithubCaptureAllowedEvent = (typeof GITHUB_CAPTURE_EVENT_VALUES)[number]
+type GithubCaptureAllowedEvent = (typeof GITHUB_CAPTURE_EVENT_VALUES)[number]
 
 const EVENT_ALIAS_MAP: Record<string, GithubCaptureAllowedEvent> = {
   pr: "pull_request",
@@ -13,7 +13,7 @@ const EVENT_ALIAS_MAP: Record<string, GithubCaptureAllowedEvent> = {
   release: "release",
 }
 
-export interface GithubCaptureSettings {
+interface GithubCaptureSettings {
   allowed_events: GithubCaptureAllowedEvent[]
   repo_allow_list: string[]
   repo_block_list: string[]

--- a/packages/web/src/lib/graph-url-state.ts
+++ b/packages/web/src/lib/graph-url-state.ts
@@ -1,10 +1,10 @@
-export interface GraphUrlNodeSelection {
+interface GraphUrlNodeSelection {
   nodeType: string
   nodeKey: string
   label: string
 }
 
-export interface GraphUrlState {
+interface GraphUrlState {
   selectedNode: GraphUrlNodeSelection | null
   selectedEdgeId: string | null
   isFocusMode: boolean

--- a/packages/web/src/lib/memory-service/graph/extract.ts
+++ b/packages/web/src/lib/memory-service/graph/extract.ts
@@ -16,14 +16,14 @@ export interface GraphNodeRef {
   nodeKey: string
 }
 
-export interface GraphNodeCandidate {
+interface GraphNodeCandidate {
   nodeType: string
   nodeKey: string
   label: string
   metadata: Record<string, unknown> | null
 }
 
-export interface GraphEdgeCandidate {
+interface GraphEdgeCandidate {
   from: GraphNodeRef
   to: GraphNodeRef
   edgeType: string
@@ -32,12 +32,12 @@ export interface GraphEdgeCandidate {
   expiresAt: string | null
 }
 
-export interface GraphLinkCandidate {
+interface GraphLinkCandidate {
   node: GraphNodeRef
   role: string
 }
 
-export interface DeterministicGraphExtract {
+interface DeterministicGraphExtract {
   nodes: GraphNodeCandidate[]
   edges: GraphEdgeCandidate[]
   links: GraphLinkCandidate[]

--- a/packages/web/src/lib/memory-service/graph/retrieval.ts
+++ b/packages/web/src/lib/memory-service/graph/retrieval.ts
@@ -17,7 +17,7 @@ interface CandidateScore extends NodeReason {
   linkedViaNode: string
 }
 
-export interface GraphExpansionReason {
+interface GraphExpansionReason {
   whyIncluded: "graph_expansion"
   linkedViaNode: string
   edgeType: string
@@ -25,7 +25,7 @@ export interface GraphExpansionReason {
   seedMemoryId: string
 }
 
-export interface GraphExpansionResult {
+interface GraphExpansionResult {
   memoryIds: string[]
   reasons: Map<string, GraphExpansionReason>
   totalCandidates: number

--- a/packages/web/src/lib/memory-service/graph/rollout.ts
+++ b/packages/web/src/lib/memory-service/graph/rollout.ts
@@ -8,7 +8,7 @@ export interface GraphRolloutConfig {
   updatedBy: string | null
 }
 
-export interface GraphRolloutMetricInput {
+interface GraphRolloutMetricInput {
   nowIso: string
   mode: GraphRolloutMode
   requestedStrategy: "baseline" | "hybrid_graph"

--- a/packages/web/src/lib/org-audit.ts
+++ b/packages/web/src/lib/org-audit.ts
@@ -6,7 +6,7 @@ type SupabaseLikeClient = {
   }
 }
 
-export interface OrgAuditEventInput {
+interface OrgAuditEventInput {
   orgId: string
   actorUserId?: string | null
   action: string

--- a/packages/web/src/lib/rate-limit.ts
+++ b/packages/web/src/lib/rate-limit.ts
@@ -9,7 +9,7 @@ interface RateLimitResult {
   reset: number
 }
 
-export interface RateLimiter {
+interface RateLimiter {
   limit: (identifier: string) => Promise<RateLimitResult>
 }
 

--- a/packages/web/src/lib/tools.ts
+++ b/packages/web/src/lib/tools.ts
@@ -1,4 +1,4 @@
-export interface Tool {
+interface Tool {
   name: string;
   logo: string;
   slug: string;

--- a/packages/web/src/lib/workspace-switch-performance.ts
+++ b/packages/web/src/lib/workspace-switch-performance.ts
@@ -5,7 +5,7 @@ export const WORKSPACE_SWITCH_BUDGETS = {
   p95Ms: 1000,
 } as const
 
-export type WorkspaceSwitchAlarmCode =
+type WorkspaceSwitchAlarmCode =
   | "WORKSPACE_SWITCH_P50_BUDGET_EXCEEDED"
   | "WORKSPACE_SWITCH_P95_BUDGET_EXCEEDED"
 
@@ -44,7 +44,7 @@ export interface WorkspaceSwitchHealth {
   error: string | null
 }
 
-export interface WorkspaceSwitchEvaluationOptions {
+interface WorkspaceSwitchEvaluationOptions {
   nowIso?: string
   windowHours?: number
   minSamples?: number

--- a/packages/web/src/lib/workspace-switch-profiling.ts
+++ b/packages/web/src/lib/workspace-switch-profiling.ts
@@ -48,7 +48,7 @@ export interface WorkspaceSwitchProfilingHealth {
   error: string | null
 }
 
-export interface WorkspaceSwitchProfilingOptions {
+interface WorkspaceSwitchProfilingOptions {
   minSamples?: number
   p95ClientTotalBudgetMs?: number
   p95LargeTenantClientTotalBudgetMs?: number


### PR DESCRIPTION
## Summary
- Removed `export` keyword from 21 type/interface definitions that are only used within their own files
- 9 types in `packages/cli`, 12 types in `packages/web`
- Reduces public API surface area without any behavioral changes
- Follows up on PR #28 which removed unused function exports

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (552 tests)

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no runtime changes; risk is limited to any external/other-package code that imported these now-unexported types.
> 
> **Overview**
> Reduces the public TypeScript API surface by removing `export` from ~21 type/interface definitions across `packages/cli` and `packages/web` that are only used within their defining modules.
> 
> No runtime/behavior changes are introduced; the impact is limited to downstream TypeScript imports that may have relied on these types being exported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea437343c6d7e48947c2eaa24b018c0e03c5698b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->