### PR TITLE
fix(web): make MCP API keys discoverable in dashboard

### DIFF
--- a/packages/web/content/docs/integrations/mcp.mdx
+++ b/packages/web/content/docs/integrations/mcp.mdx
@@ -15,7 +15,7 @@ For SaaS integrations, prefer SDK endpoints (`/api/sdk/v1/*`). Use this MCP path
 
 ## Get Your API Key
 
-Get your API key from the [dashboard](/app). This key connects your AI tools to your personal memory database.
+Get your API key from the [API Keys dashboard page](/app/api-keys). This key connects your AI tools to your personal memory database.
 
 ---
 
@@ -41,7 +41,7 @@ Add to `.cursor/mcp.json` in your project (or `~/.cursor/mcp.json` globally):
 ```
 
 <Callout type="warn">
-**Replace** `REPLACE_WITH_YOUR_API_KEY` with your actual API key from the [dashboard](/app).
+**Replace** `REPLACE_WITH_YOUR_API_KEY` with your actual API key from the [API Keys dashboard page](/app/api-keys).
 </Callout>
 
 <div id="claude-code" />

--- a/packages/web/content/docs/integrations/v0.mdx
+++ b/packages/web/content/docs/integrations/v0.mdx
@@ -9,7 +9,7 @@ description: Connect v0 to your memories.sh account via MCP.
 
 ### 1. Get Your API Key
 
-1. Sign up or log in at [memories.sh/app](https://memories.sh/app)
+1. Sign up or log in at [memories.sh/app/api-keys](https://memories.sh/app/api-keys)
 2. In the dashboard, find the **MCP API Key** section
 3. Click **Generate API Key**
 4. Copy the key (you won't see it again)
@@ -95,7 +95,7 @@ Now your memories are available both in v0 and your local CLI/IDE tools.
 
 ## Managing Your API Key
 
-In the [dashboard](https://memories.sh/app):
+In the [API Keys dashboard page](https://memories.sh/app/api-keys):
 
 - **Regenerate** — Create a new key (invalidates the old one)
 - **Revoke** — Delete the key entirely

--- a/packages/web/content/docs/mcp-server/index.mdx
+++ b/packages/web/content/docs/mcp-server/index.mdx
@@ -27,7 +27,7 @@ For signed-up users, the easiest way to connect is via our hosted MCP endpoint. 
 
 ### 1. Generate an API Key
 
-Get your API key from the [dashboard](/app) or run:
+Get your API key from the [API Keys dashboard page](/app/api-keys) or run:
 
 ```bash
 memories login

--- a/packages/web/src/app/app/api-keys/page.tsx
+++ b/packages/web/src/app/app/api-keys/page.tsx
@@ -1,6 +1,29 @@
 import React from "react"
-import { redirect } from "next/navigation"
+import Link from "next/link"
+import { ApiKeySection } from "@/components/dashboard/ApiKeySection"
+
+export const metadata = {
+  title: "API Keys",
+}
 
 export default function ApiKeysPage(): React.JSX.Element {
-  redirect("/app/sdk-projects")
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">API Keys</h1>
+        <p className="text-sm text-muted-foreground mt-1 max-w-3xl">
+          Generate and rotate `mem_` keys for hosted MCP clients and SDK runtime calls.
+        </p>
+        <p className="text-xs text-muted-foreground mt-2 max-w-3xl">
+          Need tenant routing and project database mappings? Use{" "}
+          <Link href="/app/sdk-projects" className="text-primary hover:text-primary/80">
+            AI SDK Projects
+          </Link>
+          .
+        </p>
+      </div>
+
+      <ApiKeySection />
+    </div>
+  )
 }

--- a/packages/web/src/components/MCPInstallButtons.tsx
+++ b/packages/web/src/components/MCPInstallButtons.tsx
@@ -99,7 +99,7 @@ export function MCPInstallButtons(): React.JSX.Element {
         <h3 className="text-lg font-semibold mb-2">Quick Install</h3>
         <p className="text-sm text-muted-foreground mb-6">
           Add memories.sh to your AI assistant. You&apos;ll need an{" "}
-          <a href="/app" className="underline hover:text-foreground">
+          <a href="/app/api-keys" className="underline hover:text-foreground">
             API key
           </a>{" "}
           from the dashboard.
@@ -161,7 +161,7 @@ export function MCPInstallButtons(): React.JSX.Element {
             <div className="mt-3 flex items-center justify-between gap-3">
               <p className="text-xs text-muted-foreground">
                 <strong>Replace</strong> <code className="bg-muted px-1 rounded">{API_KEY_PLACEHOLDER}</code> with your{" "}
-                <a href="/app/sdk-projects" className="underline hover:text-foreground">API key</a>.
+                <a href="/app/api-keys" className="underline hover:text-foreground">API key</a>.
               </p>
               <a
                 href={CURSOR_INSTALL_URL}

--- a/packages/web/src/components/dashboard/DashboardShell.tsx
+++ b/packages/web/src/components/dashboard/DashboardShell.tsx
@@ -39,6 +39,7 @@ interface WorkspaceSummary {
 
 const navItems = [
   { href: "/app", label: "Memories", icon: Database },
+  { href: "/app/api-keys", label: "API Keys", icon: KeyRound },
   { href: "/app/sdk-projects", label: "SDK Projects", icon: KeyRound },
   { href: "/app/stats", label: "Stats", icon: BarChart3 },
   { href: "/app/graph-explorer", label: "Graph", icon: Network },


### PR DESCRIPTION
## Summary
- add a dedicated `/app/api-keys` dashboard page with `ApiKeySection`
- add an explicit `API Keys` sidebar nav item
- update MCP setup links/components/docs to point directly to `/app/api-keys`

## Why
Pro users need a clear in-dashboard path to generate/copy the MCP API key.

Closes #153

## Validation
- `cd packages/web && pnpm exec eslint src/app/app/api-keys/page.tsx src/components/dashboard/DashboardShell.tsx src/components/MCPInstallButtons.tsx`