### PR TITLE
fix: stabilize invites DELETE failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -323,7 +323,13 @@ export async function DELETE(
     .eq("org_id", orgId)
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to delete org invite row:", {
+      error,
+      orgId,
+      userId: user.id,
+      inviteId,
+    })
+    return NextResponse.json({ error: "Failed to revoke invite" }, { status: 500 })
   }
 
   if (inviteToRevoke) {


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when invite deletion fails in `DELETE /api/orgs/[orgId]/invites`
- log structured diagnostic context for revoke deletion failures
- return stable 500 response (`Failed to revoke invite`)
- add route test coverage for invite deletion failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/invites/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #91

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to an error path plus added test coverage; no changes to authz logic or data mutation behavior beyond the error response body.
> 
> **Overview**
> Stabilizes the error contract for `DELETE /api/orgs/[orgId]/invites` by no longer returning the raw DB error message when deleting an invite fails, and instead returning a consistent `500` with `Failed to revoke invite`.
> 
> Adds structured server-side logging (`orgId`, `userId`, `inviteId`, and the underlying error) for failed deletions, and introduces a dedicated test covering the invite-deletion failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff86dc54268f6b2a0c74236b66df47947600a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->