### PR TITLE
fix: carry pricing checkout intent through login and enable billing plan switching

### DIFF
--- a/packages/web/src/app/app/billing/billing-content.tsx
+++ b/packages/web/src/app/app/billing/billing-content.tsx
@@ -84,6 +84,16 @@ const GROWTH_FEATURES = [
   "Usage-based metering",
 ]
 
+function getSwitchPlanTarget(
+  ownerType: "user" | "organization",
+  currentPlan: WorkspacePlan,
+): "individual" | "team" | "growth" {
+  if (ownerType === "organization") {
+    return currentPlan === "growth" ? "team" : "growth"
+  }
+  return currentPlan === "growth" ? "individual" : "growth"
+}
+
 export function BillingContent({
   plan,
   hasStripeCustomer,
@@ -112,6 +122,8 @@ export function BillingContent({
         : PRO_FEATURES
   const tenantOverageProjects = Math.max(0, tenantRouting.totalTenantCount - GROWTH_INCLUDED_PROJECTS_PER_MONTH)
   const tenantProjectedOverage = tenantOverageProjects * GROWTH_OVERAGE_USD_PER_PROJECT
+  const switchPlanTarget = getSwitchPlanTarget(ownerType, plan)
+  const switchPlanHref = `/app/upgrade?plan=${switchPlanTarget}`
 
   async function handleManageBilling() {
     if (!canManageBilling) return
@@ -304,17 +316,28 @@ export function BillingContent({
                   </span>
                 ))}
               </div>
-              {hasStripeCustomer && canManageBilling && (
-                <button
-                  onClick={handleManageBilling}
-                  disabled={loading}
-                  className="flex items-center gap-2 px-4 py-2 bg-muted/30 hover:bg-muted/50 text-sm font-medium transition-colors disabled:opacity-50"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  {loading ? "Loading..." : "Manage Subscription"}
-                </button>
+              {canManageBilling && (
+                <div className="flex flex-wrap items-center gap-3">
+                  {hasStripeCustomer && (
+                    <button
+                      onClick={handleManageBilling}
+                      disabled={loading}
+                      className="flex items-center gap-2 px-4 py-2 bg-muted/30 hover:bg-muted/50 text-sm font-medium transition-colors disabled:opacity-50"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      {loading ? "Loading..." : "Manage Subscription"}
+                    </button>
+                  )}
+                  <Link
+                    href={switchPlanHref}
+                    className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+                  >
+                    <Zap className="h-4 w-4" />
+                    Switch Plan
+                  </Link>
+                </div>
               )}
-              {hasStripeCustomer && !canManageBilling && (
+              {!canManageBilling && (
                 <p className="text-xs text-muted-foreground">
                   Billing changes are restricted to the organization owner.
                 </p>


### PR DESCRIPTION
## Summary
- preserve selected plan + billing intent from pricing cards through login redirects
- add optional checkout auto-start behavior on `/app/upgrade` when intent is present
- allow paid workspaces to access `/app/upgrade` for plan switching
- add visible "Switch Plan" action in billing for paid workspaces that can manage billing

## What changed
- `Pricing.tsx`
  - paid plan CTAs now include `plan`, `billing`, and `checkout=1` intent
  - unauthenticated users now get `/login?next=<encoded-upgrade-intent>`
- `app/app/upgrade/page.tsx`
  - accepts `plan`, `billing`, and `checkout` search params
  - removes paid-plan redirect so plan changes are possible
  - passes initial billing/auto-checkout props into upgrade card
- `app/app/upgrade/upgrade-card.tsx`
  - supports `initialBilling` and `autoCheckout`
  - auto-starts checkout once when explicit checkout intent is present
- `app/app/billing/billing-content.tsx`
  - adds "Switch Plan" CTA for paid/past_due workspaces with billing permissions

## Testing
- pnpm --filter @memories.sh/web typecheck
- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/invites/accept/route.test.ts'

Closes #147
Closes #148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect upgrade/billing navigation and can auto-trigger Stripe checkout, so incorrect query params or state could start the wrong purchase flow, but the scope is limited to client-side routing and UI behavior.
> 
> **Overview**
> Enables **end-to-end “checkout intent” flow** from pricing CTAs through login to `/app/upgrade`, carrying `plan` + `billing` and optionally auto-starting Stripe checkout when `checkout=1` is present.
> 
> Allows paid workspaces to use `/app/upgrade` for **plan switching** (removes paid-plan redirect), adds a **Switch Plan** CTA in the billing page for billing managers, and updates upgrade UI to respect preselected plan/billing and show current workspace status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 279871df12eb33329ea6168d25208f6f97a799ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->