### PR TITLE
fix: stabilize invites POST insert failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -197,7 +197,14 @@ export async function POST(
     .single()
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to create org invite row:", {
+      error,
+      orgId,
+      userId: user.id,
+      email: email.toLowerCase(),
+      role,
+    })
+    return NextResponse.json({ error: "Failed to create invite" }, { status: 500 })
   }
 
   // Get org name and inviter name for email


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when invite insert fails in `POST /api/orgs/[orgId]/invites`
- log structured diagnostic context for invite insert failures
- return stable 500 response (`Failed to create invite`)
- add route test coverage for invite insert failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #89

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to an error path and additional test coverage; minimal behavioral impact beyond response message consistency and extra logging.
> 
> **Overview**
> Stabilizes `POST /api/orgs/[orgId]/invites` error handling when the `org_invites` insert fails by **logging structured diagnostics** and returning a consistent `500` response (`Failed to create invite`) instead of leaking the raw DB/provider message.
> 
> Adds a new route test covering the invite-insert failure path to ensure the stable error response is preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55627d40db7990061089bb585a6ec91444a208bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->