### PR TITLE
feat(web): white-label Turso DB domain URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ NODE_TOKEN=
 # ─── Turso (Cloud Sync) ─────────────────────────────────────────────────────
 TURSO_TOKEN=
 TURSO_PLATFORM_API_TOKEN=
+TURSO_ORG_SLUG=webrenew
+TURSO_DB_DOMAIN_SUFFIX=
 
 # ─── Database ────────────────────────────────────────────────────────────────
 DATABASE_PASSWORD=

--- a/packages/web/src/app/api/db/credentials/route.ts
+++ b/packages/web/src/app/api/db/credentials/route.ts
@@ -4,6 +4,7 @@ import { apiRateLimit, checkRateLimit } from "@/lib/rate-limit"
 import { authenticateRequest } from "@/lib/auth"
 import { resolveActiveMemoryContext } from "@/lib/active-memory-context"
 import { hashMcpApiKey, isValidMcpApiKey } from "@/lib/mcp-api-key"
+import { applyTursoDomainAlias } from "@/lib/turso-domain"
 
 export async function GET(request: NextRequest): Promise<Response> {
   const authHeader = request.headers.get("authorization")
@@ -64,12 +65,14 @@ export async function GET(request: NextRequest): Promise<Response> {
     return NextResponse.json({ error: "Database not provisioned" }, { status: 400 })
   }
 
+  const tursoDbUrl = applyTursoDomainAlias(context.turso_db_url)
+
   // Return both canonical and legacy keys for compatibility with existing clients.
   return NextResponse.json({
-    url: context.turso_db_url,
+    url: tursoDbUrl,
     token: context.turso_db_token,
     dbName: context.turso_db_name,
-    turso_db_url: context.turso_db_url,
+    turso_db_url: tursoDbUrl,
     turso_db_token: context.turso_db_token,
     turso_db_name: context.turso_db_name,
     ownerType: context.ownerType,

--- a/packages/web/src/app/api/db/provision/__tests__/route.test.ts
+++ b/packages/web/src/app/api/db/provision/__tests__/route.test.ts
@@ -128,8 +128,9 @@ describe("/api/db/provision", () => {
       url: "libsql://demo.turso.io",
       provisioned: true,
     })
-    expect(mockCreateDatabase).toHaveBeenCalledWith("webrenew")
-    expect(mockCreateDatabaseToken).toHaveBeenCalledWith("webrenew", "db-demo")
+    const tursoOrg = process.env.TURSO_ORG_SLUG ?? "webrenew"
+    expect(mockCreateDatabase).toHaveBeenCalledWith(tursoOrg)
+    expect(mockCreateDatabaseToken).toHaveBeenCalledWith(tursoOrg, "db-demo")
     expect(mockInitSchema).toHaveBeenCalledWith("libsql://demo.turso.io", "token-123")
     expect(mockOrgUpdate).toHaveBeenCalledWith({
       turso_db_url: "libsql://demo.turso.io",

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -197,6 +197,27 @@ export function getTursoOrgSlug(): string {
   return process.env.TURSO_ORG_SLUG ?? "webrenew"
 }
 
+/**
+ * Optional custom hostname suffix for white-labeling Turso DB URLs.
+ * Example: TURSO_DB_DOMAIN_SUFFIX=db.memories.sh
+ * - libsql://my-db.turso.io -> libsql://my-db.db.memories.sh
+ */
+export function getTursoDbDomainSuffix(): string | null {
+  const raw = envValue("TURSO_DB_DOMAIN_SUFFIX")
+  if (!raw) return null
+
+  const normalized = raw
+    .replace(/^libsql:\/\//i, "")
+    .replace(/^https?:\/\//i, "")
+    .replace(/^\*\./, "")
+    .replace(/\/.*$/, "")
+    .replace(/\.$/, "")
+    .trim()
+    .toLowerCase()
+
+  return normalized.length > 0 ? normalized : null
+}
+
 export function getTursoPlatformApiToken(): string {
   const token = process.env.TURSO_PLATFORM_API_TOKEN
   if (!token) throw new Error("TURSO_PLATFORM_API_TOKEN not set")

--- a/packages/web/src/lib/memory-service/scope.ts
+++ b/packages/web/src/lib/memory-service/scope.ts
@@ -7,6 +7,7 @@ import {
   hasTursoPlatformApiToken,
   shouldAutoProvisionTenants,
 } from "@/lib/env"
+import { buildLibsqlUrlFromHostname } from "@/lib/turso-domain"
 import {
   enforceSdkProjectProvisionLimit,
   recordGrowthProjectMeterEvent,
@@ -102,10 +103,11 @@ async function autoProvisionTenantDatabase(params: {
   const tursoOrg = getTursoOrgSlug()
   const db = await createDatabase(tursoOrg)
   const token = await createDatabaseToken(tursoOrg, db.name)
-  const url = `libsql://${db.hostname}`
+  const canonicalUrl = `libsql://${db.hostname}`
+  const url = buildLibsqlUrlFromHostname(db.hostname)
 
   await delay(3000)
-  await initSchema(url, token)
+  await initSchema(canonicalUrl, token)
 
   const now = new Date().toISOString()
   const metadata = {

--- a/packages/web/src/lib/turso-domain.test.ts
+++ b/packages/web/src/lib/turso-domain.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { applyTursoDomainAlias, buildLibsqlUrlFromHostname } from "./turso-domain"
+
+const originalDomainSuffix = process.env.TURSO_DB_DOMAIN_SUFFIX
+
+afterEach(() => {
+  if (originalDomainSuffix === undefined) {
+    delete process.env.TURSO_DB_DOMAIN_SUFFIX
+  } else {
+    process.env.TURSO_DB_DOMAIN_SUFFIX = originalDomainSuffix
+  }
+})
+
+describe("turso domain aliasing", () => {
+  it("keeps default turso hostname when no override is set", () => {
+    delete process.env.TURSO_DB_DOMAIN_SUFFIX
+
+    expect(buildLibsqlUrlFromHostname("demo.turso.io")).toBe("libsql://demo.turso.io")
+  })
+
+  it("rewrites turso hostnames when a white-label suffix is configured", () => {
+    process.env.TURSO_DB_DOMAIN_SUFFIX = "db.memories.sh"
+
+    expect(buildLibsqlUrlFromHostname("demo.turso.io")).toBe("libsql://demo.db.memories.sh")
+    expect(applyTursoDomainAlias("libsql://tenant-a.turso.io")).toBe(
+      "libsql://tenant-a.db.memories.sh"
+    )
+  })
+
+  it("keeps non-turso domains unchanged", () => {
+    process.env.TURSO_DB_DOMAIN_SUFFIX = "db.memories.sh"
+
+    expect(buildLibsqlUrlFromHostname("example.internal")).toBe("libsql://example.internal")
+    expect(applyTursoDomainAlias("libsql://custom.db.memories.sh")).toBe(
+      "libsql://custom.db.memories.sh"
+    )
+  })
+})

--- a/packages/web/src/lib/turso-domain.ts
+++ b/packages/web/src/lib/turso-domain.ts
@@ -1,0 +1,59 @@
+import { getTursoDbDomainSuffix } from "@/lib/env"
+
+const LIBSQL_PREFIX = "libsql://"
+const TURSO_PUBLIC_SUFFIX = ".turso.io"
+
+function extractHostname(value: string): string {
+  const stripped = value
+    .trim()
+    .replace(/^libsql:\/\//i, "")
+    .replace(/^https?:\/\//i, "")
+
+  const hostname = stripped.split("/")[0]?.trim().replace(/\.$/, "")
+  if (!hostname) {
+    throw new Error("Invalid Turso hostname")
+  }
+
+  return hostname
+}
+
+function applySuffixOverride(hostname: string, overrideSuffix: string): string {
+  const lowerHost = hostname.toLowerCase()
+  const lowerSuffix = overrideSuffix.toLowerCase()
+
+  if (lowerHost === lowerSuffix || lowerHost.endsWith(`.${lowerSuffix}`)) {
+    return hostname
+  }
+
+  if (lowerHost.endsWith(TURSO_PUBLIC_SUFFIX)) {
+    return `${hostname.slice(0, hostname.length - TURSO_PUBLIC_SUFFIX.length)}.${overrideSuffix}`
+  }
+
+  return hostname
+}
+
+/**
+ * Build a libsql URL from Turso hostname and optionally apply white-label suffix.
+ */
+export function buildLibsqlUrlFromHostname(hostname: string): string {
+  const normalizedHost = extractHostname(hostname)
+  const overrideSuffix = getTursoDbDomainSuffix()
+  const finalHost = overrideSuffix
+    ? applySuffixOverride(normalizedHost, overrideSuffix)
+    : normalizedHost
+
+  return `${LIBSQL_PREFIX}${finalHost}`
+}
+
+/**
+ * Rewrite existing libsql URLs to optional white-label domain suffix.
+ */
+export function applyTursoDomainAlias(url: string): string {
+  const normalized = url.trim()
+  if (!normalized.toLowerCase().startsWith(LIBSQL_PREFIX)) {
+    return normalized
+  }
+
+  const hostname = extractHostname(normalized)
+  return buildLibsqlUrlFromHostname(hostname)
+}


### PR DESCRIPTION
## Summary
- add optional Turso white-label host support via `TURSO_DB_DOMAIN_SUFFIX`
- centralize URL construction/aliasing in `packages/web/src/lib/turso-domain.ts`
- apply the helper in all Turso provision paths:
  - `/api/db/provision`
  - `/api/mcp/tenants` (provision + attach + list output)
  - SDK auto-provision in `memory-service/scope.ts`
- remove hardcoded Turso org from `/api/db/provision` and use `getTursoOrgSlug()`
- rewrite `/api/db/credentials` response URLs through the alias helper so existing stored `.turso.io` URLs can be white-labeled in API output
- document new env settings in `.env.example`

## Validation
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm --filter @memories.sh/web exec vitest run src/lib/turso-domain.test.ts src/app/api/db/credentials/__tests__/route.test.ts src/app/api/db/provision/__tests__/route.test.ts src/app/api/mcp/tenants/__tests__/route.test.ts`

## Notes
- schema initialization still uses the canonical Turso hostname immediately after DB creation, while persisted/returned URLs use the optional white-label alias

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple DB provisioning/credential endpoints and changes the URLs persisted/returned to clients based on environment configuration. Misconfiguration of `TURSO_DB_DOMAIN_SUFFIX` could produce unusable connection URLs even though schema init still targets the canonical host.
> 
> **Overview**
> Adds optional *white-labeling* for Turso `libsql://` hostnames via new `TURSO_DB_DOMAIN_SUFFIX`, with centralized helpers in `lib/turso-domain.ts` and parsing/normalization in `lib/env.ts`.
> 
> Updates `/api/db/credentials`, `/api/db/provision`, legacy `/api/mcp/tenants`, and SDK auto-provisioning to return/persist rewritten URLs while still initializing schemas against the canonical `*.turso.io` hostname; `/api/db/provision` also stops hardcoding the Turso org and uses `getTursoOrgSlug()`.
> 
> Adds unit tests covering domain rewriting behavior and updates env documentation in `.env.example`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5bcfcc2fe1e79555c2078328d2de65ead69fa9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->