### PR TITLE
fix: stabilize /api/orgs POST insert failure response

### DIFF
--- a/packages/web/src/app/api/orgs/route.ts
+++ b/packages/web/src/app/api/orgs/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: Request): Promise<Response> {
       userId: auth.userId,
       orgName: name.trim(),
     })
-    return NextResponse.json({ error: orgError.message || "Failed to create organization" }, { status: 500 })
+    return NextResponse.json({ error: "Failed to create organization" }, { status: 500 })
   }
 
   // Add creator as owner member


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when organization insert fails in `POST /api/orgs`
- return stable 500 response (`Failed to create organization`)
- add test coverage for organization insert failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/__tests__/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to an error message on a single endpoint plus added test coverage; minimal functional impact beyond response body consistency.
> 
> **Overview**
> Stabilizes `POST /api/orgs` error handling by no longer returning the raw database/provider error message when the organization `insert` fails, and instead always responding with `{"error":"Failed to create organization"}` (500).
> 
> Adds a targeted test case covering the organization insert failure path to ensure the response remains consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79205e6ab28293ddc3f4b4476180fab0ddc0372d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->