### PR TITLE
fix: stabilize org DELETE mutation failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.ts
@@ -274,7 +274,12 @@ export async function DELETE(
     .eq("id", orgId)
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    console.error("Failed to delete organization row:", {
+      error,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to delete organization" }, { status: 500 })
   }
 
   return NextResponse.json({ success: true })


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider text when org deletion fails in `DELETE /api/orgs/[orgId]`
- log structured diagnostic context for deletion failures
- return stable 500 response (`Failed to delete organization`)
- add route test coverage for org deletion failure

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error handling and logging for `DELETE /api/orgs/[orgId]`, plus test coverage; no behavioral changes on success paths or auth/authorization logic.
> 
> **Overview**
> `DELETE /api/orgs/[orgId]` now returns a stable 500 error payload (`Failed to delete organization`) instead of surfacing the raw provider/DB error message when the `organizations` delete fails.
> 
> Adds structured server-side logging (including `orgId` and `userId`) for delete-row failures, and extends route tests to cover the failed-delete scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb66a4b3036668ea2e661a22be157e4d9f3520bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->