### PR TITLE
fix: hide DB error text in github capture settings save failures

### DIFF
--- a/packages/web/src/app/api/github/capture/settings/route.ts
+++ b/packages/web/src/app/api/github/capture/settings/route.ts
@@ -219,8 +219,11 @@ export async function PATCH(request: Request): Promise<Response> {
       )
     }
 
-    const message = response.error?.message ?? "Failed to save settings"
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error("Failed to save GitHub capture settings:", {
+      userId: user.id,
+      error: response.error,
+    })
+    return NextResponse.json({ error: "Failed to save settings" }, { status: 500 })
   }
 
   const row = response.data as GithubCaptureSettingsRow


### PR DESCRIPTION
## Summary
- stop returning raw DB message when update/insert save fails in `PATCH /api/github/capture/settings`
- add structured server-side logging for settings save failures
- return stable 500 payload: `Failed to save settings`
- add PATCH regression test for save failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/settings/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error handling for a single API endpoint; main risk is reduced client-visible error detail while relying on server logs for debugging.
> 
> **Overview**
> The `PATCH /api/github/capture/settings` endpoint no longer returns raw database error messages on save failures; it now logs the underlying error server-side and responds with a stable `500` payload (`Failed to save settings`).
> 
> Adds a new test covering the failed-save path to ensure the stable error response is preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8c2a9afa7579974f61be4e9769b9c7f08726e52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->