### PR TITLE
Default tenant DB assignment to auto; add tenant override management endpoint

### DIFF
--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -576,7 +576,7 @@ describe("MemoriesClient", () => {
         )
       }
 
-      if (url === "https://example.com/api/sdk/v1/management/tenants" && method === "GET") {
+      if (url === "https://example.com/api/sdk/v1/management/tenant-overrides" && method === "GET") {
         return new Response(
           JSON.stringify({
             ok: true,
@@ -598,7 +598,7 @@ describe("MemoriesClient", () => {
         )
       }
 
-      if (url === "https://example.com/api/sdk/v1/management/tenants" && method === "POST") {
+      if (url === "https://example.com/api/sdk/v1/management/tenant-overrides" && method === "POST") {
         const body = JSON.parse((init?.body as string) ?? "{}") as { tenantId?: string; mode?: string }
         expect(body.tenantId).toBe("tenant-b")
         expect(body.mode).toBe("provision")
@@ -623,7 +623,7 @@ describe("MemoriesClient", () => {
         )
       }
 
-      if (url === "https://example.com/api/sdk/v1/management/tenants?tenantId=tenant-b" && method === "DELETE") {
+      if (url === "https://example.com/api/sdk/v1/management/tenant-overrides?tenantId=tenant-b" && method === "DELETE") {
         return new Response(
           JSON.stringify({
             ok: true,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -509,13 +509,13 @@ export class MemoriesClient {
 
     tenants: {
       list: async (): Promise<ManagementTenantListResult> => {
-        const endpoint = "/api/sdk/v1/management/tenants"
+        const endpoint = "/api/sdk/v1/management/tenant-overrides"
         const result = await this.callSdkRequest(endpoint, { method: "GET" })
         return parseStructuredData(managementTenantListSchema, endpoint, result.structured)
       },
 
       upsert: async (input: ManagementTenantUpsertInput): Promise<ManagementTenantUpsertResult> => {
-        const endpoint = "/api/sdk/v1/management/tenants"
+        const endpoint = "/api/sdk/v1/management/tenant-overrides"
         const result = await this.callSdkRequest(endpoint, {
           method: "POST",
           body: {
@@ -531,7 +531,7 @@ export class MemoriesClient {
       },
 
       disable: async (tenantId: string): Promise<ManagementTenantDisableResult> => {
-        const endpoint = "/api/sdk/v1/management/tenants"
+        const endpoint = "/api/sdk/v1/management/tenant-overrides"
         const normalizedTenantId = tenantId?.trim()
         if (!normalizedTenantId) {
           throw new MemoriesClientError("tenantId is required", {

--- a/packages/web/content/docs/mcp-server/tenant-routing.mdx
+++ b/packages/web/content/docs/mcp-server/tenant-routing.mdx
@@ -11,13 +11,13 @@ Use this page when you are routing MCP client traffic.
 </Callout>
 
 <Callout>
-If you are integrating through the SDK HTTP surface, use `/api/sdk/v1/management/tenants`. The MCP route names below are legacy-compatible aliases.
+If you are integrating through the SDK HTTP surface, use `/api/sdk/v1/management/tenant-overrides`. The routes below remain available as legacy aliases.
 </Callout>
 
 ## How Routing Works
 
 1. Use your API key as usual (`Authorization: Bearer mem_...`).
-2. Configure per-tenant database mappings with `/api/sdk/v1/management/tenants` (or legacy `/api/mcp/tenants`).
+2. Configure per-tenant database mappings with `/api/sdk/v1/management/tenant-overrides` (or legacy `/api/sdk/v1/management/tenants` / `/api/mcp/tenants`).
 3. Include `tenant_id` in tool arguments (`get_context`, `add_memory`, etc.).
 4. The server resolves `(api_key_hash, tenant_id)` to the mapped Turso database.
 
@@ -35,7 +35,7 @@ Scope mapping:
 
 ### List Tenants
 
-`GET /api/sdk/v1/management/tenants`
+`GET /api/sdk/v1/management/tenant-overrides`
 
 Legacy alias: `/api/mcp/tenants`
 
@@ -43,7 +43,7 @@ Returns all AI SDK Project mappings for your active API key.
 
 ### Create or Update Tenant
 
-`POST /api/sdk/v1/management/tenants`
+`POST /api/sdk/v1/management/tenant-overrides`
 
 Legacy alias: `/api/mcp/tenants`
 
@@ -84,7 +84,7 @@ Example (`attach`):
 
 ### Delete Tenant
 
-`DELETE /api/sdk/v1/management/tenants?tenantId=...`
+`DELETE /api/sdk/v1/management/tenant-overrides?tenantId=...`
 
 Legacy alias: `/api/mcp/tenants`
 

--- a/packages/web/content/docs/sdk/client.mdx
+++ b/packages/web/content/docs/sdk/client.mdx
@@ -272,7 +272,7 @@ const context = await client.context.get({
 When you manage API keys or AI SDK Projects (`tenantId` mappings) programmatically, prefer the SDK management endpoints:
 
 - `/api/sdk/v1/management/keys`
-- `/api/sdk/v1/management/tenants`
+- `/api/sdk/v1/management/tenant-overrides`
 
 The core client exposes these directly:
 
@@ -301,7 +301,7 @@ const disabledProject = await client.management.tenants.disable("acme-prod")
 void [keyStatus, rotatedKey, revoked, sdkProjects, upsertedProject, disabledProject]
 ```
 
-Legacy MCP management routes (`/api/mcp/key`, `/api/mcp/tenants`) remain available for backward compatibility.
+Legacy management routes (`/api/sdk/v1/management/tenants`, `/api/mcp/tenants`, `/api/mcp/key`) remain available for backward compatibility.
 
 For single-user apps, `tenantId` can be your app environment or workspace id:
 

--- a/packages/web/content/docs/sdk/endpoint-contract.mdx
+++ b/packages/web/content/docs/sdk/endpoint-contract.mdx
@@ -39,7 +39,8 @@ https://memories.sh
 | Graph | `/api/sdk/v1/graph/trace` | `POST` | Bearer API key (`mem_...`) |
 | Graph | `/api/sdk/v1/graph/rollout` | `GET`, `POST`, `PATCH` | Bearer API key (`mem_...`) |
 | Management | `/api/sdk/v1/management/keys` | `GET`, `POST`, `DELETE` | Legacy management auth (session/legacy path) |
-| Management | `/api/sdk/v1/management/tenants` | `GET`, `POST`, `DELETE` | Legacy management auth (session/legacy path) |
+| Management | `/api/sdk/v1/management/tenant-overrides` | `GET`, `POST`, `DELETE` | Bearer API key (`mem_...`) or session |
+| Management | `/api/sdk/v1/management/tenants` | `GET`, `POST`, `DELETE` | Legacy compatibility wrapper |
 
 Legacy aliases are still available:
 
@@ -59,9 +60,8 @@ Content-Type: application/json
 
 ### Management endpoints
 
-`/api/sdk/v1/management/*` is currently a compatibility wrapper over legacy management routes and uses the same auth path as those endpoints.
-
-If you are doing headless server-to-server management calls, validate auth flow in your environment before rollout.
+Use `/api/sdk/v1/management/tenant-overrides` for headless server-to-server tenant routing management.
+`/api/sdk/v1/management/tenants` remains available as a legacy compatibility wrapper.
 
 ## Canonical Response Envelope
 
@@ -586,7 +586,8 @@ Response `data`:
 
 ## Management Endpoint Contracts
 
-`/api/sdk/v1/management/*` currently wraps legacy `/api/mcp/*` responses into SDK envelopes.
+`/api/sdk/v1/management/tenant-overrides` is the primary tenant override API.
+`/api/sdk/v1/management/tenants` and `/api/mcp/tenants` remain legacy-compatible aliases.
 
 ### `GET|POST|DELETE /api/sdk/v1/management/keys`
 
@@ -602,7 +603,7 @@ Response `data`:
 }
 ```
 
-### `GET|POST|DELETE /api/sdk/v1/management/tenants`
+### `GET|POST|DELETE /api/sdk/v1/management/tenant-overrides`
 
 - `GET`: list AI SDK Projects (`tenantId` mappings)
 - `POST`: upsert AI SDK Project mapping
@@ -635,7 +636,7 @@ Attach mode request:
 `DELETE` example:
 
 ```http
-DELETE /api/sdk/v1/management/tenants?tenantId=acme-prod
+DELETE /api/sdk/v1/management/tenant-overrides?tenantId=acme-prod
 ```
 
 ## cURL Quick Reference

--- a/packages/web/content/docs/sdk/index.mdx
+++ b/packages/web/content/docs/sdk/index.mdx
@@ -47,7 +47,8 @@ Start with [AI SDK Projects](/docs/sdk/projects) if you want the dashboard-first
 
 1. Open **Dashboard → AI SDK Projects**.
 2. Generate a `mem_...` API key.
-3. Create your first project (`tenantId`) by attaching an existing Turso DB or provisioning a new one.
+3. Use trusted backend-derived `tenantId` values. Databases auto-provision on first use when enabled.
+4. Configure tenant overrides only if you need explicit DB attachment/provisioning control.
 
 ### Install
 

--- a/packages/web/content/docs/sdk/projects.mdx
+++ b/packages/web/content/docs/sdk/projects.mdx
@@ -12,7 +12,7 @@ Use MCP routing only when you are serving MCP-native clients.
 
 ## What is an AI SDK Project?
 
-In the dashboard, an **AI SDK Project** is a `tenantId` mapping to an isolated memory database.
+In the dashboard, an **AI SDK Project** is a `tenantId` boundary that routes to an isolated memory database.
 
 - One project per customer workspace, org, environment, or app surface
 - Works for solo devs and teams
@@ -22,10 +22,9 @@ In the dashboard, an **AI SDK Project** is a `tenantId` mapping to an isolated m
 
 1. Open **Dashboard → AI SDK Projects**.
 2. Generate a `mem_...` API key.
-3. Create your first project:
-   - **Attach Existing DB** (recommended): map an existing Turso database.
-   - **Provision New Project DB**: create a new Turso DB from the dashboard.
-4. Use that `tenantId` from your backend when calling memories.
+3. Use backend-derived `tenantId` values in SDK requests.
+4. Runtime provisions or resolves tenant DBs automatically on first use (when server provisioning is enabled).
+5. Use **Tenant Overrides** only for explicit DB attachment/provisioning control.
 
 ## Scope Cheat Sheet
 

--- a/packages/web/src/app/api/mcp/tenants/__tests__/route.test.ts
+++ b/packages/web/src/app/api/mcp/tenants/__tests__/route.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/lib/sdk-project-billing", () => ({
 import { DELETE, GET, POST } from "../route"
 
 describe("/api/mcp/tenants", () => {
-  const expectedLink = '</api/sdk/v1/management/tenants>; rel="successor-version"'
+  const expectedLink = '</api/sdk/v1/management/tenant-overrides>; rel="successor-version"'
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/packages/web/src/app/api/mcp/tenants/route.ts
+++ b/packages/web/src/app/api/mcp/tenants/route.ts
@@ -15,7 +15,7 @@ import {
 
 const TURSO_ORG = getTursoOrgSlug()
 const LEGACY_ENDPOINT = "/api/mcp/tenants"
-const SUCCESSOR_ENDPOINT = "/api/sdk/v1/management/tenants"
+const SUCCESSOR_ENDPOINT = "/api/sdk/v1/management/tenant-overrides"
 const LEGACY_SUNSET = "Tue, 30 Jun 2026 00:00:00 GMT"
 
 const tenantIdSchema = z.string().trim().min(1, "tenantId is required").max(120, "tenantId is too long")

--- a/packages/web/src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockAuthenticateRequest,
+  mockCheckRateLimit,
+  mockGetApiKey,
+  mockAuthenticateApiKey,
+  mockAdminFrom,
+  mockEnforceSdkProjectProvisionLimit,
+  mockCountActiveProjectsForBillingContext,
+  mockRecordGrowthProjectMeterEvent,
+} = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockGetApiKey: vi.fn(),
+  mockAuthenticateApiKey: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockEnforceSdkProjectProvisionLimit: vi.fn(),
+  mockCountActiveProjectsForBillingContext: vi.fn(),
+  mockRecordGrowthProjectMeterEvent: vi.fn(),
+}))
+
+vi.mock("@/lib/auth", () => ({
+  authenticateRequest: mockAuthenticateRequest,
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiRateLimit: { limit: vi.fn() },
+  strictRateLimit: { limit: vi.fn() },
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockAdminFrom,
+  })),
+}))
+
+vi.mock("@/lib/sdk-project-billing", () => ({
+  enforceSdkProjectProvisionLimit: mockEnforceSdkProjectProvisionLimit,
+  countActiveProjectsForBillingContext: mockCountActiveProjectsForBillingContext,
+  recordGrowthProjectMeterEvent: mockRecordGrowthProjectMeterEvent,
+}))
+
+vi.mock("@/lib/sdk-api/runtime", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sdk-api/runtime")>("@/lib/sdk-api/runtime")
+  return {
+    ...actual,
+    getApiKey: mockGetApiKey,
+    authenticateApiKey: mockAuthenticateApiKey,
+  }
+})
+
+vi.mock("@/lib/turso", () => ({
+  createDatabase: vi.fn(),
+  createDatabaseToken: vi.fn(),
+  initSchema: vi.fn(),
+}))
+
+vi.mock("@libsql/client", () => ({
+  createClient: vi.fn(() => ({
+    execute: vi.fn(),
+  })),
+}))
+
+import { DELETE, GET, POST } from "../route"
+
+describe("/api/sdk/v1/management/tenant-overrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockGetApiKey.mockReturnValue("mem_test_key")
+    mockAuthenticateApiKey.mockResolvedValue({
+      userId: "user-1",
+      apiKeyHash: "hash_123",
+    })
+    mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "owner@example.com" })
+    mockCheckRateLimit.mockResolvedValue(null)
+
+    mockEnforceSdkProjectProvisionLimit.mockResolvedValue({
+      ok: true,
+      billing: {
+        plan: "growth",
+        ownerType: "user",
+        ownerUserId: "user-1",
+        orgId: null,
+        stripeCustomerId: "cus_123",
+        includedProjects: 500,
+        overageUsdPerProject: 0.05,
+        maxProjectsPerMonth: null,
+      },
+      activeProjectCount: 1,
+    })
+    mockCountActiveProjectsForBillingContext.mockResolvedValue(1)
+    mockRecordGrowthProjectMeterEvent.mockResolvedValue(undefined)
+  })
+
+  it("lists tenant overrides with sdk envelope", async () => {
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "sdk_tenant_databases") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    tenant_id: "tenant-a",
+                    turso_db_url: "libsql://tenant-a.turso.io",
+                    turso_db_name: "tenant-a",
+                    status: "ready",
+                    metadata: {},
+                    created_at: "2026-02-11T00:00:00.000Z",
+                    updated_at: "2026-02-11T00:00:00.000Z",
+                    last_verified_at: "2026-02-11T00:00:00.000Z",
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+      return {}
+    })
+
+    const response = await GET(new Request("https://example.com", { method: "GET" }) as never)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body.ok).toBe(true)
+    expect(body.meta.endpoint).toBe("/api/sdk/v1/management/tenant-overrides")
+    expect(body.data.count).toBe(1)
+    expect(body.data.tenantDatabases[0].tenantId).toBe("tenant-a")
+  })
+
+  it("returns unauthorized envelope when session auth fails and no api key is present", async () => {
+    mockGetApiKey.mockReturnValue(null)
+    mockAuthenticateRequest.mockResolvedValue(null)
+
+    const response = await GET(new Request("https://example.com", { method: "GET" }) as never)
+    expect(response.status).toBe(401)
+    const body = await response.json()
+
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("UNAUTHORIZED")
+  })
+
+  it("returns invalid request envelope for malformed POST payload", async () => {
+    const response = await POST(
+      new Request("https://example.com", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }) as never
+    )
+    expect(response.status).toBe(400)
+    const body = await response.json()
+
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("INVALID_REQUEST")
+  })
+
+  it("returns growth gating envelope when billing check denies provisioning", async () => {
+    mockEnforceSdkProjectProvisionLimit.mockResolvedValue({
+      ok: false,
+      status: 403,
+      code: "GROWTH_PLAN_REQUIRED",
+      message: "AI SDK project routing requires the Growth plan.",
+    })
+
+    const response = await POST(
+      new Request("https://example.com", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tenantId: "tenant-b", mode: "provision" }),
+      }) as never
+    )
+    expect(response.status).toBe(403)
+    const body = await response.json()
+
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("GROWTH_PLAN_REQUIRED")
+  })
+
+  it("returns invalid request envelope when DELETE misses tenantId", async () => {
+    const response = await DELETE(new Request("https://example.com", { method: "DELETE" }) as never)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("INVALID_REQUEST")
+  })
+})

--- a/packages/web/src/app/api/sdk/v1/management/tenant-overrides/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/tenant-overrides/route.ts
@@ -1,0 +1,508 @@
+import { createClient as createTurso } from "@libsql/client"
+import { setTimeout as delay } from "node:timers/promises"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { authenticateRequest } from "@/lib/auth"
+import { getTursoOrgSlug } from "@/lib/env"
+import { apiError } from "@/lib/memory-service/tools"
+import { apiRateLimit, checkRateLimit, strictRateLimit } from "@/lib/rate-limit"
+import {
+  authenticateApiKey,
+  errorResponse,
+  getApiKey,
+  invalidRequestResponse,
+  successResponse,
+} from "@/lib/sdk-api/runtime"
+import {
+  countActiveProjectsForBillingContext,
+  enforceSdkProjectProvisionLimit,
+  recordGrowthProjectMeterEvent,
+} from "@/lib/sdk-project-billing"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { createDatabase, createDatabaseToken, initSchema } from "@/lib/turso"
+
+const ENDPOINT = "/api/sdk/v1/management/tenant-overrides"
+const TURSO_ORG = getTursoOrgSlug()
+
+const tenantIdSchema = z.string().trim().min(1, "tenantId is required").max(120, "tenantId is too long")
+
+const tenantCreateSchema = z.object({
+  tenantId: tenantIdSchema,
+  mode: z.enum(["provision", "attach"]).default("provision"),
+  tursoDbUrl: z.string().trim().optional(),
+  tursoDbToken: z.string().trim().optional(),
+  tursoDbName: z.string().trim().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+
+type TenantRow = {
+  tenant_id: string
+  turso_db_url: string
+  turso_db_name: string | null
+  status: string
+  metadata: Record<string, unknown> | null
+  created_at: string
+  updated_at: string
+  last_verified_at: string | null
+}
+
+type ManagementIdentity = {
+  userId: string
+  apiKeyHash: string
+  authMode: "api_key" | "session"
+}
+
+function mapTenantRow(row: TenantRow) {
+  return {
+    tenantId: row.tenant_id,
+    tursoDbUrl: row.turso_db_url,
+    tursoDbName: row.turso_db_name,
+    status: row.status,
+    metadata: row.metadata ?? {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastVerifiedAt: row.last_verified_at,
+  }
+}
+
+function errorTypeForStatus(status: number): "auth_error" | "validation_error" | "rate_limit_error" | "internal_error" | "not_found_error" {
+  if (status === 400) return "validation_error"
+  if (status === 401 || status === 403) return "auth_error"
+  if (status === 404) return "not_found_error"
+  if (status === 429) return "rate_limit_error"
+  return "internal_error"
+}
+
+function rateLimitEnvelopeResponse(requestId: string, source: NextResponse): NextResponse {
+  const retryAfter = Number(source.headers.get("Retry-After") ?? "60")
+  const response = errorResponse(
+    ENDPOINT,
+    requestId,
+    apiError({
+      type: "rate_limit_error",
+      code: "RATE_LIMITED",
+      message: "Too many requests",
+      status: 429,
+      retryable: true,
+      details: {
+        retryAfterSeconds: Number.isFinite(retryAfter) ? retryAfter : 60,
+      },
+    })
+  )
+
+  const rateHeaders = ["Retry-After", "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"]
+  for (const headerName of rateHeaders) {
+    const value = source.headers.get(headerName)
+    if (value) response.headers.set(headerName, value)
+  }
+
+  return response
+}
+
+async function resolveSessionIdentity(request: NextRequest, requestId: string, method: "GET" | "POST" | "DELETE"): Promise<ManagementIdentity | NextResponse> {
+  const auth = await authenticateRequest(request)
+  if (!auth) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "auth_error",
+        code: "UNAUTHORIZED",
+        message: "Unauthorized",
+        status: 401,
+        retryable: false,
+      })
+    )
+  }
+
+  const limiter = method === "POST" ? strictRateLimit : apiRateLimit
+  const rateLimited = await checkRateLimit(limiter, auth.userId)
+  if (rateLimited) {
+    return rateLimitEnvelopeResponse(requestId, rateLimited)
+  }
+
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from("users")
+    .select("mcp_api_key_hash, mcp_api_key_expires_at")
+    .eq("id", auth.userId)
+    .single()
+
+  if (error) {
+    console.error("Failed to load API key metadata for tenant override management:", error)
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "API_KEY_METADATA_LOOKUP_FAILED",
+        message: "Failed to load API key metadata",
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+
+  if (!data?.mcp_api_key_hash) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "validation_error",
+        code: "MISSING_API_KEY",
+        message: "Generate an API key before configuring tenant overrides",
+        status: 400,
+        retryable: false,
+      })
+    )
+  }
+
+  if (!data.mcp_api_key_expires_at || new Date(data.mcp_api_key_expires_at).getTime() <= Date.now()) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "auth_error",
+        code: "API_KEY_EXPIRED",
+        message: "API key expired. Generate a new key before configuring tenant overrides.",
+        status: 401,
+        retryable: false,
+      })
+    )
+  }
+
+  return {
+    userId: auth.userId,
+    apiKeyHash: data.mcp_api_key_hash as string,
+    authMode: "session",
+  }
+}
+
+async function resolveManagementIdentity(
+  request: NextRequest,
+  requestId: string,
+  method: "GET" | "POST" | "DELETE"
+): Promise<ManagementIdentity | NextResponse> {
+  const apiKey = getApiKey(request)
+  if (apiKey) {
+    const auth = await authenticateApiKey(apiKey, ENDPOINT, requestId)
+    if (auth instanceof NextResponse) {
+      return auth
+    }
+
+    if (method === "POST") {
+      const strictLimited = await checkRateLimit(strictRateLimit, auth.userId)
+      if (strictLimited) {
+        return rateLimitEnvelopeResponse(requestId, strictLimited)
+      }
+    }
+
+    return {
+      userId: auth.userId,
+      apiKeyHash: auth.apiKeyHash,
+      authMode: "api_key",
+    }
+  }
+
+  return resolveSessionIdentity(request, requestId, method)
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+  const identity = await resolveManagementIdentity(request, requestId, "GET")
+  if (identity instanceof NextResponse) return identity
+
+  const admin = createAdminClient()
+  const billingState = await enforceSdkProjectProvisionLimit({
+    admin,
+    userId: identity.userId,
+    apiKeyHash: identity.apiKeyHash,
+  })
+
+  const billingSummary =
+    billingState.ok
+      ? {
+          plan: billingState.billing.plan,
+          includedProjects: billingState.billing.includedProjects,
+          overageUsdPerProject: billingState.billing.overageUsdPerProject,
+          maxProjectsPerMonth: billingState.billing.maxProjectsPerMonth,
+          activeProjects: billingState.activeProjectCount,
+        }
+      : null
+
+  const { data, error } = await admin
+    .from("sdk_tenant_databases")
+    .select("tenant_id, turso_db_url, turso_db_name, status, metadata, created_at, updated_at, last_verified_at")
+    .eq("api_key_hash", identity.apiKeyHash)
+    .order("created_at", { ascending: true })
+
+  if (error) {
+    console.error("Failed to list tenant overrides:", error)
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "TENANT_OVERRIDE_LIST_FAILED",
+        message: "Failed to list tenant overrides",
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+
+  const rows = (data ?? []) as TenantRow[]
+  return successResponse(ENDPOINT, requestId, {
+    tenantDatabases: rows.map(mapTenantRow),
+    count: rows.length,
+    billing: billingSummary,
+  })
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+  const identity = await resolveManagementIdentity(request, requestId, "POST")
+  if (identity instanceof NextResponse) return identity
+
+  const parsed = tenantCreateSchema.safeParse(await request.json().catch(() => ({})))
+  if (!parsed.success) {
+    return invalidRequestResponse(
+      ENDPOINT,
+      requestId,
+      parsed.error.issues[0]?.message ?? "Invalid request payload"
+    )
+  }
+
+  const admin = createAdminClient()
+  const billingState = await enforceSdkProjectProvisionLimit({
+    admin,
+    userId: identity.userId,
+    apiKeyHash: identity.apiKeyHash,
+  })
+
+  if (!billingState.ok) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: errorTypeForStatus(billingState.status),
+        code: billingState.code,
+        message: billingState.message,
+        status: billingState.status,
+        retryable: billingState.status === 429 || billingState.status >= 500,
+      })
+    )
+  }
+
+  const { tenantId, mode, metadata } = parsed.data
+  const { data: existing, error: existingError } = await admin
+    .from("sdk_tenant_databases")
+    .select("tenant_id, turso_db_url, turso_db_name, status, metadata, created_at, updated_at, last_verified_at")
+    .eq("api_key_hash", identity.apiKeyHash)
+    .eq("tenant_id", tenantId)
+    .maybeSingle()
+
+  if (existingError) {
+    console.error("Failed to check existing tenant override:", existingError)
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "TENANT_OVERRIDE_LOOKUP_FAILED",
+        message: "Failed to configure tenant override",
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+
+  if (mode === "provision" && existing?.status === "ready" && existing.turso_db_url) {
+    return successResponse(ENDPOINT, requestId, {
+      tenantDatabase: mapTenantRow(existing as TenantRow),
+      provisioned: false,
+      mode,
+    })
+  }
+
+  let tursoDbUrl: string
+  let tursoDbToken: string
+  let tursoDbName: string | null = parsed.data.tursoDbName ?? null
+
+  try {
+    if (mode === "attach") {
+      const attachUrl = parsed.data.tursoDbUrl
+      const attachToken = parsed.data.tursoDbToken
+      if (!attachUrl?.startsWith("libsql://")) {
+        return invalidRequestResponse(
+          ENDPOINT,
+          requestId,
+          "tursoDbUrl must start with libsql:// when mode is attach"
+        )
+      }
+
+      if (!attachToken || attachToken.length === 0) {
+        return invalidRequestResponse(ENDPOINT, requestId, "tursoDbToken is required when mode is attach")
+      }
+
+      const attachedClient = createTurso({
+        url: attachUrl,
+        authToken: attachToken,
+      })
+      await attachedClient.execute("SELECT 1")
+
+      tursoDbUrl = attachUrl
+      tursoDbToken = attachToken
+      if (!tursoDbName) {
+        tursoDbName = attachUrl.replace("libsql://", "")
+      }
+    } else {
+      const db = await createDatabase(TURSO_ORG)
+      const token = await createDatabaseToken(TURSO_ORG, db.name)
+      const url = `libsql://${db.hostname}`
+
+      await delay(3000)
+      await initSchema(url, token)
+
+      tursoDbUrl = url
+      tursoDbToken = token
+      tursoDbName = db.name
+    }
+  } catch (error) {
+    console.error("Tenant override setup failed:", error)
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "TENANT_OVERRIDE_SETUP_FAILED",
+        message: "Failed to setup tenant database override",
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+
+  const now = new Date().toISOString()
+  const payload = {
+    api_key_hash: identity.apiKeyHash,
+    tenant_id: tenantId,
+    turso_db_url: tursoDbUrl,
+    turso_db_token: tursoDbToken,
+    turso_db_name: tursoDbName,
+    status: "ready",
+    metadata: metadata ?? {},
+    created_by_user_id: identity.userId,
+    billing_owner_type: billingState.billing.ownerType,
+    billing_owner_user_id: billingState.billing.ownerUserId,
+    billing_org_id: billingState.billing.orgId,
+    stripe_customer_id: billingState.billing.stripeCustomerId,
+    updated_at: now,
+    last_verified_at: now,
+  }
+
+  const { data: saved, error: saveError } = await admin
+    .from("sdk_tenant_databases")
+    .upsert(payload, { onConflict: "api_key_hash,tenant_id" })
+    .select("tenant_id, turso_db_url, turso_db_name, status, metadata, created_at, updated_at, last_verified_at")
+    .single()
+
+  if (saveError || !saved) {
+    console.error("Failed to save tenant override mapping:", saveError)
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "TENANT_OVERRIDE_SAVE_FAILED",
+        message: "Failed to save tenant database override",
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+
+  await recordGrowthProjectMeterEvent({
+    admin,
+    billing: billingState.billing,
+    apiKeyHash: identity.apiKeyHash,
+    tenantId,
+  })
+
+  const activeProjects = await countActiveProjectsForBillingContext(
+    admin,
+    identity.apiKeyHash,
+    billingState.billing.stripeCustomerId
+  )
+
+  return successResponse(ENDPOINT, requestId, {
+    tenantDatabase: mapTenantRow(saved as TenantRow),
+    provisioned: true,
+    mode,
+    billing: {
+      plan: billingState.billing.plan,
+      includedProjects: billingState.billing.includedProjects,
+      overageUsdPerProject: billingState.billing.overageUsdPerProject,
+      maxProjectsPerMonth: billingState.billing.maxProjectsPerMonth,
+      activeProjects,
+    },
+  })
+}
+
+export async function DELETE(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+  const identity = await resolveManagementIdentity(request, requestId, "DELETE")
+  if (identity instanceof NextResponse) return identity
+
+  const url = new URL(request.url)
+  const parsedTenantId = tenantIdSchema.safeParse(url.searchParams.get("tenantId"))
+  if (!parsedTenantId.success) {
+    return invalidRequestResponse(ENDPOINT, requestId, "tenantId is required")
+  }
+
+  const admin = createAdminClient()
+  const now = new Date().toISOString()
+  const { data, error } = await admin
+    .from("sdk_tenant_databases")
+    .update({ status: "disabled", updated_at: now })
+    .eq("api_key_hash", identity.apiKeyHash)
+    .eq("tenant_id", parsedTenantId.data)
+    .select("tenant_id, status, updated_at")
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to disable tenant override:", error)
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "TENANT_OVERRIDE_DISABLE_FAILED",
+        message: "Failed to disable tenant override",
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+
+  if (!data) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "not_found_error",
+        code: "TENANT_OVERRIDE_NOT_FOUND",
+        message: "Tenant override not found",
+        status: 404,
+        retryable: false,
+      })
+    )
+  }
+
+  return successResponse(ENDPOINT, requestId, {
+    ok: true,
+    tenantId: data.tenant_id,
+    status: data.status,
+    updatedAt: data.updated_at,
+  })
+}

--- a/packages/web/src/app/app/api-keys/page.tsx
+++ b/packages/web/src/app/app/api-keys/page.tsx
@@ -23,7 +23,7 @@ export default async function ApiKeysPage(): Promise<React.JSX.Element> {
           Generate and rotate `mem_` keys for hosted MCP clients and SDK runtime calls.
         </p>
         <p className="text-xs text-muted-foreground mt-2 max-w-3xl">
-          Need tenant routing and project database mappings? Use{" "}
+          Need tenant routing and optional database overrides? Use{" "}
           <Link href="/app/sdk-projects" className="text-primary hover:text-primary/80">
             AI SDK Projects
           </Link>

--- a/packages/web/src/app/app/billing/billing-content.tsx
+++ b/packages/web/src/app/app/billing/billing-content.tsx
@@ -480,6 +480,9 @@ export function BillingContent({
           <p className="text-muted-foreground">
             Routes SDK traffic by <code className="text-foreground">tenantId</code> to isolated Turso databases.
           </p>
+          <p className="text-xs text-muted-foreground">
+            Tenant databases auto-route on first use. Manual overrides are optional for advanced control.
+          </p>
           {plan === "growth" ? (
             <p className="text-xs text-emerald-300/90">
               Includes {GROWTH_INCLUDED_PROJECTS_PER_MONTH.toLocaleString()} projects per month, then $

--- a/packages/web/src/app/app/sdk-projects/page.tsx
+++ b/packages/web/src/app/app/sdk-projects/page.tsx
@@ -41,12 +41,15 @@ export default async function SdkProjectsPage(): Promise<React.JSX.Element> {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">AI SDK Projects</h1>
         <p className="text-sm text-muted-foreground mt-1 max-w-3xl">
-          The entry point for SaaS integrations. Create API keys, provision project databases, and map the right
-          scope model for your app.
+          The entry point for SaaS integrations. Create API keys, use trusted `tenantId`/`userId` scopes, and let
+          tenant databases route automatically on first use.
         </p>
         <p className="text-xs text-muted-foreground mt-2 max-w-3xl">
           Growth billing includes 500 AI SDK projects per month, then usage is metered at $0.05 per additional
           project.
+        </p>
+        <p className="text-xs text-muted-foreground mt-2 max-w-3xl">
+          Advanced tenant DB overrides are optional and intended for migration, sharding, or existing Turso fleets.
         </p>
         <p className="text-xs text-muted-foreground mt-2 max-w-3xl">
           If your app only uses SDK endpoints (`/api/sdk/v1/*`), you do not need MCP multitenancy.

--- a/packages/web/src/components/dashboard/ApiKeySection.tsx
+++ b/packages/web/src/components/dashboard/ApiKeySection.tsx
@@ -267,10 +267,10 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
         <div className="p-4 border-b border-border">
           <div className="flex items-center gap-2">
             <Key className="h-4 w-4 text-primary" />
-            <h3 className="font-semibold">Step 1: API Key</h3>
+            <h3 className="font-semibold">API Key</h3>
           </div>
           <p className="text-sm text-muted-foreground mt-1">
-            Generate a `mem_` key for SDK runtime calls and MCP clients.
+            Generate a `mem_` key for SDK runtime calls and MCP clients. Tenant databases auto-route by `tenantId`.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- switch AI SDK tenant UX to **auto by default** and position manual DB mapping as an advanced override flow
- add new management endpoint: `/api/sdk/v1/management/tenant-overrides`
  - supports bearer API key auth (`mem_...`) for headless server-to-server management
  - supports dashboard session auth fallback
  - preserves Growth gating, metering, and typed SDK response envelopes
- update SDK core client management tenant operations to use the new endpoint
- update docs and legacy successor links to point at the new override endpoint

## Why
This removes unnecessary setup friction for SaaS customers by relying on first-use auto-routing/provisioning, while still providing explicit override CRUD when customers need custom DB assignment.

## Changes
- New endpoint + tests:
  - `packages/web/src/app/api/sdk/v1/management/tenant-overrides/route.ts`
  - `packages/web/src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts`
- UI/copy updates to make tenant routing automatic-first:
  - `packages/web/src/components/dashboard/TenantDatabaseMappingsSection.tsx`
  - `packages/web/src/components/dashboard/ApiKeySection.tsx`
  - `packages/web/src/app/app/sdk-projects/page.tsx`
  - `packages/web/src/app/app/api-keys/page.tsx`
  - `packages/web/src/app/app/billing/billing-content.tsx`
- SDK core management client path update:
  - `packages/core/src/client.ts`
  - `packages/core/src/__tests__/client.test.ts`
- Docs + legacy successor header update:
  - `packages/web/content/docs/sdk/client.mdx`
  - `packages/web/content/docs/sdk/endpoint-contract.mdx`
  - `packages/web/content/docs/sdk/index.mdx`
  - `packages/web/content/docs/sdk/projects.mdx`
  - `packages/web/content/docs/mcp-server/tenant-routing.mdx`
  - `packages/web/src/app/api/mcp/tenants/route.ts`
  - `packages/web/src/app/api/mcp/tenants/__tests__/route.test.ts`

## Validation
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm --filter @memories.sh/web test:sdk-contracts`
- `pnpm --filter @memories.sh/web exec vitest run src/app/api/mcp/tenants/__tests__/route.test.ts src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts`
- `pnpm --filter @memories.sh/core test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new authenticated management surface that can provision/attach and disable tenant databases, touching auth, rate limiting, billing gates, and infrastructure-creation flows. Errors or auth regressions could impact tenant routing management or allow unintended DB operations.
> 
> **Overview**
> **Adds a new management API** at `/api/sdk/v1/management/tenant-overrides` (with tests) to list/upsert/disable tenant DB overrides using SDK response envelopes, supporting **Bearer API key auth for headless calls** with session fallback, plus rate limiting, Growth plan gating/metering, and Turso provision/attach flows.
> 
> **Moves clients and UX to the new override model:** the core `MemoriesClient.management.tenants.*` endpoints and tests now call `tenant-overrides`; the dashboard tenant mapping section is reworded/restructured to emphasize *automatic tenant routing by default* and treat overrides as advanced controls (removing prior “spend control”/ack gating UI and defaulting to `attach`). Legacy MCP and `/api/sdk/v1/management/tenants` remain as compatibility layers, with docs and successor links updated to point to the new endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2ca2c0673e9c932c7a52cddb3d6bfbe6721e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->