### PR TITLE
fix: return 500 for org GET lookup failures

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.ts
@@ -61,7 +61,16 @@ export async function GET(
     .eq("id", orgId)
     .single()
 
-  if (error || !org) {
+  if (error) {
+    console.error("Failed to load organization by ID:", {
+      error,
+      orgId,
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to fetch organization" }, { status: 500 })
+  }
+
+  if (!org) {
     return NextResponse.json({ error: "Organization not found" }, { status: 404 })
   }
 


### PR DESCRIPTION
## Summary
- distinguish DB/query failures from true not-found in `GET /api/orgs/[orgId]`
- return stable 500 (`Failed to fetch organization`) when org lookup fails operationally
- keep 404 behavior for actual missing org records
- add route test coverage for organization lookup failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #112

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to GET error-handling semantics plus a new test; main risk is altering client-visible status codes/messages in an edge-case failure path.
> 
> **Overview**
> Adjusts `GET /api/orgs/[orgId]` to **treat organization query errors as operational failures** (logging details and returning `500 Failed to fetch organization`) while keeping `404 Organization not found` for the `no row` case.
> 
> Adds a Vitest case in `route.test.ts` to cover the new 500 behavior when the `organizations` lookup returns an error after a successful membership check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d5556fdaa9e44ede20e09a06a18809ad16afdb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->