### PR TITLE
Add explicit org-owner mappings for memory repo routing

### DIFF
--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -81,6 +81,14 @@ Graph data respects the same routing model as memories:
 
 When workspace repo-routing mode is `auto`, org repos route to org workspace memory and personal repos route to personal workspace memory by default.
 
+You can also set explicit owner mappings in **Settings → Repo Workspace Routing** to handle org-owned repos that do not match your workspace slug.
+
+Examples:
+
+- `projectId: "github.com/jane/side-project"` with no mapping routes to personal memory.
+- `projectId: "github.com/webrenew/memories"` routes to the `webrenew` org workspace when you are a member.
+- Mapping `acme-platform -> org_acme` routes `projectId: "github.com/acme-platform/backend"` to the selected `org_acme` workspace even if the slug differs.
+
 ## Dashboard Explorer Mapping
 
 The dashboard graph explorer (`Memory Graph` section) reads from `/api/graph/explore` and renders:

--- a/packages/web/src/app/app/settings/page.tsx
+++ b/packages/web/src/app/app/settings/page.tsx
@@ -12,11 +12,32 @@ export default async function SettingsPage(): Promise<React.JSX.Element | null> 
 
   if (!user) return null
 
-  const { data: profile } = await supabase
-    .from("users")
-    .select("*")
-    .eq("id", user.id)
-    .single()
+  const [profileResult, membershipsResult] = await Promise.all([
+    supabase
+      .from("users")
+      .select("*")
+      .eq("id", user.id)
+      .single(),
+    supabase
+      .from("org_members")
+      .select("role, organizations(id, name, slug)")
+      .eq("user_id", user.id),
+  ])
+
+  const profile = profileResult.data
+  const organizations = (membershipsResult.data ?? [])
+    .filter(
+      (row): row is typeof row & { organizations: { id: string; name: string; slug: string } } =>
+        row.organizations !== null &&
+        typeof row.organizations === "object" &&
+        !Array.isArray(row.organizations)
+    )
+    .map((row) => ({
+      id: row.organizations.id,
+      name: row.organizations.name,
+      slug: row.organizations.slug,
+      role: row.role as "owner" | "admin" | "member",
+    }))
 
   return (
     <div>
@@ -35,6 +56,21 @@ export default async function SettingsPage(): Promise<React.JSX.Element | null> 
           plan: profile?.plan ?? "free",
           embedding_model: profile?.embedding_model ?? null,
           repo_workspace_routing_mode: profile?.repo_workspace_routing_mode ?? "auto",
+          repo_owner_org_mappings: Array.isArray(profile?.repo_owner_org_mappings)
+            ? profile.repo_owner_org_mappings
+                .filter(
+                  (
+                    mapping: unknown
+                  ): mapping is { owner: string; org_id: string } =>
+                    mapping !== null &&
+                    typeof mapping === "object" &&
+                    "owner" in mapping &&
+                    typeof (mapping as { owner?: unknown }).owner === "string" &&
+                    "org_id" in mapping &&
+                    typeof (mapping as { org_id?: unknown }).org_id === "string"
+                )
+            : [],
+          organizations,
           auth_providers: (user.identities || [])
             .map((identity) => identity.provider)
             .filter((provider): provider is string => Boolean(provider)),

--- a/packages/web/src/lib/__tests__/validations.test.ts
+++ b/packages/web/src/lib/__tests__/validations.test.ts
@@ -371,6 +371,39 @@ describe("updateUserSchema", () => {
     expect(result.success).toBe(false)
   })
 
+  it("should accept valid repo owner org mappings", () => {
+    const result = updateUserSchema.safeParse({
+      repo_owner_org_mappings: [
+        { owner: "WebRenew", org_id: "org-1" },
+        { owner: "@acme", org_id: "org-2" },
+      ],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.repo_owner_org_mappings).toEqual([
+        { owner: "webrenew", org_id: "org-1" },
+        { owner: "acme", org_id: "org-2" },
+      ])
+    }
+  })
+
+  it("should reject invalid repo owner values", () => {
+    const result = updateUserSchema.safeParse({
+      repo_owner_org_mappings: [{ owner: "not valid owner", org_id: "org-1" }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("should reject duplicate repo owner mappings", () => {
+    const result = updateUserSchema.safeParse({
+      repo_owner_org_mappings: [
+        { owner: "acme", org_id: "org-1" },
+        { owner: "ACME", org_id: "org-2" },
+      ],
+    })
+    expect(result.success).toBe(false)
+  })
+
   it("should reject name over 200 chars", () => {
     const result = updateUserSchema.safeParse({ name: "a".repeat(201) })
     expect(result.success).toBe(false)

--- a/packages/web/src/lib/active-memory-context.ts
+++ b/packages/web/src/lib/active-memory-context.ts
@@ -1,3 +1,5 @@
+import { normalizeGithubOwner, parseGithubOwnerFromProjectId } from "@/lib/github-owner"
+
 type RepoWorkspaceRoutingMode = "auto" | "active_workspace"
 
 interface UserMemoryRow {
@@ -8,6 +10,7 @@ interface UserMemoryRow {
   turso_db_token: string | null
   turso_db_name: string | null
   repo_workspace_routing_mode?: RepoWorkspaceRoutingMode | null
+  repo_owner_org_mappings?: unknown
 }
 
 type OrgSubscriptionStatus = "active" | "past_due" | "cancelled" | null
@@ -26,6 +29,28 @@ interface OrganizationMemoryRow {
 interface OrgMembershipRow {
   role: "owner" | "admin" | "member"
 }
+
+type MemorySupabaseClient = {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (column: string, value: string) => {
+        eq: (column: string, value: string) => {
+          single: () => Promise<{ data: unknown; error: unknown }>
+        }
+        single: () => Promise<{ data: unknown; error: unknown }>
+      }
+    }
+  }
+}
+
+const ORGANIZATION_MEMORY_COLUMNS =
+  "id, slug, plan, subscription_status, stripe_subscription_id, turso_db_url, turso_db_token, turso_db_name"
+
+const USER_MEMORY_SELECT_VARIANTS = [
+  "id, current_org_id, plan, turso_db_url, turso_db_token, turso_db_name, repo_workspace_routing_mode, repo_owner_org_mappings",
+  "id, current_org_id, plan, turso_db_url, turso_db_token, turso_db_name, repo_workspace_routing_mode",
+  "id, current_org_id, plan, turso_db_url, turso_db_token, turso_db_name",
+] as const
 
 export interface ActiveMemoryContext {
   ownerType: "user" | "organization"
@@ -104,21 +129,6 @@ function normalizeRoutingMode(value: string | null | undefined): RepoWorkspaceRo
   return value === "active_workspace" ? "active_workspace" : "auto"
 }
 
-function parseGithubOwner(projectId: string | null | undefined): string | null {
-  const raw = projectId?.trim()
-  if (!raw) return null
-
-  const normalized = raw
-    .replace(/^https?:\/\//i, "")
-    .replace(/^git@github\.com:/i, "github.com/")
-    .replace(/\.git$/i, "")
-    .toLowerCase()
-
-  const parts = normalized.split("/").filter(Boolean)
-  if (parts.length < 3 || parts[0] !== "github.com") return null
-  return parts[1] || null
-}
-
 function isMissingColumnError(error: unknown, columnName: string): boolean {
   const message =
     typeof error === "object" && error !== null && "message" in error
@@ -132,44 +142,128 @@ function isMissingColumnError(error: unknown, columnName: string): boolean {
   )
 }
 
+function isMissingAnyColumnError(error: unknown, columnNames: string[]): boolean {
+  return columnNames.some((columnName) => isMissingColumnError(error, columnName))
+}
+
+async function loadUserMemoryRow(
+  supabase: MemorySupabaseClient,
+  userId: string
+): Promise<{ data: UserMemoryRow | null; error: unknown }> {
+  for (const selectColumns of USER_MEMORY_SELECT_VARIANTS) {
+    const query = await supabase
+      .from("users")
+      .select(selectColumns)
+      .eq("id", userId)
+      .single()
+
+    if (!query.error || !isMissingAnyColumnError(query.error, ["repo_owner_org_mappings", "repo_workspace_routing_mode"])) {
+      return {
+        data: query.data as UserMemoryRow | null,
+        error: query.error,
+      }
+    }
+  }
+
+  return {
+    data: null,
+    error: { message: "Failed to load user profile" },
+  }
+}
+
+function parseRepoOwnerMappings(value: unknown): Map<string, string> {
+  if (!Array.isArray(value)) {
+    return new Map()
+  }
+
+  const mappings = new Map<string, string>()
+
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") {
+      continue
+    }
+
+    const ownerRaw = "owner" in entry ? (entry as { owner?: unknown }).owner : null
+    const orgIdRaw = "org_id" in entry ? (entry as { org_id?: unknown }).org_id : null
+
+    const owner = normalizeGithubOwner(typeof ownerRaw === "string" ? ownerRaw : null)
+    const orgId = typeof orgIdRaw === "string" ? orgIdRaw.trim() : ""
+
+    if (!owner || !orgId || mappings.has(owner)) {
+      continue
+    }
+
+    mappings.set(owner, orgId)
+  }
+
+  return mappings
+}
+
+function toOrganizationContext(
+  org: OrganizationMemoryRow,
+  membership: OrgMembershipRow,
+  userId: string,
+  userPlan: string | null
+): ActiveMemoryContext {
+  return {
+    ownerType: "organization",
+    userId,
+    orgId: org.id,
+    orgRole: membership.role,
+    plan: resolveOrganizationPlan(org, userPlan),
+    turso_db_url: org.turso_db_url,
+    turso_db_token: org.turso_db_token,
+    turso_db_name: org.turso_db_name,
+  }
+}
+
+async function resolveAutoRoutedOrganizationContext(
+  supabase: MemorySupabaseClient,
+  userId: string,
+  userPlan: string | null,
+  lookup: { column: "id" | "slug"; value: string }
+): Promise<ActiveMemoryContext | null> {
+  const { data: orgData, error: orgError } = await supabase
+    .from("organizations")
+    .select(ORGANIZATION_MEMORY_COLUMNS)
+    .eq(lookup.column, lookup.value)
+    .single()
+
+  if (orgError || !orgData) {
+    return null
+  }
+
+  const org = orgData as OrganizationMemoryRow
+  const { data: membershipData, error: membershipError } = await supabase
+    .from("org_members")
+    .select("role")
+    .eq("org_id", org.id)
+    .eq("user_id", userId)
+    .single()
+
+  if (membershipError || !membershipData) {
+    return null
+  }
+
+  // Auto mode should never strand requests on an org without Turso credentials.
+  if (!org.turso_db_url || !org.turso_db_token) {
+    return null
+  }
+
+  return toOrganizationContext(org, membershipData as OrgMembershipRow, userId, userPlan)
+}
+
 export async function resolveActiveMemoryContext(
   client: unknown,
   userId: string,
   options: ResolveActiveMemoryContextOptions = {}
 ): Promise<ActiveMemoryContext | null> {
-  const supabase = client as {
-    from: (table: string) => {
-      select: (columns: string) => {
-        eq: (column: string, value: string) => {
-          eq: (column: string, value: string) => {
-            single: () => Promise<{ data: unknown; error: unknown }>
-          }
-          single: () => Promise<{ data: unknown; error: unknown }>
-        }
-      }
-    }
-  }
+  const supabase = client as MemorySupabaseClient
 
   const fallbackToUserWithoutOrgCredentials =
     options.fallbackToUserWithoutOrgCredentials ?? false
 
-  let { data: userData, error: userError } = await supabase
-    .from("users")
-    .select(
-      "id, current_org_id, plan, turso_db_url, turso_db_token, turso_db_name, repo_workspace_routing_mode"
-    )
-    .eq("id", userId)
-    .single()
-
-  if (userError && isMissingColumnError(userError, "repo_workspace_routing_mode")) {
-    const fallback = await supabase
-      .from("users")
-      .select("id, current_org_id, plan, turso_db_url, turso_db_token, turso_db_name")
-      .eq("id", userId)
-      .single()
-    userData = fallback.data
-    userError = fallback.error
-  }
+  const { data: userData, error: userError } = await loadUserMemoryRow(supabase, userId)
 
   if (userError || !userData) {
     return null
@@ -178,56 +272,43 @@ export async function resolveActiveMemoryContext(
   const user = userData as UserMemoryRow
   const userContext = toUserContext(user)
   const routingMode = normalizeRoutingMode(user.repo_workspace_routing_mode)
-  const projectOwner = parseGithubOwner(options.projectId)
+  const projectOwner = parseGithubOwnerFromProjectId(options.projectId)
 
   // Default behavior: repo-scoped memories route by GitHub owner.
-  // If owner matches an org slug this user belongs to, route to org workspace.
+  // Explicit owner mappings take precedence, then slug matching is used.
   // Otherwise route to personal workspace.
   if (routingMode === "auto" && options.projectId?.trim()) {
     if (!projectOwner) {
       return userContext
     }
 
-    const { data: orgBySlugData, error: orgBySlugError } = await supabase
-      .from("organizations")
-      .select(
-        "id, slug, plan, subscription_status, stripe_subscription_id, turso_db_url, turso_db_token, turso_db_name"
+    const ownerMappings = parseRepoOwnerMappings(user.repo_owner_org_mappings)
+    const mappedOrgId = ownerMappings.get(projectOwner)
+    if (mappedOrgId) {
+      const mappedContext = await resolveAutoRoutedOrganizationContext(
+        supabase,
+        userId,
+        user.plan,
+        { column: "id", value: mappedOrgId }
       )
-      .eq("slug", projectOwner)
-      .single()
 
-    if (orgBySlugError || !orgBySlugData) {
-      return userContext
+      if (mappedContext) {
+        return mappedContext
+      }
     }
 
-    const orgBySlug = orgBySlugData as OrganizationMemoryRow
-    const { data: membershipBySlugData, error: membershipBySlugError } = await supabase
-      .from("org_members")
-      .select("role")
-      .eq("org_id", orgBySlug.id)
-      .eq("user_id", userId)
-      .single()
-
-    if (membershipBySlugError || !membershipBySlugData) {
-      return userContext
-    }
-
-    // Auto mode should never strand requests on an org without Turso credentials.
-    if (!orgBySlug.turso_db_url || !orgBySlug.turso_db_token) {
-      return userContext
-    }
-
-    const membership = membershipBySlugData as OrgMembershipRow
-    return {
-      ownerType: "organization",
+    const slugContext = await resolveAutoRoutedOrganizationContext(
+      supabase,
       userId,
-      orgId: orgBySlug.id,
-      orgRole: membership.role,
-      plan: resolveOrganizationPlan(orgBySlug, user.plan),
-      turso_db_url: orgBySlug.turso_db_url,
-      turso_db_token: orgBySlug.turso_db_token,
-      turso_db_name: orgBySlug.turso_db_name,
+      user.plan,
+      { column: "slug", value: projectOwner }
+    )
+
+    if (slugContext) {
+      return slugContext
     }
+
+    return userContext
   }
 
   if (!user.current_org_id) {
@@ -247,9 +328,7 @@ export async function resolveActiveMemoryContext(
 
   const { data: orgData, error: orgError } = await supabase
     .from("organizations")
-    .select(
-      "id, slug, plan, subscription_status, stripe_subscription_id, turso_db_url, turso_db_token, turso_db_name"
-    )
+    .select(ORGANIZATION_MEMORY_COLUMNS)
     .eq("id", user.current_org_id)
     .single()
 
@@ -265,14 +344,5 @@ export async function resolveActiveMemoryContext(
     return userContext
   }
 
-  return {
-    ownerType: "organization",
-    userId,
-    orgId: org.id,
-    orgRole: membership.role,
-    plan: resolveOrganizationPlan(org, user.plan),
-    turso_db_url: org.turso_db_url,
-    turso_db_token: org.turso_db_token,
-    turso_db_name: org.turso_db_name,
-  }
+  return toOrganizationContext(org, membership, userId, user.plan)
 }

--- a/packages/web/src/lib/github-owner.ts
+++ b/packages/web/src/lib/github-owner.ts
@@ -1,0 +1,46 @@
+const GITHUB_OWNER_PATTERN = /^[a-z\d](?:[a-z\d-]{0,38})$/i
+
+function normalizeGithubPath(raw: string): string {
+  return raw
+    .replace(/^https?:\/\//i, "")
+    .replace(/^git@github\.com:/i, "github.com/")
+    .replace(/\.git$/i, "")
+    .toLowerCase()
+}
+
+export function normalizeGithubOwner(value: string | null | undefined): string | null {
+  const raw = value?.trim()
+  if (!raw) return null
+
+  const normalized = normalizeGithubPath(raw.replace(/^@/, ""))
+  const parts = normalized.split("/").filter(Boolean)
+
+  let owner: string | null = null
+  if (parts.length === 1) {
+    owner = parts[0] ?? null
+  } else if (parts[0] === "github.com") {
+    owner = parts[1] ?? null
+  } else {
+    owner = parts[0] ?? null
+  }
+
+  if (!owner || !GITHUB_OWNER_PATTERN.test(owner)) {
+    return null
+  }
+
+  return owner
+}
+
+export function parseGithubOwnerFromProjectId(projectId: string | null | undefined): string | null {
+  const raw = projectId?.trim()
+  if (!raw) return null
+
+  const normalized = normalizeGithubPath(raw)
+  const parts = normalized.split("/").filter(Boolean)
+
+  if (parts.length < 3 || parts[0] !== "github.com") {
+    return null
+  }
+
+  return normalizeGithubOwner(parts[1] ?? null)
+}

--- a/supabase/migrations/20260216190000_add_repo_owner_org_mappings.sql
+++ b/supabase/migrations/20260216190000_add_repo_owner_org_mappings.sql
@@ -1,0 +1,16 @@
+ALTER TABLE public.users
+ADD COLUMN IF NOT EXISTS repo_owner_org_mappings JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'users_repo_owner_org_mappings_is_array'
+      AND conrelid = 'public.users'::regclass
+  ) THEN
+    ALTER TABLE public.users
+      ADD CONSTRAINT users_repo_owner_org_mappings_is_array
+      CHECK (jsonb_typeof(repo_owner_org_mappings) = 'array');
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add `users.repo_owner_org_mappings` (jsonb) migration for explicit GitHub owner -> org mappings
- extend settings profile API and validation schema to read/write owner mappings with safe fallback for older DB schemas
- add Repo Workspace Routing UI controls to add/remove owner mappings for paid users
- update active memory context auto-routing to prioritize explicit owner mappings before slug fallback
- document personal vs org routing examples and mapping behavior

## Testing
- cd packages/web && pnpm exec vitest run src/lib/__tests__/validations.test.ts src/lib/__tests__/active-memory-context.test.ts src/app/api/user/__tests__/route.test.ts
- cd packages/web && pnpm exec eslint src/lib/validations.ts src/lib/active-memory-context.ts src/lib/github-owner.ts src/lib/__tests__/validations.test.ts src/lib/__tests__/active-memory-context.test.ts src/app/api/user/route.ts src/app/api/user/__tests__/route.test.ts src/app/app/settings/page.tsx src/app/app/settings/settings-form.tsx
- cd packages/web && pnpm exec tsc --noEmit

Closes #157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace routing behavior and persists new routing configuration in the user profile, which can affect where reads/writes are directed if mappings or migrations are misconfigured.
> 
> **Overview**
> Adds support for explicit GitHub owner-to-organization workspace routing to override slug-based auto routing.
> 
> Introduces a `users.repo_owner_org_mappings` JSONB column (with array constraint) and extends `/api/user` GET/PATCH + Zod validation to read/write mappings with backwards-compatible column fallbacks and a `503` when migrations are missing.
> 
> Updates `resolveActiveMemoryContext` auto-routing to prefer explicit mappings before slug lookup, adds shared GitHub owner normalization/parsing helpers, and exposes a paid-plan Settings UI to manage mappings (including org membership fetching, client-side validation, and save payload updates). Docs and tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 828642025f8454a07de54b55421c7ae08a23d4b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->