### PR TITLE
fix: hide raw DB errors when approving capture queue items

### DIFF
--- a/packages/web/src/app/api/github/capture/queue/[id]/route.test.ts
+++ b/packages/web/src/app/api/github/capture/queue/[id]/route.test.ts
@@ -4,10 +4,16 @@ const {
   mockGetUser,
   mockFrom,
   mockCheckRateLimit,
+  mockAddMemoryPayload,
+  mockEnsureMemoryUserIdSchema,
+  mockCreateTurso,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
   mockCheckRateLimit: vi.fn(),
+  mockAddMemoryPayload: vi.fn(),
+  mockEnsureMemoryUserIdSchema: vi.fn(),
+  mockCreateTurso: vi.fn(),
 }))
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -30,11 +36,15 @@ vi.mock("@/lib/rate-limit", () => ({
 }))
 
 vi.mock("@/lib/memory-service/mutations", () => ({
-  addMemoryPayload: vi.fn(),
+  addMemoryPayload: mockAddMemoryPayload,
 }))
 
 vi.mock("@/lib/memory-service/tools", () => ({
-  ensureMemoryUserIdSchema: vi.fn(),
+  ensureMemoryUserIdSchema: mockEnsureMemoryUserIdSchema,
+}))
+
+vi.mock("@libsql/client", () => ({
+  createClient: mockCreateTurso,
 }))
 
 import { PATCH } from "./route"
@@ -43,6 +53,11 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockCheckRateLimit.mockResolvedValue(null)
+    mockCreateTurso.mockReturnValue({})
+    mockEnsureMemoryUserIdSchema.mockResolvedValue(undefined)
+    mockAddMemoryPayload.mockResolvedValue({
+      data: { id: "mem-1" },
+    })
   })
 
   it("returns 401 when unauthenticated", async () => {
@@ -185,6 +200,87 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
       new Request("https://example.com/api/github/capture/queue/q-1", {
         method: "PATCH",
         body: JSON.stringify({ action: "reject", note: "noise" }),
+        headers: { "content-type": "application/json" },
+      }),
+      { params: Promise.resolve({ id: "q-1" }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to update capture queue item",
+    })
+  })
+
+  it("returns 500 with stable error when approve update fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    let githubQueueReadUsed = false
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "github_capture_queue" && !githubQueueReadUsed) {
+        githubQueueReadUsed = true
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: "q-1",
+                  target_owner_type: "user",
+                  target_user_id: "user-1",
+                  target_org_id: null,
+                  status: "pending",
+                  source_event: "issues",
+                  source_action: "opened",
+                  repo_full_name: "webrenew/memories",
+                  project_id: "github.com/webrenew/memories",
+                  actor_login: "charles",
+                  source_id: "issue:1:2",
+                  title: "Issue",
+                  content: "Issue content",
+                  source_url: "https://github.com/webrenew/memories/issues/2",
+                  metadata: {},
+                },
+                error: null,
+              }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "users") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  turso_db_url: "libsql://db",
+                  turso_db_token: "token",
+                  turso_db_name: "db-name",
+                },
+                error: null,
+              }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "github_capture_queue") {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              error: { message: "update failed" },
+            }),
+          })),
+        }
+      }
+
+      return {}
+    })
+
+    const response = await PATCH(
+      new Request("https://example.com/api/github/capture/queue/q-1", {
+        method: "PATCH",
+        body: JSON.stringify({ action: "approve", note: "looks good" }),
         headers: { "content-type": "application/json" },
       }),
       { params: Promise.resolve({ id: "q-1" }) }

--- a/packages/web/src/app/api/github/capture/queue/[id]/route.ts
+++ b/packages/web/src/app/api/github/capture/queue/[id]/route.ts
@@ -231,7 +231,13 @@ export async function PATCH(
     .eq("id", id)
 
   if (updateError) {
-    return NextResponse.json({ error: updateError.message }, { status: 500 })
+    console.error("Failed to approve capture queue item:", {
+      queueId: id,
+      reviewerUserId: user.id,
+      approvedMemoryId: payload.data.id,
+      error: updateError,
+    })
+    return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
   }
 
   return NextResponse.json({


### PR DESCRIPTION
## Summary
- avoid returning raw `updateError.message` from approve path in `PATCH /api/github/capture/queue/[id]`
- add structured logging for approve update failures
- return stable 500 response: `Failed to update capture queue item`
- add regression test for approve update failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/queue/[id]/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change plus test coverage; behavior only differs on failure paths and reduces information leakage.
> 
> **Overview**
> Prevents `PATCH /api/github/capture/queue/[id]` *approve* failures from leaking raw database error messages by returning a stable `500` response (`Failed to update capture queue item`) and emitting structured `console.error` logs with queue/reviewer/memory context.
> 
> Extends the route test to mock Turso + memory-service dependencies and adds a regression case asserting the stable error behavior when the approve update fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99660502e8beb0f9094ea10e4bfe09fb353e02b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->