### PR TITLE
fix: handle github settings membership lookup failures

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.ts
@@ -128,12 +128,22 @@ export async function GET(
   const rateLimited = await checkRateLimit(apiRateLimit, user.id)
   if (rateLimited) return rateLimited
 
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", user.id)
     .single()
+
+  if (membershipError) {
+    console.error("Failed to verify GitHub capture settings access:", {
+      error: membershipError,
+      orgId,
+      userId: user.id,
+      method: "GET",
+    })
+    return NextResponse.json({ error: "Failed to load settings" }, { status: 500 })
+  }
 
   const role = (membership as OrgMembershipRow | null)?.role
   if (!canManage(role)) {
@@ -184,12 +194,22 @@ export async function PATCH(
   const rateLimited = await checkRateLimit(apiRateLimit, user.id)
   if (rateLimited) return rateLimited
 
-  const { data: membership } = await supabase
+  const { data: membership, error: membershipError } = await supabase
     .from("org_members")
     .select("role")
     .eq("org_id", orgId)
     .eq("user_id", user.id)
     .single()
+
+  if (membershipError) {
+    console.error("Failed to verify GitHub capture settings access:", {
+      error: membershipError,
+      orgId,
+      userId: user.id,
+      method: "PATCH",
+    })
+    return NextResponse.json({ error: "Failed to save settings" }, { status: 500 })
+  }
 
   const role = (membership as OrgMembershipRow | null)?.role
   if (!canManage(role)) {


### PR DESCRIPTION
## Summary
- handle org membership lookup errors explicitly in GitHub capture settings GET/PATCH handlers
- return stable 500 responses when membership lookup fails:
  - GET: `Failed to load settings`
  - PATCH: `Failed to save settings`
- add route test coverage for both failure paths

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/github-capture/settings/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #106

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error handling and logging for a single route; no changes to auth rules or write logic beyond returning a consistent 500 on membership query failure.
> 
> **Overview**
> Improves resiliency of `/api/orgs/[orgId]/github-capture/settings` by explicitly handling Supabase `org_members` lookup failures in both `GET` and `PATCH`.
> 
> On membership query errors, the handlers now log diagnostic context and return stable `500` responses (`Failed to load settings` for `GET`, `Failed to save settings` for `PATCH`), with new Vitest coverage for both failure paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aadb715f243c8377c483d3270f0acb1a64455d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->