### PR TITLE
fix: hide DB error text in github capture settings PATCH lookup

### DIFF
--- a/packages/web/src/app/api/github/capture/settings/route.ts
+++ b/packages/web/src/app/api/github/capture/settings/route.ts
@@ -178,11 +178,11 @@ export async function PATCH(request: Request): Promise<Response> {
       )
     }
 
-    const message =
-      typeof existingError === "object" && existingError !== null && "message" in existingError
-        ? String((existingError as { message?: unknown }).message ?? "Failed to load settings")
-        : "Failed to load settings"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to load existing GitHub capture settings for update:", {
+      userId: user.id,
+      error: existingError,
+    })
+    return NextResponse.json({ error: "Failed to load settings" }, { status: 500 })
   }
 
   const timestamp = new Date().toISOString()


### PR DESCRIPTION
## Summary
- stop returning raw DB message when loading existing settings fails in `PATCH /api/github/capture/settings`
- add structured server-side logging for this lookup failure
- return stable 500 payload: `Failed to load settings`
- add PATCH regression test coverage for this failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/settings/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change that only affects the PATCH lookup-failure path and adds a regression test; low risk beyond potentially impacting debugging if logs aren’t monitored.
> 
> **Overview**
> Prevents `PATCH /api/github/capture/settings` from returning raw database error messages when loading existing settings fails; it now logs the underlying error server-side and always responds with a stable `{ error: "Failed to load settings" }` 500.
> 
> Adds test coverage to ensure this PATCH failure path returns the stable error payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c2fa5055ae947f30726d9cad0820c9785880f05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->