### PR TITLE
fix: hide raw DB errors when rejecting capture queue items

### DIFF
--- a/packages/web/src/app/api/github/capture/queue/[id]/route.ts
+++ b/packages/web/src/app/api/github/capture/queue/[id]/route.ts
@@ -156,7 +156,12 @@ export async function PATCH(
       .eq("id", id)
 
     if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 })
+      console.error("Failed to reject capture queue item:", {
+        queueId: id,
+        reviewerUserId: user.id,
+        error,
+      })
+      return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
     }
 
     return NextResponse.json({ ok: true, status: "rejected" })


### PR DESCRIPTION
## Summary
- avoid returning raw update error text from reject path in `PATCH /api/github/capture/queue/[id]`
- add structured logging for reject update failures
- return stable 500 response: `Failed to update capture queue item`
- add route test coverage for reject update failure behavior

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/queue/[id]/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error handling/logging on the reject path plus a unit test; no behavior changes on successful flows or data shape.
> 
> **Overview**
> Rejecting a GitHub capture queue item via `PATCH /api/github/capture/queue/[id]` now returns a **stable 500 error message** (`Failed to update capture queue item`) instead of passing through the raw DB error string.
> 
> On reject-update failure the route now emits **structured `console.error` logging** with queue/user context, and a new Vitest case asserts the 500 response body for this failure path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f00edb6d82001e59850594f5dece8e0974106251. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->