### PR TITLE
fix: stabilize org audit log query failure response

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/audit/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/audit/route.ts
@@ -107,7 +107,14 @@ export async function GET(
         { status: 503 }
       )
     }
-    return NextResponse.json({ error: logsError.message }, { status: 500 })
+    console.error("Failed to load org audit log rows:", {
+      error: logsError,
+      orgId,
+      userId: user.id,
+      actionFilter,
+      limit,
+    })
+    return NextResponse.json({ error: "Failed to load audit events" }, { status: 500 })
   }
 
   const rows = (logs ?? []) as OrgAuditLogRow[]


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider text when org audit log query fails in `GET /api/orgs/[orgId]/audit`
- log structured diagnostics for generic audit query failures
- return stable 500 response (`Failed to load audit events`)
- add route test coverage for audit logs query failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/audit/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error handling and logging plus added tests; no changes to authz logic or successful response shape.
> 
> **Overview**
> `GET /api/orgs/[orgId]/audit` now returns a consistent `500` payload (`{"error":"Failed to load audit events"}`) when the `org_audit_logs` query fails, instead of returning the raw provider/DB error message.
> 
> The route also emits structured `console.error` diagnostics (including `orgId`, `userId`, `actionFilter`, and `limit`) for these failures, and adds a Vitest case covering the audit-log query error path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e100bc07c178c6bf8ddafd89dd92928ea73a8fc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->