### PR TITLE
fix: stabilize /api/orgs owner-membership failure response

### DIFF
--- a/packages/web/src/app/api/orgs/__tests__/route.test.ts
+++ b/packages/web/src/app/api/orgs/__tests__/route.test.ts
@@ -276,5 +276,64 @@ describe("/api/orgs", () => {
       const body = await response.json()
       expect(body.error).toBe("Failed to create organization")
     })
+
+    it("should return 500 when owner membership insert fails", async () => {
+      mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
+
+      let orgCallCount = 0
+      mockAdminFrom.mockImplementation((table: string) => {
+        if (table === "organizations") {
+          orgCallCount += 1
+
+          if (orgCallCount === 1) {
+            return {
+              select: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                }),
+              }),
+            }
+          }
+
+          if (orgCallCount === 2) {
+            return {
+              insert: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: { id: "org-new", name: "New Team", slug: "new-team" },
+                    error: null,
+                  }),
+                }),
+              }),
+            }
+          }
+
+          return {
+            delete: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }
+        }
+
+        if (table === "org_members") {
+          return {
+            insert: vi.fn().mockResolvedValue({ error: { message: "DB write failed" } }),
+          }
+        }
+
+        return {}
+      })
+
+      const request = new Request("https://example.com/api/orgs", {
+        method: "POST",
+        body: JSON.stringify({ name: "New Team" }),
+        headers: { "content-type": "application/json" },
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.error).toBe("Failed to add organization owner")
+    })
   })
 })

--- a/packages/web/src/app/api/orgs/route.ts
+++ b/packages/web/src/app/api/orgs/route.ts
@@ -139,9 +139,7 @@ export async function POST(request: Request): Promise<Response> {
     if (deleteError) {
       console.error("Failed to rollback org creation:", deleteError)
     }
-    return NextResponse.json({ 
-      error: memberError.message || "Failed to add you as organization owner. This may be a permissions issue." 
-    }, { status: 500 })
+    return NextResponse.json({ error: "Failed to add organization owner" }, { status: 500 })
   }
 
   // Set as user's current org if they don't have one


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider message when owner membership insertion fails in `POST /api/orgs`
- return stable 500 response (`Failed to add organization owner`)
- add test coverage for owner-membership insert failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/__tests__/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #97

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to an error message in a failure path plus added test coverage; no behavioral changes on success paths.
> 
> **Overview**
> Stabilizes the error response from `POST /api/orgs` when inserting the creator’s owner membership fails by returning a generic `500` JSON error (`Failed to add organization owner`) instead of surfacing the underlying provider/DB message.
> 
> Adds a new Vitest case covering the owner-membership insert failure path (including org creation then rollback) to ensure the response remains consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a2c4c440e25f6791e69ec560ec451e8f8da61c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->