### PR TITLE
fix: stabilize members users-lookup error response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -166,7 +166,13 @@ export async function GET(
       .in("id", userIds)
 
     if (usersError) {
-      return NextResponse.json({ error: usersError.message }, { status: 500 })
+      console.error("Failed to load member user profiles:", {
+        error: usersError,
+        orgId,
+        actorUserId: user.id,
+        userIds,
+      })
+      return NextResponse.json({ error: "Failed to load organization members" }, { status: 500 })
     }
 
     usersById = new Map((users as UserRow[] | null | undefined)?.map((row) => [row.id, row]) ?? [])


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when `GET /api/orgs/[orgId]/members` fails to load `users`
- add structured server-side logging context for that failure path
- return stable 500 response (`Failed to load organization members`)
- add route test coverage for users lookup failure

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error handling and logging for a single endpoint plus added test coverage; no behavioral changes on success paths.
> 
> **Overview**
> Stabilizes the `GET /api/orgs/[orgId]/members` failure path when the `users` profile batch lookup fails by **no longer returning the raw DB error message**.
> 
> The route now emits structured `console.error` context (`orgId`, `actorUserId`, `userIds`, error) and returns a consistent 500 payload (`Failed to load organization members`). Adds a Vitest case covering the `users` lookup failure scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 607f67662179b7f8b811086bea9e5c2c0a7551e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->