### PR TITLE
fix: stabilize /api/github/capture/queue membership lookup failures

### DIFF
--- a/packages/web/src/app/api/github/capture/queue/route.test.ts
+++ b/packages/web/src/app/api/github/capture/queue/route.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockGetUser,
+  mockAdminFrom,
+  mockCheckRateLimit,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  })),
+}))
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockAdminFrom,
+  })),
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiRateLimit: { limit: vi.fn() },
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+import { GET } from "./route"
+
+describe("/api/github/capture/queue GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue(null)
+  })
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const response = await GET(new Request("https://example.com/api/github/capture/queue"))
+    expect(response.status).toBe(401)
+  })
+
+  it("returns 500 with stable error when memberships lookup fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "db timeout" },
+            }),
+          })),
+        }
+      }
+
+      return {}
+    })
+
+    const response = await GET(new Request("https://example.com/api/github/capture/queue"))
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to load queue",
+    })
+  })
+})

--- a/packages/web/src/app/api/github/capture/queue/route.ts
+++ b/packages/web/src/app/api/github/capture/queue/route.ts
@@ -147,7 +147,11 @@ export async function GET(request: Request): Promise<Response> {
     .eq("user_id", user.id)
 
   if (membershipsError) {
-    return NextResponse.json({ error: membershipsError.message }, { status: 500 })
+    console.error("Failed to load capture queue memberships:", {
+      userId: user.id,
+      error: membershipsError,
+    })
+    return NextResponse.json({ error: "Failed to load queue" }, { status: 500 })
   }
 
   const orgMemberships = (memberships ?? []) as OrgMembershipRow[]


### PR DESCRIPTION
## Summary
- stop returning raw `membershipsError.message` from `GET /api/github/capture/queue`
- add structured server-side logging for membership lookup failures
- return stable 500 payload: `Failed to load queue`
- add new route test for membership lookup error path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/queue/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to an error-handling path: replaces a leaked/raw DB error message with a stable response and adds logging plus a test to lock behavior in.
> 
> **Overview**
> Stabilizes `GET /api/github/capture/queue` when the `org_members` lookup fails by **logging a structured server-side error** and returning a **fixed 500 payload** (`{ error: "Failed to load queue" }`) instead of exposing the raw `membershipsError.message`.
> 
> Adds a new Vitest suite for the route, covering unauthenticated `401` responses and the membership-lookup failure path to ensure the stable error contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ecbcf18ad3b20efd3a5ad29a741e55833ad1ff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->