### PR TITLE
refactor: replace unsafe type assertions in web and ai-sdk

### DIFF
--- a/packages/ai-sdk/src/middleware.ts
+++ b/packages/ai-sdk/src/middleware.ts
@@ -49,7 +49,7 @@ export function memoriesMiddleware(options: MemoriesMiddlewareOptions = {}): { t
   return {
     async transformParams(input: unknown) {
       const isEnvelope = isRecord(input) && isRecord(input.params)
-      const params = (isEnvelope ? (input as MiddlewareEnvelope).params : input) as Record<string, unknown>
+      const params: Record<string, unknown> = isEnvelope && isRecord(input) && isRecord(input.params) ? input.params : (isRecord(input) ? input : {})
 
       const query = options.extractQuery?.(params) ?? defaultExtractQuery(params)
 

--- a/packages/web/src/app/enterprise/enterprise-contact-form.tsx
+++ b/packages/web/src/app/enterprise/enterprise-contact-form.tsx
@@ -4,6 +4,11 @@ import React, { FormEvent, useState } from "react"
 
 type Interest = "enterprise" | "usage_based" | "both"
 
+const VALID_INTERESTS: readonly Interest[] = ["enterprise", "usage_based", "both"] as const
+function isInterest(value: string): value is Interest {
+  return (VALID_INTERESTS as readonly string[]).includes(value)
+}
+
 interface FormState {
   name: string
   workEmail: string
@@ -120,7 +125,10 @@ export function EnterpriseContactForm(): React.JSX.Element {
         <select
           value={form.interest}
           onChange={(event) =>
-            setForm((prev) => ({ ...prev, interest: event.target.value as Interest }))
+            setForm((prev) => {
+              const value = event.target.value
+              return isInterest(value) ? { ...prev, interest: value } : prev
+            })
           }
           className={inputClassName}
         >

--- a/packages/web/src/components/dashboard/MemoriesSection.tsx
+++ b/packages/web/src/components/dashboard/MemoriesSection.tsx
@@ -36,6 +36,7 @@ export function MemoriesSection({ initialMemories }: { initialMemories: Memory[]
 
   useEffect(() => {
     function onInsightApplied(event: Event) {
+      if (!(event instanceof CustomEvent)) return
       const detail = (event as CustomEvent<ApplyMemoryInsightActionResult>).detail
       if (!detail) return
 

--- a/packages/web/src/components/dashboard/WorkspaceSwitcher.tsx
+++ b/packages/web/src/components/dashboard/WorkspaceSwitcher.tsx
@@ -100,7 +100,7 @@ export function WorkspaceSwitcher({ currentOrgId, memberships }: WorkspaceSwitch
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      if (dropdownRef.current && e.target instanceof Node && !dropdownRef.current.contains(e.target)) {
         setIsOpen(false)
       }
     }

--- a/packages/web/src/components/ui/input-group.tsx
+++ b/packages/web/src/components/ui/input-group.tsx
@@ -69,7 +69,7 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
-        if ((e.target as HTMLElement).closest("button")) {
+        if (e.target instanceof HTMLElement && e.target.closest("button")) {
           return
         }
         e.currentTarget.parentElement?.querySelector("input")?.focus()


### PR DESCRIPTION
## Summary
- Replace `(e.target as HTMLElement)` with `instanceof HTMLElement` in input-group.tsx
- Replace `(e.target as Node)` with `instanceof Node` in WorkspaceSwitcher.tsx
- Add `instanceof CustomEvent` guard in MemoriesSection.tsx
- Add `isInterest()` type guard in enterprise-contact-form.tsx
- Replace double cast with `isRecord()` narrowing in ai-sdk middleware.ts

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (552 tests)

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly defensive type-safety refactors with minimal behavioral change; small risk of subtly changing how invalid/unknown inputs are handled (now ignored/defaulted).
> 
> **Overview**
> Reduces reliance on unsafe casts by adding runtime type guards across the web app and `ai-sdk`.
> 
> In `memoriesMiddleware`, params extraction now safely narrows `input`/envelope handling via `isRecord`, defaulting to `{}` when shape is unexpected. Web UI handlers now guard `event.target` (`instanceof Node`/`HTMLElement`) and `CustomEvent` details, and the enterprise contact form validates the `interest` select value via an `isInterest` guard before updating state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac6c247c253eeee5a91eff91d2a4c54e3006b05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->