### PR TITLE
fix(web): return 500 when invites membership lookup fails

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockGetUser,
+  mockFrom,
+  mockCheckRateLimit,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  })),
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiRateLimit: { limit: vi.fn().mockResolvedValue({ success: true }) },
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+import { GET } from "./route"
+
+describe("/api/orgs/[orgId]/invites GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue(null)
+  })
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const response = await GET(
+      new Request("https://example.com/api/orgs/org-1/invites"),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it("returns 500 when membership lookup fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { message: "DB read failed" },
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), is: vi.fn(), gt: vi.fn(), order: vi.fn() })),
+      }
+    })
+
+    const response = await GET(
+      new Request("https://example.com/api/orgs/org-1/invites"),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to load invites",
+    })
+  })
+})

--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -24,12 +24,21 @@ export async function GET(
   if (rateLimited) return rateLimited
 
   // Check user is admin or owner
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", user.id)
     .single()
+
+  if (membershipError) {
+    console.error("Failed to verify invite list membership:", {
+      error: membershipError,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to load invites" }, { status: 500 })
+  }
 
   if (!membership || !["owner", "admin"].includes(membership.role)) {
     return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })


### PR DESCRIPTION
## Summary
- handle membership lookup query errors in `GET /api/orgs/[orgId]/invites`
- return HTTP 500 when membership verification fails instead of falling through to 403
- add route tests for unauthenticated and membership-error scenarios

Closes #67

## Verification
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change to a single GET route plus targeted tests; primary risk is altering an edge-case HTTP status code returned to clients.
> 
> **Overview**
> Fixes `GET /api/orgs/[orgId]/invites` to **treat membership query failures as server errors**: it now checks `membershipError`, logs diagnostic context, and returns a `500` with `Failed to load invites` instead of falling through to a `403`.
> 
> Adds `vitest` coverage for the route, including unauthenticated (`401`) and membership-lookup error (`500`) scenarios via mocked Supabase and rate-limit helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d7f05b95846fd53dbdc9dc7fe534df51bc8de9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->