### PR TITLE
fix: stabilize members PATCH update failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -473,7 +473,14 @@ export async function PATCH(
     .eq("user_id", userId)
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to update org member role row:", {
+      error,
+      orgId,
+      actorUserId: user.id,
+      targetUserId: userId,
+      targetRole: role,
+    })
+    return NextResponse.json({ error: "Failed to update member role" }, { status: 500 })
   }
 
   await logOrgAuditEvent({


### PR DESCRIPTION
## Summary
- stop returning raw DB error message when role update mutation fails in `PATCH /api/orgs/[orgId]/members`
- log structured context for update failures
- return stable 500 response (`Failed to update member role`)
- add route test coverage for role update failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/members/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error handling and logging for a single endpoint, plus a new test; no auth/permission logic or data writes behavior changed beyond the returned error message.
> 
> **Overview**
> `PATCH /api/orgs/[orgId]/members` no longer returns raw Supabase DB error messages when an `org_members` role update fails; it now logs a structured error payload and responds with a stable 500 `{ error: "Failed to update member role" }`.
> 
> Adds test coverage for the role-update write-failure path to ensure the stable error response is returned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86cbadfaf6c83ae644257450124ff18ba7371209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->