### PR TITLE
fix: handle pending-invite lookup failures in invite POST

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
@@ -173,6 +173,75 @@ describe("/api/orgs/[orgId]/invites POST", () => {
       error: "Failed to create invite",
     })
   })
+
+  it("returns 500 when pending-invite lookup fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { role: "owner" },
+                  error: null,
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "users") {
+        return {
+          select: vi.fn(() => ({
+            ilike: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === "org_invites") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockReturnValue({
+                  gt: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: null,
+                      error: { message: "DB read failed" },
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
+      }
+    })
+
+    const response = await POST(
+      new Request("https://example.com/api/orgs/org-1/invites", {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", role: "member" }),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to create invite",
+    })
+  })
 })
 
 describe("/api/orgs/[orgId]/invites DELETE", () => {


### PR DESCRIPTION
## Summary
- handle pending-invite lookup errors in POST `/api/orgs/[orgId]/invites`
- switch the lookup to `maybeSingle()` for zero-or-one semantics
- return stable 500 (`Failed to create invite`) when lookup fails
- add route test coverage for this failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to invite creation error handling plus an added test; no auth/permission logic or data writes were altered beyond pre-check behavior.
> 
> **Overview**
> Improves `POST /api/orgs/[orgId]/invites` error handling by switching the pending-invite lookup from `single()` to `maybeSingle()` and explicitly handling lookup failures.
> 
> On lookup error, the route now logs context and returns a consistent `500` with `Failed to create invite` instead of leaking DB errors/throwing. Adds a route test covering the pending-invite lookup failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb7bfdab98c502fab71c9a956a31452e5abf2338. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->