### PR TITLE
fix(web): handle org slug uniqueness db lookup failures

### DIFF
--- a/packages/web/src/app/api/orgs/route.ts
+++ b/packages/web/src/app/api/orgs/route.ts
@@ -72,11 +72,20 @@ export async function POST(request: Request): Promise<Response> {
 
   // Check for slug uniqueness
   while (true) {
-    const { data: existing } = await admin
+    const { data: existing, error: existingError } = await admin
       .from("organizations")
       .select("id")
       .eq("slug", slug)
-      .single()
+      .maybeSingle()
+
+    if (existingError) {
+      console.error("Failed to verify organization slug uniqueness:", {
+        error: existingError,
+        slug,
+        userId: auth.userId,
+      })
+      return NextResponse.json({ error: "Failed to create organization" }, { status: 500 })
+    }
 
     if (!existing) break
     slug = `${baseSlug}-${counter++}`


### PR DESCRIPTION
## Summary
- switch org slug uniqueness lookup from `.single()` to `.maybeSingle()`
- return HTTP 500 when slug lookup fails instead of treating query errors as available slugs
- add regression test covering slug-check database failure

## Verification
- pnpm --filter @memories.sh/web exec vitest run src/app/api/orgs/__tests__/route.test.ts
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to org creation error handling plus tests; main risk is altered behavior on transient DB errors (now hard-fails with 500) but scope is narrow.
> 
> **Overview**
> Fixes org creation slug uniqueness validation to **distinguish “not found” from query errors** by switching the Supabase lookup from `.single()` to `.maybeSingle()`.
> 
> If the slug check returns an error, the API now logs context and returns **HTTP 500** (`{"error":"Failed to create organization"}`) rather than proceeding to create the org; tests were updated accordingly and a new regression test covers the slug-check DB failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a5a593d043647ecf5e39ecc7562180eb868de6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->