### PR TITLE
fix: return 500 when invite accept lookup query fails

### DIFF
--- a/packages/web/src/app/api/invites/accept/route.ts
+++ b/packages/web/src/app/api/invites/accept/route.ts
@@ -37,14 +37,16 @@ export async function POST(request: Request): Promise<Response> {
     .gt("expires_at", new Date().toISOString())
     .maybeSingle()
 
-  if (inviteError || !invite) {
-    if (inviteError) {
-      console.error("Invite accept lookup failed", {
-        message: inviteError.message,
-        code: inviteError.code,
-        tokenPrefix: inviteToken.slice(0, 8),
-      })
-    }
+  if (inviteError) {
+    console.error("Invite accept lookup failed", {
+      message: inviteError.message,
+      code: inviteError.code,
+      tokenPrefix: inviteToken.slice(0, 8),
+    })
+    return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
+  }
+
+  if (!invite) {
     return NextResponse.json({ error: "Invalid or expired invite" }, { status: 400 })
   }
 


### PR DESCRIPTION
## Summary
- separate invite lookup query failures from true missing/expired invite results in `POST /api/invites/accept`
- return stable 500 (`Failed to accept invite`) on lookup error
- keep 400 (`Invalid or expired invite`) for truly missing/expired invite
- add regression test for invite lookup failure path

## Testing
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/invites/accept/route.test.ts'
- pnpm --filter @memories.sh/web typecheck

Closes #144

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change to an API route plus a regression test; behavior only changes for database/query failure cases.
> 
> **Overview**
> `POST /api/invites/accept` now treats Supabase invite lookup query errors (`inviteError`) as a server failure, logging details and returning a stable `500 { error: "Failed to accept invite" }` instead of falling through to the missing/expired invite path.
> 
> A new test covers the lookup-failure scenario to ensure it returns 500 and does not proceed to billing/seat provisioning (`addTeamSeat`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fbded19e674f4e1855c3e60c43741cb4ca2188e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->