### PR TITLE
fix: use stable 500 response for invite existing-member lookup errors

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -139,7 +139,14 @@ export async function POST(
       .maybeSingle()
 
     if (existingMemberError) {
-      return NextResponse.json({ error: existingMemberError.message }, { status: 500 })
+      console.error("Failed to look up existing invite member:", {
+        error: existingMemberError,
+        orgId,
+        email: email.toLowerCase(),
+        userId: user.id,
+        existingUserIds,
+      })
+      return NextResponse.json({ error: "Failed to create invite" }, { status: 500 })
     }
 
     if (existingMember) {


### PR DESCRIPTION
## Summary
- stop returning raw DB error text from existing-member lookup in POST `/api/orgs/[orgId]/invites`
- log structured server-side context for diagnostics
- return stable 500 (`Failed to create invite`) for this failure path
- add test coverage for existing-member lookup failure

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to an error path and logging in the invite creation API; primary risk is reduced client error detail and potential log sensitivity.
> 
> **Overview**
> Standardizes the `POST /api/orgs/[orgId]/invites` error response when the *existing-member* lookup fails by no longer returning the raw DB error message.
> 
> Adds structured server-side `console.error` logging (including `orgId`, requester `userId`, normalized `email`, and `existingUserIds`) and returns a stable 500 `{ error: "Failed to create invite" }`. Updates tests to cover this failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79e72d49b6a8f3581621da81434d3825f3806092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->