### PR TITLE
fix: highlight Team pricing card as Popular

### DIFF
--- a/packages/web/src/components/Pricing.tsx
+++ b/packages/web/src/components/Pricing.tsx
@@ -57,7 +57,7 @@ const individualTiers: PricingTier[] = [
       { key: "support", label: "Priority support" },
     ],
     cta: "Choose Individual",
-    highlighted: true,
+    highlighted: false,
     checkoutPlan: "individual",
   },
 ];
@@ -181,10 +181,10 @@ export function Pricing({ user }: { user?: User | null }): React.JSX.Element {
             
             return (
               <div key={tier.name} className={`relative ${tier.highlighted ? "pt-3 -mt-4 mb-[-16px] md:-mt-6 md:mb-[-24px]" : ""}`}>
-                {/* Recommended badge — outside overflow-hidden so it's never clipped */}
+                {/* Popular badge — outside overflow-hidden so it's never clipped */}
                 {tier.highlighted && (
                   <div className="absolute top-0 left-1/2 -translate-x-1/2 px-3 py-0.5 bg-primary text-primary-foreground text-[10px] font-bold uppercase tracking-widest rounded-md z-10">
-                    Recommended
+                    Popular
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- make Team Seat the only highlighted pricing card
- change highlighted badge label from `Recommended` to `Popular`
- keep all existing pricing card ordering and checkout routing behavior unchanged

## Testing
- pnpm --filter @memories.sh/web typecheck

Follow-up to #140.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to pricing card highlighting and badge text; no impact to checkout routing or data handling.
> 
> **Overview**
> Updates the pricing UI so **only** the `Team Seat` tier is visually highlighted, and changes the highlighted badge text from `Recommended` to `Popular`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a808589f1dff69ca1e13c570a9f0cee73383c9b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->