### PR TITLE
fix: hide DB error text in github capture settings GET

### DIFF
--- a/packages/web/src/app/api/github/capture/settings/route.test.ts
+++ b/packages/web/src/app/api/github/capture/settings/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockGetUser,
+  mockFrom,
+  mockCheckRateLimit,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  })),
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiRateLimit: { limit: vi.fn() },
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+import { GET } from "./route"
+
+describe("/api/github/capture/settings GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue(null)
+  })
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const response = await GET()
+    expect(response.status).toBe(401)
+  })
+
+  it("returns 500 with stable error when settings load fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "github_capture_settings") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { message: "db timeout" },
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {}
+    })
+
+    const response = await GET()
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to load settings",
+    })
+  })
+})

--- a/packages/web/src/app/api/github/capture/settings/route.ts
+++ b/packages/web/src/app/api/github/capture/settings/route.ts
@@ -128,11 +128,11 @@ export async function GET(): Promise<Response> {
       )
     }
 
-    const message =
-      typeof error === "object" && error !== null && "message" in error
-        ? String((error as { message?: unknown }).message ?? "Failed to load settings")
-        : "Failed to load settings"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to load GitHub capture settings:", {
+      userId: user.id,
+      error,
+    })
+    return NextResponse.json({ error: "Failed to load settings" }, { status: 500 })
   }
 
   return NextResponse.json({


### PR DESCRIPTION
## Summary
- stop returning raw backend error text from `GET /api/github/capture/settings`
- add structured server-side logging for settings load failures
- return stable 500 payload: `Failed to load settings`
- add new route tests for auth and load-failure behavior

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/settings/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #134

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limits error detail exposure and adds logging/tests in a single GET route; minimal behavioral change with low blast radius.
> 
> **Overview**
> `GET /api/github/capture/settings` no longer returns raw backend error messages on unexpected load failures; it now logs the underlying error server-side (including `userId`) and responds with a stable `500` payload `{ error: "Failed to load settings" }`.
> 
> Adds Vitest coverage for unauthenticated access (`401`) and for the stable `500` error response when the settings query fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e3861f326d536f29632fb7443ce204c4ee57c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->