### PR TITLE
fix: stabilize /api/orgs GET DB failure response

### DIFF
--- a/packages/web/src/app/api/orgs/__tests__/route.test.ts
+++ b/packages/web/src/app/api/orgs/__tests__/route.test.ts
@@ -102,6 +102,8 @@ describe("/api/orgs", () => {
 
       const response = await GET(new Request("https://example.com/api/orgs"))
       expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.error).toBe("Failed to load organizations")
     })
   })
 

--- a/packages/web/src/app/api/orgs/route.ts
+++ b/packages/web/src/app/api/orgs/route.ts
@@ -35,7 +35,11 @@ export async function GET(request: Request): Promise<Response> {
     .eq("user_id", auth.userId)
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to load user organizations:", {
+      error,
+      userId: auth.userId,
+    })
+    return NextResponse.json({ error: "Failed to load organizations" }, { status: 500 })
   }
 
   const organizations = orgs?.map(m => ({


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when organization listing fails in `GET /api/orgs`
- log structured diagnostics for org list query failures
- return stable 500 response (`Failed to load organizations`)
- update route test to assert the stable message

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/__tests__/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to API error handling and logging; no business logic or data writes are altered.
> 
> **Overview**
> Stabilizes `GET /api/orgs` failure behavior by **no longer returning raw DB/provider error messages**; it now logs structured diagnostics (`userId` + error) to `console.error` and returns a consistent `500` payload `{ error: "Failed to load organizations" }`.
> 
> Updates the `/api/orgs` route test to assert the new stable error message on DB failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16985beb20e0597edaa51c537f61db3dcdb185c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->