### PR TITLE
fix(web): handle delete member target lookup failures

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -284,12 +284,22 @@ export async function DELETE(
   }
 
   // Get target user's membership
-  const { data: targetMembership } = await supabase
+  const { data: targetMembership, error: targetMembershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", targetUserId)
     .single()
+
+  if (targetMembershipError) {
+    console.error("Failed to verify target membership before removing org member:", {
+      error: targetMembershipError,
+      orgId,
+      actorUserId: user.id,
+      targetUserId,
+    })
+    return NextResponse.json({ error: "Failed to remove member" }, { status: 500 })
+  }
 
   if (!targetMembership) {
     return NextResponse.json({ error: "User is not a member" }, { status: 404 })


### PR DESCRIPTION
## Summary
- handle target membership lookup errors in `DELETE /api/orgs/[orgId]/members`
- return HTTP 500 when the target lookup query fails instead of falling through to 404
- add regression test for the DELETE target-lookup error path

Closes #65

## Verification
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change in a single endpoint plus a test; main risk is altered HTTP status semantics for a rare DB-failure path.
> 
> **Overview**
> Fixes `DELETE /api/orgs/[orgId]/members` to **treat target membership lookup errors as server failures**: it now checks `targetMembershipError`, logs diagnostic context, and returns HTTP 500 instead of falling through to the 404 “User is not a member” response.
> 
> Adds a regression test covering the case where the actor membership lookup succeeds but the subsequent target membership lookup fails, asserting the endpoint returns `500` with `Failed to remove member`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73e2cb3f304a728084c57dc320f09af67c0791ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->