### PR TITLE
fix: handle existing-user lookup failures in org invite POST

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
@@ -123,6 +123,56 @@ describe("/api/orgs/[orgId]/invites POST", () => {
       error: "Failed to create invite",
     })
   })
+
+  it("returns 500 when existing-user lookup fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { role: "owner" },
+                  error: null,
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "users") {
+        return {
+          select: vi.fn(() => ({
+            ilike: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "DB read failed" },
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
+      }
+    })
+
+    const response = await POST(
+      new Request("https://example.com/api/orgs/org-1/invites", {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", role: "member" }),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to create invite",
+    })
+  })
 })
 
 describe("/api/orgs/[orgId]/invites DELETE", () => {

--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -113,10 +113,20 @@ export async function POST(
   }
 
   // Check if any account with this email is already a member.
-  const { data: existingUsers } = await supabase
+  const { data: existingUsers, error: existingUsersError } = await supabase
     .from("users")
     .select("id")
     .ilike("email", email.toLowerCase())
+
+  if (existingUsersError) {
+    console.error("Failed to look up existing invite users:", {
+      error: existingUsersError,
+      orgId,
+      email: email.toLowerCase(),
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to create invite" }, { status: 500 })
+  }
 
   if (existingUsers && existingUsers.length > 0) {
     const existingUserIds = existingUsers.map((u) => u.id)


### PR DESCRIPTION
## Summary
- handle Supabase errors from the POST invite existing-user email lookup
- return a stable 500 response (`Failed to create invite`) when that lookup fails
- add a route test that covers this failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change in the invite flow with an added test; minimal behavioral impact beyond making failures deterministic.
> 
> **Overview**
> Invite creation (`POST /api/orgs/[orgId]/invites`) now checks and handles Supabase errors from the `users` email lookup, logging context and returning a stable `500 { error: "Failed to create invite" }` instead of proceeding with a null/errored result.
> 
> Adds a route test that simulates a `users.ilike(email)` DB failure and asserts the same 500 response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8820754a8506f14c51e32fca1102baefedc25198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->