### PR TITLE
fix(starter): forward context graph options and bump core sdk

### DIFF
--- a/examples/nextjs-starter/app/api/memories/context/route.ts
+++ b/examples/nextjs-starter/app/api/memories/context/route.ts
@@ -74,16 +74,20 @@ export async function GET(request: Request) {
       mode,
       limit,
       projectId: scope.projectId,
+      strategy,
+      graphDepth,
+      graphLimit,
     })
 
     return NextResponse.json({
       ok: true,
       rules: context.rules,
       memories: context.memories,
-      trace: {
+      trace: context.trace ?? {
         requestedStrategy: strategy,
-        requestedGraphDepth: graphDepth,
-        requestedGraphLimit: graphLimit,
+        strategy,
+        graphDepth,
+        graphLimit,
       },
     })
   } catch (error) {

--- a/examples/nextjs-starter/package-lock.json
+++ b/examples/nextjs-starter/package-lock.json
@@ -8,7 +8,7 @@
       "name": "memories-nextjs-starter",
       "version": "0.0.1",
       "dependencies": {
-        "@memories.sh/core": "^0.3.0",
+        "@memories.sh/core": "^0.3.2",
         "next": "16.1.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -1028,9 +1028,9 @@
       }
     },
     "node_modules/@memories.sh/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@memories.sh/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-b9P88K8JCwJHyItbvd8OST2FjCxagHH+p7rYyRYXEebOssQ6ZV4LzNdYp3v+H0wXw/6uT5tvtT4UMAa08T5nkw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@memories.sh/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-X452ERYCdaXEd7WTzu/n/1w2z1mK1n+oflkJYjl7SC4fT0QC5LL0bdoVFdf7uAP+IkgYeRyxsP3ocxPj8JeIQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.3.6"

--- a/examples/nextjs-starter/package.json
+++ b/examples/nextjs-starter/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@memories.sh/core": "^0.3.0",
+    "@memories.sh/core": "^0.3.2",
     "next": "16.1.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
## Summary
- Forward `strategy`, `graphDepth`, and `graphLimit` from the starter context API route into `client.context.get(...)`.
- Return server-provided `context.trace` when available, with a fallback trace object for older/non-trace responses.
- Bump starter dependency lock to `@memories.sh/core@^0.3.2` so these context options are typed and available.

## Verification
- `cd examples/nextjs-starter && npm run -s typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to an example API route plus a minor SDK bump; main risk is minor behavior/response-shape differences if callers rely on the prior `trace` contents.
> 
> **Overview**
> The starter’s `GET /api/memories/context` route now forwards `strategy`, `graphDepth`, and `graphLimit` into `client.context.get(...)`, enabling graph-based context retrieval options to take effect.
> 
> The response `trace` field now returns `context.trace` when the SDK provides it, falling back to a local trace object for older/non-trace responses.
> 
> Dependencies are updated to `@memories.sh/core@^0.3.2` (and lockfile updated accordingly) to pick up the updated typings/support for these options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 365c269c2daf87e7e97bd6871edf87afa48f6948. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->