### PR TITLE
fix: stabilize /api/invites/accept member insert failure response

### DIFF
--- a/packages/web/src/app/api/invites/accept/route.test.ts
+++ b/packages/web/src/app/api/invites/accept/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockGetUser,
+  mockFrom,
+  mockCheckRateLimit,
+  mockAddTeamSeat,
+  mockLogOrgAuditEvent,
+  mockHasServiceRoleKey,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockAddTeamSeat: vi.fn(),
+  mockLogOrgAuditEvent: vi.fn(),
+  mockHasServiceRoleKey: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  })),
+}))
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiRateLimit: { limit: vi.fn() },
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+vi.mock("@/lib/stripe/teams", () => ({
+  addTeamSeat: mockAddTeamSeat,
+}))
+
+vi.mock("@/lib/org-audit", () => ({
+  logOrgAuditEvent: mockLogOrgAuditEvent,
+}))
+
+vi.mock("@/lib/env", () => ({
+  hasServiceRoleKey: mockHasServiceRoleKey,
+}))
+
+import { POST } from "./route"
+
+describe("/api/invites/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue(null)
+    mockHasServiceRoleKey.mockReturnValue(false)
+    mockAddTeamSeat.mockResolvedValue({ action: "updated" })
+    mockLogOrgAuditEvent.mockResolvedValue(undefined)
+  })
+
+  it("returns 500 with stable error when member insert fails", async () => {
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: {
+          id: "user-1",
+          email: "member@example.com",
+          identities: [],
+        },
+      },
+    })
+
+    const invite = {
+      id: "invite-1",
+      org_id: "org-1",
+      invited_by: "owner-1",
+      email: "member@example.com",
+      role: "member",
+      organization: {
+        id: "org-1",
+        name: "Acme",
+        slug: "acme",
+        stripe_customer_id: null,
+        stripe_subscription_id: null,
+      },
+    }
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "org_invites") {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockReturnValue({
+              is: vi.fn().mockReturnValue({
+                gt: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: invite,
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          })),
+          update: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              is: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }),
+            }),
+          })),
+          insert: vi.fn().mockResolvedValue({
+            error: {
+              message: "duplicate key value violates unique constraint",
+            },
+          }),
+        }
+      }
+
+      return {
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      }
+    })
+
+    const response = await POST(
+      new Request("https://example.com/api/invites/accept", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          token: "invite-token-1",
+          billing: "monthly",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to accept invite",
+    })
+    expect(mockLogOrgAuditEvent).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/app/api/invites/accept/route.ts
+++ b/packages/web/src/app/api/invites/accept/route.ts
@@ -142,12 +142,18 @@ export async function POST(request: Request): Promise<Response> {
     })
 
   if (memberError) {
+    console.error("Failed to insert org member during invite accept:", {
+      inviteId: invite.id,
+      orgId: invite.org_id,
+      userId: user.id,
+      error: memberError,
+    })
     // Rollback invite acceptance if member insert fails
     await writeClient
       .from("org_invites")
       .update({ accepted_at: null })
       .eq("id", invite.id)
-    return NextResponse.json({ error: memberError.message }, { status: 500 })
+    return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
   }
 
   await logOrgAuditEvent({


### PR DESCRIPTION
## Summary
- stop returning raw `memberError.message` from `POST /api/invites/accept`
- add structured server-side logging for member insert failures
- return stable 500 payload: `Failed to accept invite`
- add route regression test covering member insert failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/invites/accept/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change plus a new test; minimal behavioral impact beyond stabilizing the public error payload and adding logging.
> 
> **Overview**
> `POST /api/invites/accept` no longer returns raw `memberError.message` when inserting into `org_members` fails; it now logs a structured server-side error and returns a stable `{ error: "Failed to accept invite" }` 500 payload after rolling back `accepted_at`.
> 
> Adds a Vitest regression test that mocks the Supabase calls to force a member insert failure and asserts the stable 500 response and that no org audit event is written.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d83a9ca533aab5d74a47d851015767b9a0eddb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->