### PR TITLE
fix: stabilize github settings generic load/save failures

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.ts
@@ -163,11 +163,13 @@ export async function GET(
       )
     }
 
-    const message =
-      typeof error === "object" && error !== null && "message" in error
-        ? String((error as { message?: unknown }).message ?? "Failed to load settings")
-        : "Failed to load settings"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to load GitHub capture settings row:", {
+      error,
+      orgId,
+      userId: user.id,
+      method: "GET",
+    })
+    return NextResponse.json({ error: "Failed to load settings" }, { status: 500 })
   }
 
   return NextResponse.json({
@@ -238,11 +240,13 @@ export async function PATCH(
         { status: 503 },
       )
     }
-    const message =
-      typeof existingError === "object" && existingError !== null && "message" in existingError
-        ? String((existingError as { message?: unknown }).message ?? "Failed to load settings")
-        : "Failed to load settings"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to load existing GitHub capture settings row:", {
+      error: existingError,
+      orgId,
+      userId: user.id,
+      method: "PATCH",
+    })
+    return NextResponse.json({ error: "Failed to save settings" }, { status: 500 })
   }
 
   const timestamp = new Date().toISOString()
@@ -279,8 +283,14 @@ export async function PATCH(
       )
     }
 
-    const message = response.error?.message ?? "Failed to save settings"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to persist GitHub capture settings row:", {
+      error: response.error,
+      orgId,
+      userId: user.id,
+      method: existingRow ? "PATCH:update" : "PATCH:insert",
+      updatedFields: Object.keys(updates).sort(),
+    })
+    return NextResponse.json({ error: "Failed to save settings" }, { status: 500 })
   }
 
   const row = response.data as GithubCaptureSettingsRow

--- a/packages/web/src/components/Pricing.tsx
+++ b/packages/web/src/components/Pricing.tsx
@@ -191,7 +191,11 @@ export function Pricing({ user }: { user?: User | null }): React.JSX.Element {
               }`}
             >
               Yearly
-              <span className="px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-primary/20 text-primary rounded">
+              <span
+                className={`px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider rounded ${
+                  isYearly ? "bg-primary-foreground/20 text-primary-foreground" : "bg-primary/20 text-primary"
+                }`}
+              >
                 2 Months Free
               </span>
             </button>


### PR DESCRIPTION
## Summary
- return stable 500 responses for generic GitHub capture settings load/save failures without exposing provider messages
- add structured server-side logs for these failure paths:
  - GET settings row load error
  - PATCH existing settings row load error
  - PATCH insert/update write error
- add tests for:
  - GET settings lookup failure
  - PATCH settings lookup failure
  - PATCH settings write failure
- include current branch `packages/web/src/components/Pricing.tsx` updates as requested

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/github-capture/settings/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to error-path response shaping and server-side logging for the GitHub capture settings API, plus small UI styling tweaks; no schema or core business logic changes.
> 
> **Overview**
> **Stabilizes error handling for GitHub capture settings API.** `GET`/`PATCH` now return consistent generic 500 JSON errors (`Failed to load settings` / `Failed to save settings`) instead of surfacing underlying provider/DB messages.
> 
> Adds structured `console.error` logs for settings row read/write failures (including org/user/method and updated fields), and extends route tests to cover GET settings lookup failure plus PATCH lookup and write failure scenarios.
> 
> Separately tweaks `Pricing` so the “2 Months Free” yearly badge switches colors based on the active toggle state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4e7de0a82640875311afe67586f12305f6d7638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->