### PR TITLE
fix: stabilize invites GET query failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -60,7 +60,12 @@ export async function GET(
     .order("created_at", { ascending: false })
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to load pending invites:", {
+      error,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to load invites" }, { status: 500 })
   }
 
   return NextResponse.json({ invites })


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when invites list query fails in `GET /api/orgs/[orgId]/invites`
- log structured diagnostics for this query failure path
- return stable 500 response (`Failed to load invites`)
- add route test coverage for invites query failure

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #87

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to an API error path plus added test coverage; main risk is altering client-observed error messages for this endpoint.
> 
> **Overview**
> Stabilizes `GET /api/orgs/[orgId]/invites` error handling by **stopping leakage of the underlying DB/provider error message** and instead returning a consistent `500` payload (`{"error":"Failed to load invites"}`) when the pending-invites query fails.
> 
> Adds structured `console.error` diagnostics for this failure path (including `orgId` and `userId`) and introduces a new route test to ensure the invites-query failure returns the stable 500 response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d8134d61277ed74e4a3d8c8d6f483197cc30377. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->