### PR TITLE
fix: hide queue loader DB errors in capture queue API

### DIFF
--- a/packages/web/src/app/api/github/capture/queue/route.ts
+++ b/packages/web/src/app/api/github/capture/queue/route.ts
@@ -223,7 +223,10 @@ export async function GET(request: Request): Promise<Response> {
 
     return NextResponse.json({ queue })
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to load queue"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to load capture queue rows:", {
+      userId: user.id,
+      error,
+    })
+    return NextResponse.json({ error: "Failed to load queue" }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- stop returning raw thrown DB error messages from `GET /api/github/capture/queue` catch block
- add structured logging for queue row load failures
- return stable 500 payload: `Failed to load queue`
- add regression test for queue row loading failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/queue/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #132

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error handling and logging for a single API route; main risk is reduced client error detail if any callers depended on the previous message text.
> 
> **Overview**
> `GET /api/github/capture/queue` now **always returns a stable** `{ error: "Failed to load queue" }` on unexpected failures instead of surfacing thrown DB error messages to clients.
> 
> Adds structured `console.error` logging (including `userId` and the caught error) for queue row load failures, and introduces a regression test covering the queue-row read error path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bcea9682941b6e4667ad418712c99fd3d88f0e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->