### PR TITLE
fix: treat /api/user profile lookup failures as 500

### DIFF
--- a/packages/web/src/app/api/user/route.ts
+++ b/packages/web/src/app/api/user/route.ts
@@ -122,7 +122,15 @@ export async function GET(request: Request): Promise<Response> {
     error = fallback.error
   }
 
-  if (error || !profile) {
+  if (error) {
+    console.error("Failed to load user profile:", {
+      error,
+      userId: auth.userId,
+    })
+    return NextResponse.json({ error: "Failed to load user profile" }, { status: 500 })
+  }
+
+  if (!profile) {
     return NextResponse.json({ error: "User not found" }, { status: 404 })
   }
 


### PR DESCRIPTION
## Summary
- distinguish profile lookup DB errors from true missing-user in `GET /api/user`
- return stable 500 (`Failed to load user profile`) for query failures
- keep 404 only for actual missing user records
- add route test coverage for profile lookup failure

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/user/__tests__/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #118

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling tweak to a single API route plus a new test; low blast radius, with the main risk being changed status codes for some failure cases.
> 
> **Overview**
> `GET /api/user` now distinguishes database/query failures from a truly missing user: query errors return a **500** with a stable `Failed to load user profile` message (and logs diagnostic context), while **404** is reserved for `profile` being null without an error.
> 
> Adds a route test covering the new 500 behavior when the profile lookup returns an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c77681365a3391207b4738367c45fba295dd6f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->