### PR TITLE
fix(web): return 500 when invite create membership lookup fails

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -83,12 +83,21 @@ export async function POST(
   if (rateLimited) return rateLimited
 
   // Check user is admin or owner
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", user.id)
     .single()
+
+  if (membershipError) {
+    console.error("Failed to verify invite create membership:", {
+      error: membershipError,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to create invite" }, { status: 500 })
+  }
 
   if (!membership || !["owner", "admin"].includes(membership.role)) {
     return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })


### PR DESCRIPTION
## Summary
- handle membership lookup query errors in `POST /api/orgs/[orgId]/invites`
- return HTTP 500 when membership verification fails instead of falling through to 403
- extend invites route tests to cover POST membership-error behavior

Closes #69

## Verification
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change to one API route plus test coverage; no auth logic or data writes are altered beyond the failure path.
> 
> **Overview**
> Invite creation (`POST /api/orgs/[orgId]/invites`) now explicitly handles Supabase `org_members` lookup errors, logging details and returning **HTTP 500** (`Failed to create invite`) rather than incorrectly responding with *403 insufficient permissions*.
> 
> Tests for `invites/route` are extended to include a `POST` case that simulates a membership query failure and asserts the new 500 response behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59c4655e225cf3434054109e4d9bb0096d6bb735. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->