### PR TITLE
fix(web): stop checkout customer creation on lookup db errors

### DIFF
--- a/packages/web/src/app/api/stripe/checkout/route.ts
+++ b/packages/web/src/app/api/stripe/checkout/route.ts
@@ -16,11 +16,16 @@ async function getOrCreateUserCustomerId(
   userId: string,
   email: string
 ): Promise<string | null> {
-  const { data: profile } = await admin
+  const { data: profile, error: profileError } = await admin
     .from("users")
     .select("stripe_customer_id, email")
     .eq("id", userId)
     .single()
+
+  if (profileError) {
+    console.error("Failed to load user billing customer:", profileError)
+    return null
+  }
 
   let customerId = profile?.stripe_customer_id
   if (customerId) return customerId
@@ -60,11 +65,16 @@ async function getOrCreateOrganizationCustomerId(
   admin: ReturnType<typeof createAdminClient>,
   orgId: string
 ): Promise<string | null> {
-  const { data: org } = await admin
+  const { data: org, error: orgError } = await admin
     .from("organizations")
     .select("stripe_customer_id, name")
     .eq("id", orgId)
     .single()
+
+  if (orgError) {
+    console.error("Failed to load organization billing customer:", orgError)
+    return null
+  }
 
   let customerId = org?.stripe_customer_id
   if (customerId) return customerId


### PR DESCRIPTION
## Summary
- Prevent checkout flow from creating new Stripe customers when customer lookup queries fail.
- `getOrCreateUserCustomerId` and `getOrCreateOrganizationCustomerId` now return `null` on Supabase read errors instead of continuing to customer creation.
- This avoids accidental duplicate Stripe customers during transient DB failures.
- Added regression tests for org/user lookup failure paths and assert no `customers.create` call is made.

## Verification
- `pnpm --filter @memories.sh/web exec vitest run src/app/api/stripe/checkout/__tests__/route.test.ts`
- `pnpm --filter @memories.sh/web test`
- `pnpm --filter @memories.sh/web typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error handling in the checkout flow plus tests; main risk is increased 500s during transient DB errors rather than creating a Stripe customer.
> 
> **Overview**
> Prevents accidental duplicate Stripe customers by **bailing out early** when Supabase lookups for existing `stripe_customer_id` fail during `/api/stripe/checkout`.
> 
> `getOrCreateUserCustomerId` and `getOrCreateOrganizationCustomerId` now treat read errors as fatal (log + return `null`), causing the route to return `500` with `BILLING_CUSTOMER_CREATE_FAILED` instead of continuing to `customers.create`. Adds tests covering org/user lookup failures and asserting no Stripe customer creation occurs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4407eb12d186b494456356d498c038849c101ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->