### PR TITLE
fix(web): abort account deletion on profile/user delete db errors

### DIFF
--- a/packages/web/src/app/api/account/__tests__/route.test.ts
+++ b/packages/web/src/app/api/account/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockGetUser,
+  mockSignOut,
+  mockFrom,
+  mockProfileSingle,
+  mockDeleteEq,
+  mockCheckRateLimit,
+  mockDeleteUser,
+  mockSubscriptionsList,
+  mockSubscriptionsCancel,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockSignOut: vi.fn(),
+  mockFrom: vi.fn(),
+  mockProfileSingle: vi.fn(),
+  mockDeleteEq: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockDeleteUser: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockSubscriptionsCancel: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: mockGetUser,
+      signOut: mockSignOut,
+    },
+    from: mockFrom,
+  })),
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      admin: {
+        deleteUser: mockDeleteUser,
+      },
+    },
+  })),
+}))
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn(() => ({
+    subscriptions: {
+      list: mockSubscriptionsList,
+      cancel: mockSubscriptionsCancel,
+    },
+  })),
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  strictRateLimit: { limit: vi.fn() },
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+vi.mock("@/lib/env", () => ({
+  getTursoOrgSlug: vi.fn(() => "org"),
+  getTursoApiToken: vi.fn(() => "token"),
+  getSupabaseUrl: vi.fn(() => "https://supabase.test"),
+  getSupabaseServiceRoleKey: vi.fn(() => "service-role"),
+}))
+
+import { DELETE } from "../route"
+
+describe("DELETE /api/account", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue(null)
+    mockSignOut.mockResolvedValue(undefined)
+    mockDeleteUser.mockResolvedValue({ error: null })
+    mockSubscriptionsList.mockResolvedValue({ data: [] })
+    mockSubscriptionsCancel.mockResolvedValue({})
+    mockProfileSingle.mockResolvedValue({
+      data: { stripe_customer_id: null, turso_db_name: null },
+      error: null,
+    })
+    mockDeleteEq.mockResolvedValue({ error: null })
+    mockFrom.mockImplementation((table: string) => {
+      if (table !== "users") return {}
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: mockProfileSingle,
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          eq: mockDeleteEq,
+        }),
+      }
+    })
+  })
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const response = await DELETE()
+    expect(response.status).toBe(401)
+  })
+
+  it("returns 500 when loading user profile fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    mockProfileSingle.mockResolvedValue({
+      data: null,
+      error: { message: "db read failed" },
+    })
+
+    const response = await DELETE()
+    expect(response.status).toBe(500)
+    expect(mockDeleteUser).not.toHaveBeenCalled()
+  })
+
+  it("returns 500 when deleting user row fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    mockDeleteEq.mockResolvedValue({ error: { message: "delete failed" } })
+
+    const response = await DELETE()
+    expect(response.status).toBe(500)
+    expect(mockDeleteUser).not.toHaveBeenCalled()
+  })
+
+  it("returns success when account deletion completes", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    const response = await DELETE()
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(mockDeleteUser).toHaveBeenCalledWith("user-1")
+  })
+})

--- a/packages/web/src/app/api/account/route.ts
+++ b/packages/web/src/app/api/account/route.ts
@@ -18,11 +18,16 @@ export async function DELETE(): Promise<Response> {
 
   try {
     // Get user profile
-    const { data: profile } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from("users")
       .select("stripe_customer_id, turso_db_name")
       .eq("id", user.id)
       .single()
+
+    if (profileError) {
+      console.error("Failed to load user profile for account deletion:", profileError)
+      return NextResponse.json({ error: "Failed to delete account" }, { status: 500 })
+    }
 
     // Cancel Stripe subscription if exists
     if (profile?.stripe_customer_id) {
@@ -68,6 +73,7 @@ export async function DELETE(): Promise<Response> {
 
     if (deleteError) {
       console.error("Failed to delete user record:", deleteError)
+      return NextResponse.json({ error: "Failed to delete account" }, { status: 500 })
     }
 
     // Delete auth user (requires admin client)


### PR DESCRIPTION
## Summary
- Harden `DELETE /api/account` to fail fast on critical DB read/write errors.
- Return `500` when loading the user profile fails, instead of continuing partial deletion flow.
- Return `500` when deleting the user row from `users` fails, instead of continuing to auth-user deletion and returning success.
- Add route tests covering unauthenticated, profile-read failure, user-row-delete failure, and success paths.

## Verification
- `pnpm --filter @memories.sh/web exec vitest run src/app/api/account/__tests__/route.test.ts`
- `pnpm --filter @memories.sh/web test`
- `pnpm --filter @memories.sh/web typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes account-deletion error handling to fail fast on DB read/write failures, which can alter user-facing outcomes and reduce (or increase) partial-deletion scenarios. Added tests mitigate regression risk but the flow touches billing/resource cleanup and auth deletion.
> 
> **Overview**
> `DELETE /api/account` now **aborts early with a 500** if the user profile cannot be loaded from `users`, instead of continuing the deletion flow.
> 
> It also **returns a 500** when deleting the `users` table row fails (rather than continuing to auth-user deletion and reporting success). New Vitest coverage was added for unauthenticated, profile-read failure, user-row-delete failure, and successful deletion paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e9c4be52461dd111684d5c89da105d6f6a252e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->