### PR TITLE
fix(web): handle patch member target lookup failures

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
@@ -352,4 +352,46 @@ describe("/api/orgs/[orgId]/members PATCH", () => {
       error: "Failed to update member role",
     })
   })
+
+  it("returns 500 when target membership lookup fails", async () => {
+    let membershipLookupCount = 0
+
+    mockSupabaseFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockImplementation(async () => {
+                  membershipLookupCount += 1
+                  if (membershipLookupCount === 1) {
+                    return { data: { role: "owner" }, error: null }
+                  }
+                  return { data: null, error: { message: "DB read failed" } }
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
+      }
+    })
+
+    const response = await PATCH(
+      new Request("https://example.com/api/orgs/org-1/members", {
+        method: "PATCH",
+        body: JSON.stringify({ userId: "user-2", role: "member" }),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to update member role",
+    })
+  })
 })

--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -408,12 +408,23 @@ export async function PATCH(
   }
 
   // Can't change owner's role
-  const { data: targetMembership } = await supabase
+  const { data: targetMembership, error: targetMembershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", userId)
     .single()
+
+  if (targetMembershipError) {
+    console.error("Failed to verify target membership before updating org member role:", {
+      error: targetMembershipError,
+      orgId,
+      actorUserId: user.id,
+      targetUserId: userId,
+      targetRole: role,
+    })
+    return NextResponse.json({ error: "Failed to update member role" }, { status: 500 })
+  }
 
   if (!targetMembership) {
     return NextResponse.json({ error: "User is not a member" }, { status: 404 })


### PR DESCRIPTION
## Summary
- handle target membership lookup errors in `PATCH /api/orgs/[orgId]/members`
- return HTTP 500 when the target role query fails instead of falling through to 404
- add regression test for the PATCH target-lookup error path

Closes #63

## Verification
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change to one API endpoint plus a regression test; no schema changes or auth logic modifications beyond returning the correct status code on DB read failures.
> 
> **Overview**
> Fixes `PATCH /api/orgs/[orgId]/members` to **treat target membership lookup errors as a hard failure**: the handler now checks the Supabase error from the target `org_members` query, logs diagnostic context, and returns `500 { error: "Failed to update member role" }` instead of falling through to a misleading `404`.
> 
> Adds a regression test in `route.test.ts` that simulates a successful actor role lookup followed by a failing target membership lookup, asserting the new `500` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 306bdd8f0c762fd5ca2e6a46612301d7b6560eda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->