### PR TITLE
fix(web): return 500 on org members membership lookup errors

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -104,12 +104,21 @@ export async function GET(
   if (rateLimited) return rateLimited
 
   // Check user is member
-  const { data: membership } = await admin
+  const { data: membership, error: membershipError } = await admin
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", user.id)
     .single()
+
+  if (membershipError) {
+    console.error("Failed to verify org membership before listing members:", {
+      error: membershipError,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to load organization members" }, { status: 500 })
+  }
 
   if (!membership) {
     return NextResponse.json({ error: "Not a member of this organization" }, { status: 403 })


### PR DESCRIPTION
## Summary
- handle `org_members` membership lookup failures in `GET /api/orgs/[orgId]/members`
- return HTTP 500 for lookup failures instead of falling through to `403`
- add regression test covering membership query errors

Closes #57

## Verification
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change to one endpoint plus a test; behavior only differs when the membership lookup query returns an error.
> 
> **Overview**
> Fixes `GET /api/orgs/[orgId]/members` to explicitly handle errors from the initial `org_members` membership lookup: it now logs the failure and returns a `500` with a generic "Failed to load organization members" error instead of falling through to a `403`.
> 
> Adds a regression test that simulates a database error during the membership lookup and asserts the new `500` response behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b78cec1d40919a460f677147f2583cc182ad06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->