### PR TITLE
refactor: remove individual/company pricing tabs

### DIFF
--- a/packages/web/src/components/Pricing.tsx
+++ b/packages/web/src/components/Pricing.tsx
@@ -10,8 +10,6 @@ import { useUser } from "@/hooks/use-user";
 
 const code = "font-mono text-[0.9em] text-foreground/80 bg-muted px-1.5 py-0.5 rounded";
 
-type Audience = "individuals" | "companies";
-
 interface PricingTier {
   id: string;
   name: string;
@@ -119,8 +117,7 @@ export function Pricing({ user }: { user?: User | null }): React.JSX.Element {
   const { user: sessionUser } = useUser();
   const effectiveUser = sessionUser ?? user ?? null;
   const [isYearly, setIsYearly] = useState(false);
-  const [audience, setAudience] = useState<Audience>("individuals");
-  const visibleTiers = audience === "individuals" ? individualTiers : companyTiers;
+  const visibleTiers = [...individualTiers, ...companyTiers];
 
   return (
     <section id="pricing" className="py-28 border-t border-border relative overflow-hidden">
@@ -139,34 +136,8 @@ export function Pricing({ user }: { user?: User | null }): React.JSX.Element {
             <ScrambleText text="Simple, Transparent Pricing" delayMs={200} />
           </h2>
           <p className="text-muted-foreground max-w-2xl text-base sm:text-lg font-light leading-relaxed">
-            Start with Individual for hosted memory. Move to Team and Growth when your company needs seat billing and metered AI SDK project routing.
+            Start free, upgrade when you need cloud sync, and scale to team billing with metered AI SDK project routing.
           </p>
-        </div>
-
-        {/* Audience Toggle */}
-        <div className="flex justify-center mb-6">
-          <div className="inline-flex items-center gap-1 p-1 bg-background-secondary border border-border rounded-lg">
-            <button
-              onClick={() => setAudience("individuals")}
-              className={`px-4 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
-                audience === "individuals"
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              For Individuals
-            </button>
-            <button
-              onClick={() => setAudience("companies")}
-              className={`px-4 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
-                audience === "companies"
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              For Companies
-            </button>
-          </div>
         </div>
 
         {/* Billing Toggle */}
@@ -202,7 +173,7 @@ export function Pricing({ user }: { user?: User | null }): React.JSX.Element {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-8">
           {visibleTiers.map((tier) => {
             const price = isYearly ? tier.yearlyPrice : tier.monthlyPrice;
             const isCustom = price === "Custom";


### PR DESCRIPTION
## Summary
- remove the audience tab split (`For Individuals` / `For Companies`) from pricing cards
- render a single consolidated pricing view with all plans
- keep monthly/yearly toggle and checkout plan routing behavior unchanged
- update pricing copy to reflect a unified plan progression

## Testing
- pnpm --filter @memories.sh/web typecheck
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/github/capture/settings/route.test.ts'

Closes #140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor of pricing presentation with no changes to checkout URL construction beyond which tiers are displayed together.
> 
> **Overview**
> Consolidates the pricing page into a single view by removing the `For Individuals` / `For Companies` audience tabs and always rendering all tiers together.
> 
> Keeps the monthly/yearly toggle and CTA routing (`/login?next=/app/upgrade`, `/app/upgrade?plan=...`) the same, updates the introductory pricing copy, and adjusts the layout grid to `xl:grid-cols-4` to fit the combined set of plans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c2f8af58b3bd9c5021e755ea3852c967ed11807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->