### PR TITLE
fix: stabilize org PATCH generic update failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.test.ts
@@ -98,6 +98,53 @@ describe("/api/orgs/[orgId] PATCH", () => {
     })
   })
 
+  it("returns 500 when organization update fails", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "organizations") {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { message: "DB write failed", code: "XX000" },
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {}
+    })
+
+    const response = await PATCH(
+      new Request("https://example.com/api/orgs/org-1", {
+        method: "PATCH",
+        body: JSON.stringify({ name: "New org name" }),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Failed to update organization",
+    })
+  })
+
   it("requires a domain before enabling auto-join", async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === "org_members") {

--- a/packages/web/src/app/api/orgs/[orgId]/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.ts
@@ -204,7 +204,13 @@ export async function PATCH(
         { status: 409 },
       )
     }
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to update organization row:", {
+      error,
+      orgId,
+      userId: user.id,
+      updatedFields: Object.keys(updates).sort(),
+    })
+    return NextResponse.json({ error: "Failed to update organization" }, { status: 500 })
   }
 
   await logOrgAuditEvent({


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider text for generic update failures in `PATCH /api/orgs/[orgId]`
- log structured diagnostics for the fallback update-error path
- return stable 500 response (`Failed to update organization`)
- add route test coverage for generic update failure

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #99

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error messaging/logging and a new test; core update flow and special-case error mappings remain unchanged.
> 
> **Overview**
> Stabilizes `PATCH /api/orgs/[orgId]` error handling by **no longer returning raw database error messages** for generic update failures; it now logs structured diagnostics and returns a consistent `{ error: "Failed to update organization" }` with HTTP 500.
> 
> Adds test coverage to assert the 500 response when the underlying `organizations` update call fails with an unexpected DB error code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49318d658cd14533941de967263f439325100a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->