### PR TITLE
fix(web): return 500 when org membership lookup fails

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.ts
@@ -76,12 +76,21 @@ export async function PATCH(
   if (rateLimited) return rateLimited
 
   // Check user is admin or owner
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", user.id)
     .single()
+
+  if (membershipError) {
+    console.error("Failed to verify organization membership for update:", {
+      error: membershipError,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to update organization" }, { status: 500 })
+  }
 
   if (!membership || !["owner", "admin"].includes(membership.role)) {
     return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })


### PR DESCRIPTION
## Summary
- return HTTP 500 when `org_members` lookup fails during `PATCH /api/orgs/[orgId]`
- preserve the existing 403 behavior for valid non-admin/non-owner membership checks
- add regression test for the membership lookup error path

Closes #53

## Verification
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to an API error path plus a test; main risk is altering an edge-case response code/message for callers when the membership query fails.
> 
> **Overview**
> Updates `PATCH /api/orgs/[orgId]` to **handle Supabase `org_members` lookup failures explicitly**: if the membership query returns an error, it now logs context and returns `500 { error: "Failed to update organization" }` rather than continuing to the `403` permission path.
> 
> Adds a Vitest regression case in `route.test.ts` covering the membership-query error scenario to ensure the new 500 behavior is preserved, while keeping existing `403` behavior for valid non-owner/admin memberships.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ea99b7805df2b6a86c961004fb35edd156f2c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->