### PR TITLE
fix: stabilize /api/user PATCH update failure response

### DIFF
--- a/packages/web/src/app/api/user/route.ts
+++ b/packages/web/src/app/api/user/route.ts
@@ -249,7 +249,7 @@ export async function PATCH(request: Request): Promise<Response> {
     }
 
     console.error("User update error:", error)
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ error: "Failed to update user" }, { status: 500 })
   }
 
   if (switchStartedAt !== null) {


### PR DESCRIPTION
## Summary
- stop returning raw DB/provider text when final users update mutation fails in `PATCH /api/user`
- return stable 500 response (`Failed to update user`)
- add route test coverage for update-mutation failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/user/__tests__/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error messaging and a matching test; minimal behavioral impact aside from standardizing the 500 response body.
> 
> **Overview**
> `PATCH /api/user` now returns a stable 500 JSON error (`{"error":"Failed to update user"}`) instead of leaking the underlying update error message when the final `users` update fails.
> 
> Adds a regression test covering the failed update-mutation path to ensure the endpoint responds with the standardized 500 payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78143c997a3ce3586367e4acbe6f500333e886c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->