### PR TITLE
fix: stabilize members list query failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
@@ -161,6 +161,46 @@ describe("/api/orgs/[orgId]/members", () => {
     })
   })
 
+  it("returns 500 when members list lookup fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === "role") {
+              const single = vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null })
+              const eqUser = vi.fn().mockReturnValue({ single })
+              const eqOrg = vi.fn().mockReturnValue({ eq: eqUser })
+              return { eq: eqOrg }
+            }
+
+            const order = vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "DB read failed" },
+            })
+            const eqOrg = vi.fn().mockReturnValue({ order })
+            return { eq: eqOrg }
+          }),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), in: vi.fn(), single: vi.fn(), order: vi.fn() })),
+      }
+    })
+
+    const response = await GET(
+      new Request("https://example.com/api/orgs/org-1/members"),
+      { params: Promise.resolve({ orgId: "org-1" }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to load organization members",
+    })
+  })
+
   it("returns member list including owner", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
 

--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -145,7 +145,12 @@ export async function GET(
   }
 
   if (membersError) {
-    return NextResponse.json({ error: membersError.message }, { status: 500 })
+    console.error("Failed to load org member rows:", {
+      error: membersError,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to load organization members" }, { status: 500 })
   }
 
   const memberRows = members ?? []


### PR DESCRIPTION
## Summary
- stop returning raw DB message when the members list query fails in `GET /api/orgs/[orgId]/members`
- log structured diagnostics server-side for that failure path
- return stable 500 response (`Failed to load organization members`)
- add route test coverage for this failure mode

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to an error-handling path plus test coverage; main risk is masking useful error details for clients while relying on server logs for diagnostics.
> 
> **Overview**
> Stabilizes `GET /api/orgs/[orgId]/members` error handling by **no longer returning raw DB error messages** when the org member rows query fails.
> 
> Instead, the route logs structured diagnostics server-side and returns a consistent `500` payload: `Failed to load organization members`. Adds a Vitest case covering the members-list lookup failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d79e5c2dd31885f93333b7c91210bfb36f99bf7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->