### PR TITLE
fix: stabilize /api/workspace memberships error response

### DIFF
--- a/packages/web/src/app/api/workspace/route.ts
+++ b/packages/web/src/app/api/workspace/route.ts
@@ -169,7 +169,11 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   if (membershipsResult.error) {
-    return NextResponse.json({ error: membershipsResult.error.message }, { status: 500 })
+    console.error("Failed to load workspace memberships:", {
+      userId: auth.userId,
+      error: membershipsResult.error,
+    })
+    return NextResponse.json({ error: "Failed to load workspace" }, { status: 500 })
   }
 
   const buildStartedAt = Date.now()


### PR DESCRIPTION
## Summary
- avoid returning raw `membershipsResult.error.message` from `GET /api/workspace`
- log memberships query failures server-side with user context
- return a stable client-safe 500 payload
- add coverage for memberships lookup failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/workspace/__tests__/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error handling and logging for one API route, plus a targeted unit test; minimal behavioral impact outside failure cases.
> 
> **Overview**
> `/api/workspace` now **stops returning raw Supabase error messages** when the `org_members` query fails, and instead logs the failure server-side (including `userId`) and returns a stable `{ error: "Failed to load workspace" }` with HTTP 500.
> 
> Adds a Vitest case covering the memberships-lookup failure path to ensure the new 500 response shape remains consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25c2debd4dc12e283573839ef3ac16cd73f4a731. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->