### PR TITLE
fix: stabilize members delete mutation error response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -345,7 +345,13 @@ export async function DELETE(
     .eq("user_id", targetUserId)
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to delete org member row:", {
+      error,
+      orgId,
+      actorUserId: user.id,
+      targetUserId,
+    })
+    return NextResponse.json({ error: "Failed to remove member" }, { status: 500 })
   }
 
   await logOrgAuditEvent({


### PR DESCRIPTION
## Summary
- stop returning raw DB message when member row deletion fails in `DELETE /api/orgs/[orgId]/members`
- log structured diagnostic context for deletion failures
- return stable 500 response (`Failed to remove member`)
- add route test coverage for deletion failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #83

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to the org-members DELETE error path plus a new test; no auth/permission logic changes, but it could mask specific DB error details from clients.
> 
> **Overview**
> Stabilizes the `DELETE /api/orgs/[orgId]/members` failure response by **stopping exposure of raw Supabase delete errors** and always returning a generic `500` with `Failed to remove member`.
> 
> Adds **structured server-side logging** (org, actor, target, and error) for delete failures, and expands route tests to cover the org-member row deletion failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bace5fa190d48fc8b02893510177d6bcba5a3419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->