### PR TITLE
refactor: split core/client.ts and MemoryGraphSection.tsx into focused modules

### DIFF
--- a/packages/core/src/client-error.ts
+++ b/packages/core/src/client-error.ts
@@ -1,0 +1,34 @@
+import type { MemoriesErrorData } from "./types"
+
+export class MemoriesClientError extends Error {
+  readonly status?: number
+  readonly code?: number
+  readonly data?: unknown
+  readonly type?: MemoriesErrorData["type"]
+  readonly errorCode?: string
+  readonly retryable?: boolean
+  readonly details?: unknown
+
+  constructor(
+    message: string,
+    options?: {
+      status?: number
+      code?: number
+      data?: unknown
+      type?: MemoriesErrorData["type"]
+      errorCode?: string
+      retryable?: boolean
+      details?: unknown
+    }
+  ) {
+    super(message)
+    this.name = "MemoriesClientError"
+    this.status = options?.status
+    this.code = options?.code
+    this.type = options?.type
+    this.errorCode = options?.errorCode
+    this.retryable = options?.retryable
+    this.details = options?.details
+    this.data = options?.data ?? options?.details
+  }
+}

--- a/packages/core/src/client-helpers.ts
+++ b/packages/core/src/client-helpers.ts
@@ -1,0 +1,359 @@
+import { z } from "zod"
+import type {
+  ContextGetInput,
+  ContextGetOptions,
+  ContextMode,
+  ContextStrategy,
+  MemoriesErrorData,
+  MemoriesResponseEnvelope,
+  MemoryRecord,
+  SkillFileRecord,
+} from "./types"
+import {
+  apiErrorSchema,
+  legacyHttpErrorSchema,
+  mutationEnvelopeDataSchema,
+  responseEnvelopeSchema,
+  structuredMemorySchema,
+  structuredSkillFileSchema,
+} from "./client-schemas"
+import { MemoriesClientError } from "./client-error"
+
+export interface RpcErrorPayload {
+  code: number
+  message: string
+  data?: unknown
+}
+
+export interface RpcResponsePayload {
+  result?: unknown
+  error?: RpcErrorPayload
+}
+
+export interface ParsedToolResult {
+  raw: string
+  structured: unknown
+  envelope: MemoriesResponseEnvelope<unknown> | null
+}
+
+export interface ContextBuckets {
+  working: z.infer<typeof structuredMemorySchema>[]
+  longTerm: z.infer<typeof structuredMemorySchema>[]
+}
+
+export interface NormalizedContextInput extends ContextGetInput {
+  mode: ContextMode
+  strategy: ContextStrategy
+  graphDepth: 0 | 1 | 2
+  graphLimit: number
+}
+
+export type ContextGetMethod = {
+  (input?: ContextGetInput): Promise<import("./types").ContextResult>
+  (query?: string, options?: ContextGetOptions): Promise<import("./types").ContextResult>
+}
+
+const contextModes = new Set<ContextMode>(["all", "working", "long_term", "rules_only"])
+const contextStrategies = new Set<ContextStrategy>(["baseline", "hybrid_graph"])
+
+export function errorTypeForStatus(status: number): MemoriesErrorData["type"] {
+  if (status === 400) return "validation_error"
+  if (status === 401 || status === 403) return "auth_error"
+  if (status === 404) return "not_found_error"
+  if (status === 429) return "rate_limit_error"
+  if (status >= 500) return "internal_error"
+  return "http_error"
+}
+
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500
+}
+
+export function toTypedHttpError(status: number, payload: unknown): MemoriesErrorData {
+  const parsed = legacyHttpErrorSchema.safeParse(payload)
+  if (!parsed.success) {
+    return {
+      type: errorTypeForStatus(status),
+      code: `HTTP_${status}`,
+      message: `HTTP ${status}`,
+      status,
+      retryable: isRetryableStatus(status),
+      details: payload,
+    }
+  }
+
+  if (parsed.data.errorDetail) {
+    return {
+      ...parsed.data.errorDetail,
+      status: parsed.data.errorDetail.status ?? status,
+      retryable: parsed.data.errorDetail.retryable ?? isRetryableStatus(status),
+    }
+  }
+
+  if (typeof parsed.data.error !== "string" && parsed.data.error) {
+    return {
+      ...parsed.data.error,
+      status: parsed.data.error.status ?? status,
+      retryable: parsed.data.error.retryable ?? isRetryableStatus(status),
+    }
+  }
+
+  const message = typeof parsed.data.error === "string"
+    ? parsed.data.error
+    : parsed.data.message ?? `HTTP ${status}`
+
+  return {
+    type: errorTypeForStatus(status),
+    code: `HTTP_${status}`,
+    message,
+    status,
+    retryable: isRetryableStatus(status),
+  }
+}
+
+export function readDefaultApiKey(): string | undefined {
+  if (typeof process === "undefined") return undefined
+  return process.env.MEMORIES_API_KEY
+}
+
+export function normalizeMemoryType(type: string): MemoryRecord["type"] {
+  if (type === "rule" || type === "decision" || type === "fact" || type === "note" || type === "skill") {
+    return type
+  }
+  return "note"
+}
+
+export function normalizeMemoryLayer(layer: string | undefined, type: MemoryRecord["type"]): MemoryRecord["layer"] {
+  if (layer === "rule" || layer === "working" || layer === "long_term") {
+    return layer
+  }
+  return type === "rule" ? "rule" : "long_term"
+}
+
+export function normalizeMemoryScope(scope: string): MemoryRecord["scope"] {
+  if (scope === "global" || scope === "project" || scope === "unknown") {
+    return scope
+  }
+  return "unknown"
+}
+
+export function toMemoryRecord(memory: z.infer<typeof structuredMemorySchema>): MemoryRecord {
+  const type = normalizeMemoryType(memory.type)
+  return {
+    id: memory.id ?? null,
+    content: memory.content,
+    type,
+    layer: normalizeMemoryLayer(memory.layer, type),
+    expiresAt: memory.expiresAt ?? null,
+    scope: normalizeMemoryScope(memory.scope),
+    projectId: memory.projectId ?? null,
+    tags: memory.tags ?? [],
+    graph: memory.graph ?? null,
+  }
+}
+
+export function toSkillFileRecord(skillFile: z.infer<typeof structuredSkillFileSchema>): SkillFileRecord {
+  return {
+    id: skillFile.id,
+    path: skillFile.path,
+    content: skillFile.content,
+    scope: normalizeMemoryScope(skillFile.scope),
+    projectId: skillFile.projectId ?? null,
+    userId: skillFile.userId ?? null,
+    createdAt: skillFile.createdAt,
+    updatedAt: skillFile.updatedAt,
+  }
+}
+
+export function dedupeMemories(records: z.infer<typeof structuredMemorySchema>[]): z.infer<typeof structuredMemorySchema>[] {
+  const seen = new Set<string>()
+  const deduped: z.infer<typeof structuredMemorySchema>[] = []
+
+  for (const memory of records) {
+    const key = memory.id ?? `${memory.type}:${memory.scope}:${memory.content}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(memory)
+  }
+
+  return deduped
+}
+
+export function normalizeContextMode(mode: unknown): ContextMode {
+  if (typeof mode === "string" && contextModes.has(mode as ContextMode)) {
+    return mode as ContextMode
+  }
+  return "all"
+}
+
+export function normalizeContextStrategy(strategy: unknown): ContextStrategy {
+  if (typeof strategy === "string" && contextStrategies.has(strategy as ContextStrategy)) {
+    return strategy as ContextStrategy
+  }
+  return "baseline"
+}
+
+export function normalizeGraphDepth(depth: unknown): 0 | 1 | 2 {
+  if (depth === 0 || depth === 1 || depth === 2) {
+    return depth
+  }
+  return 1
+}
+
+export function normalizeGraphLimit(limit: unknown): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) {
+    return 8
+  }
+  return Math.max(1, Math.min(Math.floor(limit), 50))
+}
+
+export function normalizeContextInput(
+  inputOrQuery?: string | ContextGetInput,
+  options: ContextGetOptions = {}
+): NormalizedContextInput {
+  const fromObject =
+    inputOrQuery && typeof inputOrQuery === "object"
+      ? inputOrQuery
+      : { query: typeof inputOrQuery === "string" ? inputOrQuery : undefined, ...options }
+
+  return {
+    ...fromObject,
+    mode: normalizeContextMode(fromObject.mode),
+    strategy: normalizeContextStrategy(fromObject.strategy),
+    graphDepth: normalizeGraphDepth(fromObject.graphDepth),
+    graphLimit: normalizeGraphLimit(fromObject.graphLimit),
+  }
+}
+
+export function partitionByLayer(records: z.infer<typeof structuredMemorySchema>[]): ContextBuckets {
+  const working: z.infer<typeof structuredMemorySchema>[] = []
+  const longTerm: z.infer<typeof structuredMemorySchema>[] = []
+
+  for (const record of records) {
+    const type = normalizeMemoryType(record.type)
+    const layer = normalizeMemoryLayer(record.layer, type)
+    if (layer === "working") {
+      working.push(record)
+      continue
+    }
+    if (layer === "long_term") {
+      longTerm.push(record)
+    }
+  }
+
+  return { working, longTerm }
+}
+
+export function pickMemoriesForMode(
+  mode: ContextMode,
+  structured: z.infer<typeof import("./client-schemas").contextStructuredSchema>
+): z.infer<typeof structuredMemorySchema>[] {
+  const fallbackBuckets = partitionByLayer(structured.memories)
+  const working = dedupeMemories([...structured.workingMemories, ...fallbackBuckets.working])
+  const longTerm = dedupeMemories([...structured.longTermMemories, ...fallbackBuckets.longTerm])
+
+  if (mode === "rules_only") {
+    return []
+  }
+  if (mode === "working") {
+    return working
+  }
+  if (mode === "long_term") {
+    return longTerm
+  }
+  return dedupeMemories([...working, ...longTerm])
+}
+
+export function toClientError(error: MemoriesErrorData, options?: { status?: number; rpcCode?: number }) {
+  return new MemoriesClientError(error.message, {
+    status: error.status ?? options?.status,
+    code: options?.rpcCode,
+    type: error.type,
+    errorCode: error.code,
+    retryable: error.retryable,
+    details: error.details,
+  })
+}
+
+export function parseToolResult(result: unknown): ParsedToolResult {
+  const parsed = z
+    .object({
+      content: z.array(z.object({ type: z.string(), text: z.string().optional() })).optional(),
+      structuredContent: z.unknown().optional(),
+    })
+    .passthrough()
+    .safeParse(result)
+
+  if (!parsed.success) {
+    return { raw: "", structured: null, envelope: null }
+  }
+
+  const textChunk = parsed.data.content?.find((entry) => entry.type === "text" && entry.text)
+  const envelope = responseEnvelopeSchema.safeParse(parsed.data.structuredContent)
+
+  if (envelope.success) {
+    const parsedEnvelope: MemoriesResponseEnvelope<unknown> = {
+      ok: envelope.data.ok,
+      data: envelope.data.data,
+      error: envelope.data.error,
+      meta: envelope.data.meta,
+    }
+    return {
+      raw: textChunk?.text ?? "",
+      structured: parsedEnvelope.data,
+      envelope: parsedEnvelope,
+    }
+  }
+
+  return {
+    raw: textChunk?.text ?? "",
+    structured: parsed.data.structuredContent ?? null,
+    envelope: null,
+  }
+}
+
+export function messageFromEnvelope(envelope: MemoriesResponseEnvelope<unknown> | null): string | null {
+  if (!envelope?.data || typeof envelope.data !== "object") return null
+  const parsed = mutationEnvelopeDataSchema.safeParse(envelope.data)
+  if (!parsed.success || typeof parsed.data.message !== "string") return null
+  return parsed.data.message
+}
+
+export function parseStructuredData<T>(
+  schema: z.ZodType<T>,
+  endpoint: string,
+  structured: unknown
+): T {
+  const parsed = schema.safeParse(structured)
+  if (parsed.success) {
+    return parsed.data
+  }
+
+  throw new MemoriesClientError(`Invalid SDK response data for ${endpoint}`, {
+    type: "http_error",
+    errorCode: "INVALID_RESPONSE_DATA",
+    retryable: false,
+    details: structured,
+  })
+}
+
+export function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+export function deriveSdkBaseUrl(baseUrl: string): string {
+  if (baseUrl.endsWith("/api/mcp")) {
+    return baseUrl.slice(0, -"/api/mcp".length)
+  }
+  if (baseUrl.endsWith("/api/sdk/v1")) {
+    return baseUrl.slice(0, -"/api/sdk/v1".length)
+  }
+  return baseUrl
+}
+
+export function deriveMcpUrl(baseUrl: string, sdkBaseUrl: string): string {
+  if (baseUrl.endsWith("/api/mcp")) {
+    return baseUrl
+  }
+  return `${sdkBaseUrl}/api/mcp`
+}

--- a/packages/core/src/client-schemas.ts
+++ b/packages/core/src/client-schemas.ts
@@ -1,0 +1,159 @@
+import { z } from "zod"
+
+export const baseUrlSchema = z.string().url()
+
+export const apiErrorSchema = z.object({
+  type: z.string(),
+  code: z.string(),
+  message: z.string(),
+  status: z.number().int().optional(),
+  retryable: z.boolean().optional(),
+  details: z.unknown().optional(),
+})
+
+export const responseEnvelopeSchema = z.object({
+  ok: z.boolean(),
+  data: z.unknown().nullable(),
+  error: apiErrorSchema.nullable(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const legacyHttpErrorSchema = z.object({
+  error: z.union([z.string(), apiErrorSchema]).optional(),
+  errorDetail: apiErrorSchema.optional(),
+  message: z.string().optional(),
+})
+
+export const structuredMemorySchema = z.object({
+  id: z.string().nullable().optional(),
+  content: z.string(),
+  type: z.string(),
+  layer: z.string().optional(),
+  expiresAt: z.string().nullable().optional(),
+  scope: z.string(),
+  projectId: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional().default([]),
+  graph: z
+    .object({
+      whyIncluded: z.literal("graph_expansion"),
+      linkedViaNode: z.string(),
+      edgeType: z.string(),
+      hopCount: z.number().int().nonnegative(),
+      seedMemoryId: z.string(),
+    })
+    .nullable()
+    .optional(),
+})
+
+export const structuredSkillFileSchema = z.object({
+  id: z.string(),
+  path: z.string(),
+  content: z.string(),
+  scope: z.string(),
+  projectId: z.string().nullable().optional(),
+  userId: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export const contextStructuredSchema = z.object({
+  rules: z.array(structuredMemorySchema).optional().default([]),
+  memories: z.array(structuredMemorySchema).optional().default([]),
+  skillFiles: z.array(structuredSkillFileSchema).optional().default([]),
+  workingMemories: z.array(structuredMemorySchema).optional().default([]),
+  longTermMemories: z.array(structuredMemorySchema).optional().default([]),
+  trace: z
+    .object({
+      requestedStrategy: z.union([z.literal("baseline"), z.literal("hybrid_graph")]).optional(),
+      strategy: z.union([z.literal("baseline"), z.literal("hybrid_graph")]),
+      graphDepth: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+      graphLimit: z.number().int().nonnegative(),
+      rolloutMode: z.union([z.literal("off"), z.literal("shadow"), z.literal("canary")]).optional(),
+      shadowExecuted: z.boolean().optional(),
+      baselineCandidates: z.number().int().nonnegative(),
+      graphCandidates: z.number().int().nonnegative(),
+      graphExpandedCount: z.number().int().nonnegative(),
+      fallbackTriggered: z.boolean().optional(),
+      fallbackReason: z.string().nullable().optional(),
+      totalCandidates: z.number().int().nonnegative(),
+    })
+    .optional(),
+})
+
+export const memoriesStructuredSchema = z.object({
+  memories: z.array(structuredMemorySchema).optional().default([]),
+})
+
+export const skillFilesStructuredSchema = z.object({
+  skillFiles: z.array(structuredSkillFileSchema).optional().default([]),
+  count: z.number().int().nonnegative().optional(),
+})
+
+export const mutationEnvelopeDataSchema = z.object({
+  message: z.string().optional(),
+})
+
+export const bulkForgetResultSchema = z.object({
+  count: z.number().int().nonnegative(),
+  ids: z.array(z.string()).optional(),
+  memories: z.array(z.object({
+    id: z.string(),
+    type: z.string(),
+    contentPreview: z.string(),
+  })).optional(),
+  message: z.string(),
+})
+
+export const vacuumResultSchema = z.object({
+  purged: z.number().int().nonnegative(),
+  message: z.string(),
+})
+
+export const managementKeyStatusSchema = z.object({
+  hasKey: z.boolean(),
+  keyPreview: z.string().optional(),
+  createdAt: z.string().nullable().optional(),
+  expiresAt: z.string().nullable().optional(),
+  isExpired: z.boolean().optional(),
+})
+
+export const managementKeyCreateSchema = z.object({
+  apiKey: z.string(),
+  keyPreview: z.string().optional(),
+  createdAt: z.string().optional(),
+  expiresAt: z.string().optional(),
+  message: z.string().optional(),
+})
+
+export const managementKeyRevokeSchema = z.object({
+  ok: z.boolean(),
+})
+
+export const managementTenantSchema = z.object({
+  tenantId: z.string(),
+  tursoDbUrl: z.string(),
+  tursoDbName: z.string().nullable().optional(),
+  status: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  lastVerifiedAt: z.string().nullable().optional(),
+})
+
+export const managementTenantListSchema = z.object({
+  tenantDatabases: z.array(managementTenantSchema),
+  count: z.number().int(),
+})
+
+export const managementTenantUpsertSchema = z.object({
+  tenantDatabase: managementTenantSchema,
+  provisioned: z.boolean(),
+  mode: z.string(),
+})
+
+export const managementTenantDisableSchema = z.object({
+  ok: z.boolean(),
+  tenantId: z.string(),
+  status: z.string(),
+  updatedAt: z.string(),
+})

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -7,8 +7,6 @@ import type {
   BulkForgetResult,
   ContextGetInput,
   ContextGetOptions,
-  ContextMode,
-  ContextStrategy,
   ContextResult,
   ManagementKeyCreateInput,
   ManagementKeyCreateResult,
@@ -32,6 +30,43 @@ import type {
   MutationResult,
   VacuumResult,
 } from "./types"
+import {
+  apiErrorSchema,
+  baseUrlSchema,
+  bulkForgetResultSchema,
+  contextStructuredSchema,
+  managementKeyCreateSchema,
+  managementKeyRevokeSchema,
+  managementKeyStatusSchema,
+  managementTenantDisableSchema,
+  managementTenantListSchema,
+  managementTenantUpsertSchema,
+  memoriesStructuredSchema,
+  responseEnvelopeSchema,
+  skillFilesStructuredSchema,
+  vacuumResultSchema,
+} from "./client-schemas"
+import {
+  type ContextGetMethod,
+  type ParsedToolResult,
+  type RpcResponsePayload,
+  deriveMcpUrl,
+  deriveSdkBaseUrl,
+  messageFromEnvelope,
+  normalizeContextInput,
+  parseStructuredData,
+  parseToolResult,
+  pickMemoriesForMode,
+  readDefaultApiKey,
+  stripTrailingSlash,
+  toClientError,
+  toMemoryRecord,
+  toSkillFileRecord,
+  toTypedHttpError,
+} from "./client-helpers"
+import { MemoriesClientError } from "./client-error"
+
+export { MemoriesClientError } from "./client-error"
 
 export interface MemoriesClientOptions {
   apiKey?: string
@@ -41,535 +76,6 @@ export interface MemoriesClientOptions {
   tenantId?: string
   fetch?: typeof fetch
   headers?: Record<string, string>
-}
-
-interface RpcErrorPayload {
-  code: number
-  message: string
-  data?: unknown
-}
-
-interface RpcResponsePayload {
-  result?: unknown
-  error?: RpcErrorPayload
-}
-
-const baseUrlSchema = z.string().url()
-const apiErrorSchema = z.object({
-  type: z.string(),
-  code: z.string(),
-  message: z.string(),
-  status: z.number().int().optional(),
-  retryable: z.boolean().optional(),
-  details: z.unknown().optional(),
-})
-
-const responseEnvelopeSchema = z.object({
-  ok: z.boolean(),
-  data: z.unknown().nullable(),
-  error: apiErrorSchema.nullable(),
-  meta: z.record(z.string(), z.unknown()).optional(),
-})
-
-const legacyHttpErrorSchema = z.object({
-  error: z.union([z.string(), apiErrorSchema]).optional(),
-  errorDetail: apiErrorSchema.optional(),
-  message: z.string().optional(),
-})
-
-const structuredMemorySchema = z.object({
-  id: z.string().nullable().optional(),
-  content: z.string(),
-  type: z.string(),
-  layer: z.string().optional(),
-  expiresAt: z.string().nullable().optional(),
-  scope: z.string(),
-  projectId: z.string().nullable().optional(),
-  tags: z.array(z.string()).optional().default([]),
-  graph: z
-    .object({
-      whyIncluded: z.literal("graph_expansion"),
-      linkedViaNode: z.string(),
-      edgeType: z.string(),
-      hopCount: z.number().int().nonnegative(),
-      seedMemoryId: z.string(),
-    })
-    .nullable()
-    .optional(),
-})
-
-const structuredSkillFileSchema = z.object({
-  id: z.string(),
-  path: z.string(),
-  content: z.string(),
-  scope: z.string(),
-  projectId: z.string().nullable().optional(),
-  userId: z.string().nullable().optional(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-})
-
-const contextStructuredSchema = z.object({
-  rules: z.array(structuredMemorySchema).optional().default([]),
-  memories: z.array(structuredMemorySchema).optional().default([]),
-  skillFiles: z.array(structuredSkillFileSchema).optional().default([]),
-  workingMemories: z.array(structuredMemorySchema).optional().default([]),
-  longTermMemories: z.array(structuredMemorySchema).optional().default([]),
-  trace: z
-    .object({
-      requestedStrategy: z.union([z.literal("baseline"), z.literal("hybrid_graph")]).optional(),
-      strategy: z.union([z.literal("baseline"), z.literal("hybrid_graph")]),
-      graphDepth: z.union([z.literal(0), z.literal(1), z.literal(2)]),
-      graphLimit: z.number().int().nonnegative(),
-      rolloutMode: z.union([z.literal("off"), z.literal("shadow"), z.literal("canary")]).optional(),
-      shadowExecuted: z.boolean().optional(),
-      baselineCandidates: z.number().int().nonnegative(),
-      graphCandidates: z.number().int().nonnegative(),
-      graphExpandedCount: z.number().int().nonnegative(),
-      fallbackTriggered: z.boolean().optional(),
-      fallbackReason: z.string().nullable().optional(),
-      totalCandidates: z.number().int().nonnegative(),
-    })
-    .optional(),
-})
-
-const memoriesStructuredSchema = z.object({
-  memories: z.array(structuredMemorySchema).optional().default([]),
-})
-
-const skillFilesStructuredSchema = z.object({
-  skillFiles: z.array(structuredSkillFileSchema).optional().default([]),
-  count: z.number().int().nonnegative().optional(),
-})
-
-const mutationEnvelopeDataSchema = z.object({
-  message: z.string().optional(),
-})
-
-const bulkForgetResultSchema = z.object({
-  count: z.number().int().nonnegative(),
-  ids: z.array(z.string()).optional(),
-  memories: z.array(z.object({
-    id: z.string(),
-    type: z.string(),
-    contentPreview: z.string(),
-  })).optional(),
-  message: z.string(),
-})
-
-const vacuumResultSchema = z.object({
-  purged: z.number().int().nonnegative(),
-  message: z.string(),
-})
-
-const managementKeyStatusSchema = z.object({
-  hasKey: z.boolean(),
-  keyPreview: z.string().optional(),
-  createdAt: z.string().nullable().optional(),
-  expiresAt: z.string().nullable().optional(),
-  isExpired: z.boolean().optional(),
-})
-
-const managementKeyCreateSchema = z.object({
-  apiKey: z.string(),
-  keyPreview: z.string().optional(),
-  createdAt: z.string().optional(),
-  expiresAt: z.string().optional(),
-  message: z.string().optional(),
-})
-
-const managementKeyRevokeSchema = z.object({
-  ok: z.boolean(),
-})
-
-const managementTenantSchema = z.object({
-  tenantId: z.string(),
-  tursoDbUrl: z.string(),
-  tursoDbName: z.string().nullable().optional(),
-  status: z.string(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-  createdAt: z.string().optional(),
-  updatedAt: z.string().optional(),
-  lastVerifiedAt: z.string().nullable().optional(),
-})
-
-const managementTenantListSchema = z.object({
-  tenantDatabases: z.array(managementTenantSchema),
-  count: z.number().int(),
-})
-
-const managementTenantUpsertSchema = z.object({
-  tenantDatabase: managementTenantSchema,
-  provisioned: z.boolean(),
-  mode: z.string(),
-})
-
-const managementTenantDisableSchema = z.object({
-  ok: z.boolean(),
-  tenantId: z.string(),
-  status: z.string(),
-  updatedAt: z.string(),
-})
-
-function errorTypeForStatus(status: number): MemoriesErrorData["type"] {
-  if (status === 400) return "validation_error"
-  if (status === 401 || status === 403) return "auth_error"
-  if (status === 404) return "not_found_error"
-  if (status === 429) return "rate_limit_error"
-  if (status >= 500) return "internal_error"
-  return "http_error"
-}
-
-function isRetryableStatus(status: number): boolean {
-  return status === 429 || status >= 500
-}
-
-function toTypedHttpError(status: number, payload: unknown): MemoriesErrorData {
-  const parsed = legacyHttpErrorSchema.safeParse(payload)
-  if (!parsed.success) {
-    return {
-      type: errorTypeForStatus(status),
-      code: `HTTP_${status}`,
-      message: `HTTP ${status}`,
-      status,
-      retryable: isRetryableStatus(status),
-      details: payload,
-    }
-  }
-
-  if (parsed.data.errorDetail) {
-    return {
-      ...parsed.data.errorDetail,
-      status: parsed.data.errorDetail.status ?? status,
-      retryable: parsed.data.errorDetail.retryable ?? isRetryableStatus(status),
-    }
-  }
-
-  if (typeof parsed.data.error !== "string" && parsed.data.error) {
-    return {
-      ...parsed.data.error,
-      status: parsed.data.error.status ?? status,
-      retryable: parsed.data.error.retryable ?? isRetryableStatus(status),
-    }
-  }
-
-  const message = typeof parsed.data.error === "string"
-    ? parsed.data.error
-    : parsed.data.message ?? `HTTP ${status}`
-
-  return {
-    type: errorTypeForStatus(status),
-    code: `HTTP_${status}`,
-    message,
-    status,
-    retryable: isRetryableStatus(status),
-  }
-}
-
-export class MemoriesClientError extends Error {
-  readonly status?: number
-  readonly code?: number
-  readonly data?: unknown
-  readonly type?: MemoriesErrorData["type"]
-  readonly errorCode?: string
-  readonly retryable?: boolean
-  readonly details?: unknown
-
-  constructor(
-    message: string,
-    options?: {
-      status?: number
-      code?: number
-      data?: unknown
-      type?: MemoriesErrorData["type"]
-      errorCode?: string
-      retryable?: boolean
-      details?: unknown
-    }
-  ) {
-    super(message)
-    this.name = "MemoriesClientError"
-    this.status = options?.status
-    this.code = options?.code
-    this.type = options?.type
-    this.errorCode = options?.errorCode
-    this.retryable = options?.retryable
-    this.details = options?.details
-    this.data = options?.data ?? options?.details
-  }
-}
-
-function readDefaultApiKey(): string | undefined {
-  if (typeof process === "undefined") return undefined
-  return process.env.MEMORIES_API_KEY
-}
-
-function normalizeMemoryType(type: string): MemoryRecord["type"] {
-  if (type === "rule" || type === "decision" || type === "fact" || type === "note" || type === "skill") {
-    return type
-  }
-  return "note"
-}
-
-function normalizeMemoryLayer(layer: string | undefined, type: MemoryRecord["type"]): MemoryRecord["layer"] {
-  if (layer === "rule" || layer === "working" || layer === "long_term") {
-    return layer
-  }
-  return type === "rule" ? "rule" : "long_term"
-}
-
-function normalizeMemoryScope(scope: string): MemoryRecord["scope"] {
-  if (scope === "global" || scope === "project" || scope === "unknown") {
-    return scope
-  }
-  return "unknown"
-}
-
-function toMemoryRecord(memory: z.infer<typeof structuredMemorySchema>): MemoryRecord {
-  const type = normalizeMemoryType(memory.type)
-  return {
-    id: memory.id ?? null,
-    content: memory.content,
-    type,
-    layer: normalizeMemoryLayer(memory.layer, type),
-    expiresAt: memory.expiresAt ?? null,
-    scope: normalizeMemoryScope(memory.scope),
-    projectId: memory.projectId ?? null,
-    tags: memory.tags ?? [],
-    graph: memory.graph ?? null,
-  }
-}
-
-function toSkillFileRecord(skillFile: z.infer<typeof structuredSkillFileSchema>): SkillFileRecord {
-  return {
-    id: skillFile.id,
-    path: skillFile.path,
-    content: skillFile.content,
-    scope: normalizeMemoryScope(skillFile.scope),
-    projectId: skillFile.projectId ?? null,
-    userId: skillFile.userId ?? null,
-    createdAt: skillFile.createdAt,
-    updatedAt: skillFile.updatedAt,
-  }
-}
-
-function dedupeMemories(records: z.infer<typeof structuredMemorySchema>[]): z.infer<typeof structuredMemorySchema>[] {
-  const seen = new Set<string>()
-  const deduped: z.infer<typeof structuredMemorySchema>[] = []
-
-  for (const memory of records) {
-    const key = memory.id ?? `${memory.type}:${memory.scope}:${memory.content}`
-    if (seen.has(key)) continue
-    seen.add(key)
-    deduped.push(memory)
-  }
-
-  return deduped
-}
-
-const contextModes = new Set<ContextMode>(["all", "working", "long_term", "rules_only"])
-const contextStrategies = new Set<ContextStrategy>(["baseline", "hybrid_graph"])
-
-interface ContextBuckets {
-  working: z.infer<typeof structuredMemorySchema>[]
-  longTerm: z.infer<typeof structuredMemorySchema>[]
-}
-
-interface NormalizedContextInput extends ContextGetInput {
-  mode: ContextMode
-  strategy: ContextStrategy
-  graphDepth: 0 | 1 | 2
-  graphLimit: number
-}
-
-type ContextGetMethod = {
-  (input?: ContextGetInput): Promise<ContextResult>
-  (query?: string, options?: ContextGetOptions): Promise<ContextResult>
-}
-
-function normalizeContextMode(mode: unknown): ContextMode {
-  if (typeof mode === "string" && contextModes.has(mode as ContextMode)) {
-    return mode as ContextMode
-  }
-  return "all"
-}
-
-function normalizeContextStrategy(strategy: unknown): ContextStrategy {
-  if (typeof strategy === "string" && contextStrategies.has(strategy as ContextStrategy)) {
-    return strategy as ContextStrategy
-  }
-  return "baseline"
-}
-
-function normalizeGraphDepth(depth: unknown): 0 | 1 | 2 {
-  if (depth === 0 || depth === 1 || depth === 2) {
-    return depth
-  }
-  return 1
-}
-
-function normalizeGraphLimit(limit: unknown): number {
-  if (typeof limit !== "number" || !Number.isFinite(limit)) {
-    return 8
-  }
-  return Math.max(1, Math.min(Math.floor(limit), 50))
-}
-
-function normalizeContextInput(
-  inputOrQuery?: string | ContextGetInput,
-  options: ContextGetOptions = {}
-): NormalizedContextInput {
-  const fromObject =
-    inputOrQuery && typeof inputOrQuery === "object"
-      ? inputOrQuery
-      : { query: typeof inputOrQuery === "string" ? inputOrQuery : undefined, ...options }
-
-  return {
-    ...fromObject,
-    mode: normalizeContextMode(fromObject.mode),
-    strategy: normalizeContextStrategy(fromObject.strategy),
-    graphDepth: normalizeGraphDepth(fromObject.graphDepth),
-    graphLimit: normalizeGraphLimit(fromObject.graphLimit),
-  }
-}
-
-function partitionByLayer(records: z.infer<typeof structuredMemorySchema>[]): ContextBuckets {
-  const working: z.infer<typeof structuredMemorySchema>[] = []
-  const longTerm: z.infer<typeof structuredMemorySchema>[] = []
-
-  for (const record of records) {
-    const type = normalizeMemoryType(record.type)
-    const layer = normalizeMemoryLayer(record.layer, type)
-    if (layer === "working") {
-      working.push(record)
-      continue
-    }
-    if (layer === "long_term") {
-      longTerm.push(record)
-    }
-  }
-
-  return { working, longTerm }
-}
-
-function pickMemoriesForMode(
-  mode: ContextMode,
-  structured: z.infer<typeof contextStructuredSchema>
-): z.infer<typeof structuredMemorySchema>[] {
-  const fallbackBuckets = partitionByLayer(structured.memories)
-  const working = dedupeMemories([...structured.workingMemories, ...fallbackBuckets.working])
-  const longTerm = dedupeMemories([...structured.longTermMemories, ...fallbackBuckets.longTerm])
-
-  if (mode === "rules_only") {
-    return []
-  }
-  if (mode === "working") {
-    return working
-  }
-  if (mode === "long_term") {
-    return longTerm
-  }
-  return dedupeMemories([...working, ...longTerm])
-}
-
-interface ParsedToolResult {
-  raw: string
-  structured: unknown
-  envelope: MemoriesResponseEnvelope<unknown> | null
-}
-
-function toClientError(error: MemoriesErrorData, options?: { status?: number; rpcCode?: number }) {
-  return new MemoriesClientError(error.message, {
-    status: error.status ?? options?.status,
-    code: options?.rpcCode,
-    type: error.type,
-    errorCode: error.code,
-    retryable: error.retryable,
-    details: error.details,
-  })
-}
-
-function parseToolResult(result: unknown): ParsedToolResult {
-  const parsed = z
-    .object({
-      content: z.array(z.object({ type: z.string(), text: z.string().optional() })).optional(),
-      structuredContent: z.unknown().optional(),
-    })
-    .passthrough()
-    .safeParse(result)
-
-  if (!parsed.success) {
-    return { raw: "", structured: null, envelope: null }
-  }
-
-  const textChunk = parsed.data.content?.find((entry) => entry.type === "text" && entry.text)
-  const envelope = responseEnvelopeSchema.safeParse(parsed.data.structuredContent)
-
-  if (envelope.success) {
-    const parsedEnvelope: MemoriesResponseEnvelope<unknown> = {
-      ok: envelope.data.ok,
-      data: envelope.data.data,
-      error: envelope.data.error,
-      meta: envelope.data.meta,
-    }
-    return {
-      raw: textChunk?.text ?? "",
-      structured: parsedEnvelope.data,
-      envelope: parsedEnvelope,
-    }
-  }
-
-  return {
-    raw: textChunk?.text ?? "",
-    structured: parsed.data.structuredContent ?? null,
-    envelope: null,
-  }
-}
-
-function messageFromEnvelope(envelope: MemoriesResponseEnvelope<unknown> | null): string | null {
-  if (!envelope?.data || typeof envelope.data !== "object") return null
-  const parsed = mutationEnvelopeDataSchema.safeParse(envelope.data)
-  if (!parsed.success || typeof parsed.data.message !== "string") return null
-  return parsed.data.message
-}
-
-function parseStructuredData<T>(
-  schema: z.ZodType<T>,
-  endpoint: string,
-  structured: unknown
-): T {
-  const parsed = schema.safeParse(structured)
-  if (parsed.success) {
-    return parsed.data
-  }
-
-  throw new MemoriesClientError(`Invalid SDK response data for ${endpoint}`, {
-    type: "http_error",
-    errorCode: "INVALID_RESPONSE_DATA",
-    retryable: false,
-    details: structured,
-  })
-}
-
-function stripTrailingSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value
-}
-
-function deriveSdkBaseUrl(baseUrl: string): string {
-  if (baseUrl.endsWith("/api/mcp")) {
-    return baseUrl.slice(0, -"/api/mcp".length)
-  }
-  if (baseUrl.endsWith("/api/sdk/v1")) {
-    return baseUrl.slice(0, -"/api/sdk/v1".length)
-  }
-  return baseUrl
-}
-
-function deriveMcpUrl(baseUrl: string, sdkBaseUrl: string): string {
-  if (baseUrl.endsWith("/api/mcp")) {
-    return baseUrl
-  }
-  return `${sdkBaseUrl}/api/mcp`
 }
 
 export class MemoriesClient {
@@ -821,7 +327,6 @@ export class MemoriesClient {
     },
 
     bulkForget: async (filters: BulkForgetFilter, options?: { dryRun?: boolean }): Promise<BulkForgetResult> => {
-      // Scope carries tenantId/userId for routing; projectId is a query-level filter only
       const rawScope = this.withDefaultScopeSdk({})
       const sdkScope = rawScope && Object.keys(rawScope).length > 0 ? rawScope : undefined
       const dryRun = options?.dryRun ?? false

--- a/packages/web/src/components/dashboard/MemoryGraphSection.tsx
+++ b/packages/web/src/components/dashboard/MemoryGraphSection.tsx
@@ -13,101 +13,31 @@ import React, {
 import { extractErrorMessage } from "@/lib/client-errors"
 import { applyGraphUrlState, graphUrlToRelativePath, parseGraphUrlState } from "@/lib/graph-url-state"
 import type { GraphStatusPayload } from "@/lib/memory-service/graph/status"
+import {
+  type GraphExplorerResponse,
+  type GraphNodeSelection,
+  type GraphRolloutMode,
+  type GraphViewport,
+  buildGraphCanvasModel,
+  clamp,
+  DEFAULT_GRAPH_VIEWPORT,
+  formatNodeLabel,
+  getNodeStyle,
+  GRAPH_HEIGHT,
+  GRAPH_WIDTH,
+  GRAPH_ZOOM_MAX,
+  GRAPH_ZOOM_MIN,
+  GRAPH_ZOOM_STEP,
+  qualityStatusClass,
+  qualityStatusLabel,
+  ROLLOUT_MODES,
+  severityClass,
+  trimMiddle,
+  truncateText,
+} from "./memory-graph-helpers"
 
 interface MemoryGraphSectionProps {
   status: GraphStatusPayload | null
-}
-
-type GraphRolloutMode = GraphStatusPayload["rollout"]["mode"]
-type GraphNodeSelection = {
-  nodeType: string
-  nodeKey: string
-  label: string
-}
-
-interface GraphExplorerEdge {
-  id: string
-  edgeType: string
-  weight: number
-  confidence: number
-  expiresAt: string | null
-  evidenceMemoryId: string | null
-  direction: "outbound" | "inbound"
-  from: GraphNodeSelection
-  to: GraphNodeSelection
-}
-
-interface GraphExplorerMemory {
-  memoryId: string
-  role: string
-  type: string
-  content: string
-  updatedAt: string | null
-}
-
-interface GraphExplorerResponse {
-  node: GraphNodeSelection | null
-  nodes: GraphNodeSelection[]
-  edges: GraphExplorerEdge[]
-  memories: GraphExplorerMemory[]
-}
-
-interface GraphCanvasNode extends GraphNodeSelection {
-  id: string
-  x: number
-  y: number
-  degree: number
-  isSelected: boolean
-}
-
-interface GraphCanvasEdge extends GraphExplorerEdge {
-  fromId: string
-  toId: string
-  path: string
-  labelX: number
-  labelY: number
-}
-
-interface GraphCanvasModel {
-  nodes: GraphCanvasNode[]
-  edges: GraphCanvasEdge[]
-  nodeTypes: string[]
-}
-
-const ROLLOUT_MODES: Array<{ value: GraphRolloutMode; label: string; description: string }> = [
-  { value: "off", label: "Off", description: "Always serve baseline retrieval." },
-  { value: "shadow", label: "Shadow", description: "Run graph retrieval without applying it." },
-  { value: "canary", label: "Canary", description: "Apply graph retrieval for hybrid requests." },
-]
-
-const GRAPH_WIDTH = 1080
-const GRAPH_HEIGHT = 620
-const GRAPH_ZOOM_MIN = 0.55
-const GRAPH_ZOOM_MAX = 2.6
-const GRAPH_ZOOM_STEP = 0.16
-
-interface GraphViewport {
-  scale: number
-  x: number
-  y: number
-}
-
-const DEFAULT_GRAPH_VIEWPORT: GraphViewport = {
-  scale: 1,
-  x: 0,
-  y: 0,
-}
-
-const NODE_TYPE_STYLES: Record<string, { fill: string; stroke: string; text: string }> = {
-  repo: { fill: "rgba(56, 189, 248, 0.16)", stroke: "#38bdf8", text: "#d8f3ff" },
-  topic: { fill: "rgba(16, 185, 129, 0.16)", stroke: "#10b981", text: "#dcfce7" },
-  category: { fill: "rgba(245, 158, 11, 0.16)", stroke: "#f59e0b", text: "#fef3c7" },
-  user: { fill: "rgba(168, 85, 247, 0.16)", stroke: "#a855f7", text: "#f3e8ff" },
-  memory_type: { fill: "rgba(99, 102, 241, 0.18)", stroke: "#6366f1", text: "#e0e7ff" },
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value))
 }
 
 function metricCard(
@@ -125,205 +55,6 @@ function metricCard(
       </p>
     </div>
   )
-}
-
-function severityClass(severity: "info" | "warning" | "critical"): string {
-  if (severity === "critical") return "text-red-500"
-  if (severity === "warning") return "text-amber-500"
-  return "text-sky-500"
-}
-
-function qualityStatusLabel(status: GraphStatusPayload["qualityGate"]["status"]): string {
-  if (status === "insufficient_data") return "Insufficient Data"
-  return status.toUpperCase()
-}
-
-function qualityStatusClass(status: GraphStatusPayload["qualityGate"]["status"], blocked: boolean): string {
-  if (blocked || status === "fail") return "text-red-500"
-  if (status === "warn") return "text-amber-500"
-  if (status === "pass") return "text-emerald-500"
-  return "text-muted-foreground"
-}
-
-function truncateText(value: string, max = 180): string {
-  if (value.length <= max) return value
-  return `${value.slice(0, max).trim()}...`
-}
-
-function nodeRefId(node: GraphNodeSelection): string {
-  return `${node.nodeType}:${node.nodeKey}`
-}
-
-function getNodeStyle(nodeType: string): { fill: string; stroke: string; text: string } {
-  return NODE_TYPE_STYLES[nodeType] ?? {
-    fill: "rgba(148, 163, 184, 0.14)",
-    stroke: "#94a3b8",
-    text: "#e2e8f0",
-  }
-}
-
-function formatNodeLabel(node: GraphNodeSelection): string {
-  if (node.nodeType === "repo") {
-    const tail = node.nodeKey.split("/").pop()
-    return tail || node.label
-  }
-  return node.label || `${node.nodeType}:${node.nodeKey}`
-}
-
-function trimMiddle(value: string, maxLength: number): string {
-  if (value.length <= maxLength) return value
-  const slice = Math.max(4, Math.floor((maxLength - 3) / 2))
-  return `${value.slice(0, slice)}...${value.slice(-slice)}`
-}
-
-function buildEdgeGeometry(from: GraphCanvasNode, to: GraphCanvasNode, curveOffset: number): {
-  path: string
-  labelX: number
-  labelY: number
-} {
-  if (from.id === to.id) {
-    const loopLift = 62 + Math.abs(curveOffset) * 0.4
-    const loopRadius = 34 + Math.abs(curveOffset) * 0.3
-    return {
-      path: `M ${from.x} ${from.y - 12}
-             C ${from.x + loopRadius} ${from.y - loopLift}
-               ${from.x - loopRadius} ${from.y - loopLift}
-               ${from.x} ${from.y - 12}`,
-      labelX: from.x,
-      labelY: from.y - loopLift - 8,
-    }
-  }
-
-  const mx = (from.x + to.x) / 2
-  const my = (from.y + to.y) / 2
-  const dx = to.x - from.x
-  const dy = to.y - from.y
-  const length = Math.hypot(dx, dy) || 1
-  const nx = -dy / length
-  const ny = dx / length
-  const cx = mx + nx * curveOffset
-  const cy = my + ny * curveOffset
-
-  return {
-    path: `M ${from.x} ${from.y} Q ${cx} ${cy} ${to.x} ${to.y}`,
-    labelX: 0.25 * from.x + 0.5 * cx + 0.25 * to.x,
-    labelY: 0.25 * from.y + 0.5 * cy + 0.25 * to.y,
-  }
-}
-
-function buildGraphCanvasModel(
-  selectedNode: GraphNodeSelection | null,
-  explorerData: GraphExplorerResponse | null
-): GraphCanvasModel | null {
-  if (!selectedNode || !explorerData) {
-    return null
-  }
-
-  const selectedId = nodeRefId(selectedNode)
-  const nodeMap = new Map<string, GraphNodeSelection>()
-  nodeMap.set(selectedId, selectedNode)
-
-  for (const node of explorerData.nodes) {
-    nodeMap.set(nodeRefId(node), node)
-  }
-
-  for (const edge of explorerData.edges) {
-    nodeMap.set(nodeRefId(edge.from), edge.from)
-    nodeMap.set(nodeRefId(edge.to), edge.to)
-  }
-
-  if (nodeMap.size === 0) {
-    return null
-  }
-
-  const degreeMap = new Map<string, number>()
-  for (const edge of explorerData.edges) {
-    const fromId = nodeRefId(edge.from)
-    const toId = nodeRefId(edge.to)
-    degreeMap.set(fromId, (degreeMap.get(fromId) ?? 0) + 1)
-    degreeMap.set(toId, (degreeMap.get(toId) ?? 0) + 1)
-  }
-
-  const positionMap = new Map<string, { x: number; y: number }>()
-  const centerX = GRAPH_WIDTH / 2
-  const centerY = GRAPH_HEIGHT / 2
-  positionMap.set(selectedId, { x: centerX, y: centerY })
-
-  const surroundingNodeIds = [...nodeMap.keys()]
-    .filter((id) => id !== selectedId)
-    .sort((left, right) => {
-      const leftDegree = degreeMap.get(left) ?? 0
-      const rightDegree = degreeMap.get(right) ?? 0
-      if (leftDegree !== rightDegree) return rightDegree - leftDegree
-      return left.localeCompare(right)
-    })
-
-  const ringSize = 10
-  const baseRadius = 165
-  const ringGap = 96
-  surroundingNodeIds.forEach((id, index) => {
-    const ringIndex = Math.floor(index / ringSize)
-    const ringStart = ringIndex * ringSize
-    const ringCount = Math.min(ringSize, surroundingNodeIds.length - ringStart)
-    const slotIndex = index - ringStart
-    const radius = baseRadius + ringIndex * ringGap
-    const angle = (slotIndex / Math.max(ringCount, 1)) * Math.PI * 2 - Math.PI / 2
-
-    positionMap.set(id, {
-      x: centerX + Math.cos(angle) * radius,
-      y: centerY + Math.sin(angle) * radius,
-    })
-  })
-
-  const nodes = [...nodeMap.entries()].map(([id, node]) => {
-    const position = positionMap.get(id) ?? { x: centerX, y: centerY }
-    return {
-      ...node,
-      id,
-      x: position.x,
-      y: position.y,
-      degree: degreeMap.get(id) ?? 0,
-      isSelected: id === selectedId,
-    }
-  })
-
-  const nodeById = new Map(nodes.map((node) => [node.id, node]))
-  const groupedEdges = new Map<string, GraphExplorerEdge[]>()
-
-  for (const edge of explorerData.edges) {
-    const key = `${nodeRefId(edge.from)}->${nodeRefId(edge.to)}`
-    const group = groupedEdges.get(key)
-    if (group) {
-      group.push(edge)
-    } else {
-      groupedEdges.set(key, [edge])
-    }
-  }
-
-  const edges: GraphCanvasEdge[] = []
-  for (const [key, group] of groupedEdges.entries()) {
-    const [fromId, toId] = key.split("->")
-    const fromNode = nodeById.get(fromId)
-    const toNode = nodeById.get(toId)
-    if (!fromNode || !toNode) continue
-
-    const centerOffset = (group.length - 1) / 2
-    group.forEach((edge, index) => {
-      const curveOffset = (index - centerOffset) * 26
-      const geometry = buildEdgeGeometry(fromNode, toNode, curveOffset)
-      edges.push({
-        ...edge,
-        fromId,
-        toId,
-        path: geometry.path,
-        labelX: geometry.labelX,
-        labelY: geometry.labelY,
-      })
-    })
-  }
-
-  const nodeTypes = [...new Set(nodes.map((node) => node.nodeType))].sort()
-  return { nodes, edges, nodeTypes }
 }
 
 export function MemoryGraphSection({ status }: MemoryGraphSectionProps): React.JSX.Element {

--- a/packages/web/src/components/dashboard/memory-graph-helpers.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.ts
@@ -1,0 +1,293 @@
+import type { GraphStatusPayload } from "@/lib/memory-service/graph/status"
+
+export type GraphRolloutMode = GraphStatusPayload["rollout"]["mode"]
+
+export interface GraphNodeSelection {
+  nodeType: string
+  nodeKey: string
+  label: string
+}
+
+export interface GraphExplorerEdge {
+  id: string
+  edgeType: string
+  weight: number
+  confidence: number
+  expiresAt: string | null
+  evidenceMemoryId: string | null
+  direction: "outbound" | "inbound"
+  from: GraphNodeSelection
+  to: GraphNodeSelection
+}
+
+export interface GraphExplorerMemory {
+  memoryId: string
+  role: string
+  type: string
+  content: string
+  updatedAt: string | null
+}
+
+export interface GraphExplorerResponse {
+  node: GraphNodeSelection | null
+  nodes: GraphNodeSelection[]
+  edges: GraphExplorerEdge[]
+  memories: GraphExplorerMemory[]
+}
+
+export interface GraphCanvasNode extends GraphNodeSelection {
+  id: string
+  x: number
+  y: number
+  degree: number
+  isSelected: boolean
+}
+
+export interface GraphCanvasEdge extends GraphExplorerEdge {
+  fromId: string
+  toId: string
+  path: string
+  labelX: number
+  labelY: number
+}
+
+export interface GraphCanvasModel {
+  nodes: GraphCanvasNode[]
+  edges: GraphCanvasEdge[]
+  nodeTypes: string[]
+}
+
+export interface GraphViewport {
+  scale: number
+  x: number
+  y: number
+}
+
+export const ROLLOUT_MODES: Array<{ value: GraphRolloutMode; label: string; description: string }> = [
+  { value: "off", label: "Off", description: "Always serve baseline retrieval." },
+  { value: "shadow", label: "Shadow", description: "Run graph retrieval without applying it." },
+  { value: "canary", label: "Canary", description: "Apply graph retrieval for hybrid requests." },
+]
+
+export const GRAPH_WIDTH = 1080
+export const GRAPH_HEIGHT = 620
+export const GRAPH_ZOOM_MIN = 0.55
+export const GRAPH_ZOOM_MAX = 2.6
+export const GRAPH_ZOOM_STEP = 0.16
+
+export const DEFAULT_GRAPH_VIEWPORT: GraphViewport = {
+  scale: 1,
+  x: 0,
+  y: 0,
+}
+
+export const NODE_TYPE_STYLES: Record<string, { fill: string; stroke: string; text: string }> = {
+  repo: { fill: "rgba(56, 189, 248, 0.16)", stroke: "#38bdf8", text: "#d8f3ff" },
+  topic: { fill: "rgba(16, 185, 129, 0.16)", stroke: "#10b981", text: "#dcfce7" },
+  category: { fill: "rgba(245, 158, 11, 0.16)", stroke: "#f59e0b", text: "#fef3c7" },
+  user: { fill: "rgba(168, 85, 247, 0.16)", stroke: "#a855f7", text: "#f3e8ff" },
+  memory_type: { fill: "rgba(99, 102, 241, 0.18)", stroke: "#6366f1", text: "#e0e7ff" },
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function severityClass(severity: "info" | "warning" | "critical"): string {
+  if (severity === "critical") return "text-red-500"
+  if (severity === "warning") return "text-amber-500"
+  return "text-sky-500"
+}
+
+export function qualityStatusLabel(status: GraphStatusPayload["qualityGate"]["status"]): string {
+  if (status === "insufficient_data") return "Insufficient Data"
+  return status.toUpperCase()
+}
+
+export function qualityStatusClass(status: GraphStatusPayload["qualityGate"]["status"], blocked: boolean): string {
+  if (blocked || status === "fail") return "text-red-500"
+  if (status === "warn") return "text-amber-500"
+  if (status === "pass") return "text-emerald-500"
+  return "text-muted-foreground"
+}
+
+export function truncateText(value: string, max = 180): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max).trim()}...`
+}
+
+export function nodeRefId(node: GraphNodeSelection): string {
+  return `${node.nodeType}:${node.nodeKey}`
+}
+
+export function getNodeStyle(nodeType: string): { fill: string; stroke: string; text: string } {
+  return NODE_TYPE_STYLES[nodeType] ?? {
+    fill: "rgba(148, 163, 184, 0.14)",
+    stroke: "#94a3b8",
+    text: "#e2e8f0",
+  }
+}
+
+export function formatNodeLabel(node: GraphNodeSelection): string {
+  if (node.nodeType === "repo") {
+    const tail = node.nodeKey.split("/").pop()
+    return tail || node.label
+  }
+  return node.label || `${node.nodeType}:${node.nodeKey}`
+}
+
+export function trimMiddle(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  const slice = Math.max(4, Math.floor((maxLength - 3) / 2))
+  return `${value.slice(0, slice)}...${value.slice(-slice)}`
+}
+
+export function buildEdgeGeometry(from: GraphCanvasNode, to: GraphCanvasNode, curveOffset: number): {
+  path: string
+  labelX: number
+  labelY: number
+} {
+  if (from.id === to.id) {
+    const loopLift = 62 + Math.abs(curveOffset) * 0.4
+    const loopRadius = 34 + Math.abs(curveOffset) * 0.3
+    return {
+      path: `M ${from.x} ${from.y - 12}
+             C ${from.x + loopRadius} ${from.y - loopLift}
+               ${from.x - loopRadius} ${from.y - loopLift}
+               ${from.x} ${from.y - 12}`,
+      labelX: from.x,
+      labelY: from.y - loopLift - 8,
+    }
+  }
+
+  const mx = (from.x + to.x) / 2
+  const my = (from.y + to.y) / 2
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const length = Math.hypot(dx, dy) || 1
+  const nx = -dy / length
+  const ny = dx / length
+  const cx = mx + nx * curveOffset
+  const cy = my + ny * curveOffset
+
+  return {
+    path: `M ${from.x} ${from.y} Q ${cx} ${cy} ${to.x} ${to.y}`,
+    labelX: 0.25 * from.x + 0.5 * cx + 0.25 * to.x,
+    labelY: 0.25 * from.y + 0.5 * cy + 0.25 * to.y,
+  }
+}
+
+export function buildGraphCanvasModel(
+  selectedNode: GraphNodeSelection | null,
+  explorerData: GraphExplorerResponse | null
+): GraphCanvasModel | null {
+  if (!selectedNode || !explorerData) {
+    return null
+  }
+
+  const selectedId = nodeRefId(selectedNode)
+  const nodeMap = new Map<string, GraphNodeSelection>()
+  nodeMap.set(selectedId, selectedNode)
+
+  for (const node of explorerData.nodes) {
+    nodeMap.set(nodeRefId(node), node)
+  }
+
+  for (const edge of explorerData.edges) {
+    nodeMap.set(nodeRefId(edge.from), edge.from)
+    nodeMap.set(nodeRefId(edge.to), edge.to)
+  }
+
+  if (nodeMap.size === 0) {
+    return null
+  }
+
+  const degreeMap = new Map<string, number>()
+  for (const edge of explorerData.edges) {
+    const fromId = nodeRefId(edge.from)
+    const toId = nodeRefId(edge.to)
+    degreeMap.set(fromId, (degreeMap.get(fromId) ?? 0) + 1)
+    degreeMap.set(toId, (degreeMap.get(toId) ?? 0) + 1)
+  }
+
+  const positionMap = new Map<string, { x: number; y: number }>()
+  const centerX = GRAPH_WIDTH / 2
+  const centerY = GRAPH_HEIGHT / 2
+  positionMap.set(selectedId, { x: centerX, y: centerY })
+
+  const surroundingNodeIds = [...nodeMap.keys()]
+    .filter((id) => id !== selectedId)
+    .sort((left, right) => {
+      const leftDegree = degreeMap.get(left) ?? 0
+      const rightDegree = degreeMap.get(right) ?? 0
+      if (leftDegree !== rightDegree) return rightDegree - leftDegree
+      return left.localeCompare(right)
+    })
+
+  const ringSize = 10
+  const baseRadius = 165
+  const ringGap = 96
+  surroundingNodeIds.forEach((id, index) => {
+    const ringIndex = Math.floor(index / ringSize)
+    const ringStart = ringIndex * ringSize
+    const ringCount = Math.min(ringSize, surroundingNodeIds.length - ringStart)
+    const slotIndex = index - ringStart
+    const radius = baseRadius + ringIndex * ringGap
+    const angle = (slotIndex / Math.max(ringCount, 1)) * Math.PI * 2 - Math.PI / 2
+
+    positionMap.set(id, {
+      x: centerX + Math.cos(angle) * radius,
+      y: centerY + Math.sin(angle) * radius,
+    })
+  })
+
+  const nodes = [...nodeMap.entries()].map(([id, node]) => {
+    const position = positionMap.get(id) ?? { x: centerX, y: centerY }
+    return {
+      ...node,
+      id,
+      x: position.x,
+      y: position.y,
+      degree: degreeMap.get(id) ?? 0,
+      isSelected: id === selectedId,
+    }
+  })
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const groupedEdges = new Map<string, GraphExplorerEdge[]>()
+
+  for (const edge of explorerData.edges) {
+    const key = `${nodeRefId(edge.from)}->${nodeRefId(edge.to)}`
+    const group = groupedEdges.get(key)
+    if (group) {
+      group.push(edge)
+    } else {
+      groupedEdges.set(key, [edge])
+    }
+  }
+
+  const edges: GraphCanvasEdge[] = []
+  for (const [key, group] of groupedEdges.entries()) {
+    const [fromId, toId] = key.split("->")
+    const fromNode = nodeById.get(fromId)
+    const toNode = nodeById.get(toId)
+    if (!fromNode || !toNode) continue
+
+    const centerOffset = (group.length - 1) / 2
+    group.forEach((edge, index) => {
+      const curveOffset = (index - centerOffset) * 26
+      const geometry = buildEdgeGeometry(fromNode, toNode, curveOffset)
+      edges.push({
+        ...edge,
+        fromId,
+        toId,
+        path: geometry.path,
+        labelX: geometry.labelX,
+        labelY: geometry.labelY,
+      })
+    })
+  }
+
+  const nodeTypes = [...new Set(nodes.map((node) => node.nodeType))].sort()
+  return { nodes, edges, nodeTypes }
+}


### PR DESCRIPTION
## Summary
- **`packages/core/src/client.ts`** (1294 → 799 lines, -495)
  - Extracted `client-schemas.ts` (159 lines) — all Zod validation schemas
  - Extracted `client-helpers.ts` (359 lines) — utility/normalizer/parser functions
  - Extracted `client-error.ts` (34 lines) — MemoriesClientError class (avoids circular deps)
  - Kept MemoriesClient class in client.ts with imports from new modules

- **`packages/web/src/components/dashboard/MemoryGraphSection.tsx`** (1649 → 1380 lines, -269)
  - Extracted `memory-graph-helpers.ts` (293 lines) — types, interfaces, constants, utility functions, canvas model builder
  - Kept main React component and JSX-returning metricCard in original file

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

🤖 Generated by refactor-loop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a code-organization refactor with logic moved but not substantially changed; risk is limited to import/export or subtle wiring regressions in the SDK client and graph UI.
> 
> **Overview**
> Refactors the core SDK by splitting the large `client.ts` into focused modules: Zod schemas move to `client-schemas.ts`, utility/parsing/normalization logic to `client-helpers.ts`, and `MemoriesClientError` to `client-error.ts` (re-exported from `client.ts`).
> 
> Refactors the dashboard graph UI by extracting graph types/constants and canvas-model/utility functions from `MemoryGraphSection.tsx` into `memory-graph-helpers.ts`, leaving the React component behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db38f1c756ae7d9ab26adf64b05ee5183383629c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->