### PR TITLE
feat(web): add OpenClaw landing page, resources, and agent runbook

### DIFF
--- a/packages/web/public/openclaw/llms.txt
+++ b/packages/web/public/openclaw/llms.txt
@@ -1,0 +1,188 @@
+# memories.sh x OpenClaw (llms.txt)
+
+> Comprehensive, agent-readable runbook for using memories.sh to stabilize OpenClaw memory and workspace behavior.
+
+Last updated: 2026-02-18
+
+## What this is
+
+This file is a canonical guide for AI agents and automation scripts.
+Use it when setting up or maintaining memories.sh with OpenClaw.
+
+Primary objective:
+- Keep OpenClaw workspace instructions, memory files, and skills synchronized from memories.sh so behavior remains consistent across sessions, machines, and tools.
+
+## Why use memories.sh with OpenClaw
+
+OpenClaw uses a workspace contract (not a single prompt file). That contract can drift over time when edited manually.
+
+memories.sh solves this by:
+
+1. Durable memory source
+- Rules, decisions, facts, notes, and skills live in a searchable memory store.
+
+2. Workspace-first synchronization
+- Generate and apply OpenClaw workspace artifacts from memory, instead of hand-editing each file.
+
+3. Cross-agent portability
+- Reuse the same memory base across OpenClaw, Claude Code, Cursor, Windsurf, and other integrations.
+
+4. Repeatable operations
+- A deterministic command sequence for first setup and ongoing refresh.
+
+## How it works (high-level flow)
+
+1. OpenClaw creates or initializes workspace structure (`openclaw onboard`).
+2. memories.sh generates workspace-facing artifacts from memory (`AGENTS.md`, skills).
+3. Workspace files are synced using `memories files ingest/apply`.
+4. OpenClaw runtime reads the updated workspace contract.
+
+## Canonical links
+
+- OpenClaw landing page: https://memories.sh/openclaw
+- OpenClaw resource guide: https://memories.sh/openclaw/resources
+- memories.sh OpenClaw integration docs: https://memories.sh/docs/integrations/openclaw
+- memories.sh file sync docs: https://memories.sh/docs/cli/files
+- OpenClaw official install docs: https://docs.openclaw.ai/install/index
+- OpenClaw onboarding docs: https://docs.openclaw.ai/start/onboarding
+- OpenClaw workspace concept: https://docs.openclaw.ai/concepts/agent-workspace
+
+## Installation and setup paths
+
+### Path A: First-time setup (recommended)
+
+Use this when OpenClaw and memories are not fully configured yet.
+
+```bash
+# 1) Install memories CLI
+pnpm add -g @memories.sh/cli
+
+# 2) Initialize OpenClaw workspace
+openclaw onboard
+
+# 3) Move to your project
+cd your-project
+
+# 4) Initialize memories in project
+memories init
+
+# 5) Generate OpenClaw AGENTS workspace file
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+
+# 6) Generate skills from memories
+memories generate agents
+
+# 7) Ensure OpenClaw skills directory exists
+mkdir -p ~/.openclaw/workspace/skills
+
+# 8) Copy generated skills into OpenClaw workspace
+if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi
+
+# 9) Ingest workspace files (include runtime config)
+memories files ingest --global --include-config
+
+# 10) Apply workspace files
+memories files apply --global --include-config --force
+```
+
+### Path B: Ongoing refresh (after memory updates)
+
+Use this when setup already exists and you only need to refresh workspace outputs.
+
+```bash
+cd your-project
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+memories generate agents
+if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi
+memories files ingest --global --include-config
+memories files apply --global --include-config --force
+```
+
+## Expected OpenClaw workspace artifacts
+
+Expected files/directories managed in this integration:
+
+- `~/.openclaw/workspace/AGENTS.md`
+- `~/.openclaw/workspace/SOUL.md`
+- `~/.openclaw/workspace/TOOLS.md`
+- `~/.openclaw/workspace/IDENTITY.md`
+- `~/.openclaw/workspace/USER.md`
+- `~/.openclaw/workspace/HEARTBEAT.md`
+- `~/.openclaw/workspace/BOOTSTRAP.md`
+- `~/.openclaw/workspace/BOOT.md` (if present)
+- `~/.openclaw/workspace/MEMORY.md` or `~/.openclaw/workspace/memory.md`
+- `~/.openclaw/workspace/memory/*.md`
+- `~/.openclaw/workspace/skills/**/*`
+
+Optional config sync (explicit):
+- `~/.openclaw/openclaw.json` via `--include-config`
+
+## Verification checklist
+
+After setup, verify:
+
+```bash
+# Workspace exists
+ls -la ~/.openclaw/workspace
+
+# AGENTS file updated
+ls -la ~/.openclaw/workspace/AGENTS.md
+
+# Skills copied (if any were generated)
+ls -la ~/.openclaw/workspace/skills
+```
+
+Project-side validation:
+
+```bash
+# Generated skills exist locally (conditional)
+ls -la .agents/skills
+```
+
+## Troubleshooting quick map
+
+### `openclaw: command not found`
+- Install OpenClaw from official docs first.
+- Do not invent an install command.
+
+### Skills did not copy
+- `memories generate agents` only outputs `.agents/skills` when skills exist.
+- Keep the copy command conditional:
+  - `if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi`
+
+### Wrong workspace path
+- Your workspace path may be customized in `~/.openclaw/openclaw.json`.
+- If customized, replace `~/.openclaw/workspace` paths accordingly.
+
+### Sync appears stale
+- Re-run Path B refresh sequence in order.
+- Ensure you are in the correct `your-project` before running generate commands.
+
+## Agent guidance (operational behavior)
+
+When using this integration, agents should:
+
+1. Respect order
+- Run setup commands top-to-bottom.
+- Do not skip initialization on first setup.
+
+2. Avoid unsafe assumptions
+- If OpenClaw binary is missing, stop and direct to official install docs.
+- If workspace path differs, use configured path from OpenClaw config.
+
+3. Prefer deterministic sync over manual edits
+- Generate and apply from memories.sh.
+- Do not manually patch individual workspace files unless explicitly requested.
+
+4. Preserve user environment
+- Use conditional copy for skills.
+- Do not delete workspace content unless explicitly asked.
+
+5. Keep references canonical
+- Prefer memories.sh docs + official OpenClaw docs for source-of-truth behavior.
+
+## Suggested agent prompts (optional)
+
+- "Run the first-time OpenClaw + memories setup from llms.txt and show each command before execution."
+- "Run only the ongoing refresh sequence for OpenClaw workspace sync."
+- "Validate expected workspace artifacts and report what is missing."

--- a/packages/web/src/app/openclaw/page.tsx
+++ b/packages/web/src/app/openclaw/page.tsx
@@ -1,0 +1,407 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  Database,
+  FileCode2,
+  FolderSync,
+  ShieldCheck,
+  Sparkles,
+  Workflow,
+} from "lucide-react";
+import { TopNav } from "@/components/TopNav";
+import { Footer } from "@/components/Footer";
+import { ScrambleText } from "@/components/animations/ScrambleText";
+import { OpenClawHeroBackground } from "@/components/openclaw/HeroBackground";
+import { OpenClawHeroIllustration } from "@/components/openclaw/HeroIllustration";
+import { OpenClawSetupCommandSequence } from "@/components/openclaw/SetupCommandSequence";
+
+export const metadata: Metadata = {
+  title: "OpenClaw Memory Landing Page",
+  description:
+    "How memories.sh solves OpenClaw's memory problem by keeping the full workspace contract synced, searchable, and reusable across tools.",
+  openGraph: {
+    title: "How memories.sh solves OpenClaw's memory problem",
+    description:
+      "Workspace-first OpenClaw integration with durable memory, portable rules, and repeatable sync workflows.",
+    url: "https://memories.sh/openclaw",
+    type: "website",
+  },
+};
+
+const solvePillars = [
+  {
+    title: "Workspace contract sync",
+    detail:
+      "Carry OpenClaw's workspace files as one versioned set, not ad-hoc edits scattered across machines.",
+    metric: "AGENTS + SOUL + TOOLS + memory/**",
+  },
+  {
+    title: "Structured local memory",
+    detail:
+      "Store rules, facts, and decisions in one searchable database so context is durable between sessions.",
+    metric: "SQLite + semantic recall",
+  },
+  {
+    title: "Cross-agent portability",
+    detail:
+      "Keep OpenClaw behavior and reuse it in Claude Code, Cursor, Windsurf, and other integrations.",
+    metric: "One source of truth",
+  },
+  {
+    title: "Skill reuse",
+    detail:
+      "Generate `.agents/skills/**/SKILL.md` and sync into OpenClaw workspace `skills/` with predictable structure.",
+    metric: "No manual skill rewrites",
+  },
+  {
+    title: "Safe config sync",
+    detail:
+      "Include `~/.openclaw/openclaw.json` when needed while redacting secret-like fields from stored files.",
+    metric: "--include-config support",
+  },
+  {
+    title: "Repeatable maintenance loop",
+    detail:
+      "Regenerate and re-apply workspace artifacts whenever memories change, so runtime instructions stay aligned.",
+    metric: "Automatable refresh cycle",
+  },
+];
+
+const workspaceFiles = [
+  "~/.openclaw/workspace/AGENTS.md",
+  "~/.openclaw/workspace/SOUL.md",
+  "~/.openclaw/workspace/TOOLS.md",
+  "~/.openclaw/workspace/IDENTITY.md",
+  "~/.openclaw/workspace/USER.md",
+  "~/.openclaw/workspace/HEARTBEAT.md",
+  "~/.openclaw/workspace/BOOTSTRAP.md",
+  "~/.openclaw/workspace/MEMORY.md or memory.md",
+  "~/.openclaw/workspace/memory/*.md",
+  "~/.openclaw/workspace/skills/**/*",
+];
+
+const faqs = [
+  {
+    q: "What exactly is the OpenClaw memory problem?",
+    a: "OpenClaw relies on a full workspace pack, not one file. As that pack changes across sessions and machines, behavior drifts. memories.sh keeps those instructions and skills synchronized from a durable memory source.",
+  },
+  {
+    q: "Is this AGENTS.md only?",
+    a: "No. The recommended workflow is workspace-first and includes AGENTS, SOUL, TOOLS, IDENTITY, USER, HEARTBEAT, BOOTSTRAP, memory files, and skills.",
+  },
+  {
+    q: "Does this replace OpenClaw onboarding?",
+    a: "No. Run `openclaw onboard` first so OpenClaw creates its workspace. Then memories.sh generates and syncs updates into that workspace.",
+  },
+  {
+    q: "Can I keep OpenClaw memory aligned with other agents?",
+    a: "Yes. memories.sh stores memory once and generates outputs for multiple integrations, so decisions and rules stay consistent when you switch tools.",
+  },
+];
+
+export default function OpenClawPage(): React.JSX.Element {
+  return (
+    <div className="min-h-screen bg-background text-foreground selection:bg-primary/30">
+      <TopNav />
+
+      <main className="relative text-[15px] leading-7">
+        <section id="overview" className="relative min-h-screen overflow-hidden border-b border-border pt-24 pb-16">
+          <OpenClawHeroBackground />
+
+          <div className="relative z-10 flex w-full min-h-[calc(100vh-160px)] items-center px-6 lg:px-16 xl:px-24">
+            <div className="grid w-full items-center gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:gap-16">
+              <div className="flex flex-col items-start text-left">
+                <div className="mb-6 inline-flex items-center gap-2">
+                  <div className="h-2 w-2 animate-pulse rounded-full bg-primary" />
+                  <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                    OpenClaw Integration
+                  </span>
+                </div>
+
+                <h1 className="mb-6 font-mono text-3xl leading-[0.95] tracking-tight text-foreground sm:text-4xl lg:text-5xl xl:text-6xl">
+                  <ScrambleText text="How memories.sh solves OpenClaw's memory problem." delayMs={220} duration={0.9} />
+                </h1>
+
+                <p className="mb-8 max-w-2xl text-lg leading-relaxed text-muted-foreground md:text-xl">
+                  OpenClaw runs on a workspace pack, not a single instruction file. memories.sh keeps that full pack synced,
+                  searchable, and portable across tools so behavior stays stable over time.
+                </p>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <Link
+                    href="/docs/integrations/openclaw"
+                    className="group inline-flex items-center px-5 py-2 bg-primary/90 text-primary-foreground shadow-[0_0_30px_rgba(99,102,241,0.25)] hover:opacity-90 transition-all duration-300 rounded-md"
+                  >
+                    <span className="text-[10px] uppercase tracking-[0.2em] font-bold">OpenClaw Setup Guide</span>
+                    <ArrowRight className="ml-2 h-3.5 w-3.5" />
+                  </Link>
+                  <Link
+                    href="/openclaw/resources"
+                    className="inline-flex items-center gap-2 rounded-md border border-border bg-card/30 px-5 py-2 text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Resource Guide
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </Link>
+                  <a
+                    href="/openclaw/llms.txt"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 rounded-md border border-border bg-card/20 px-5 py-2 text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground hover:border-primary/30 transition-colors"
+                  >
+                    For Agents (llms.txt)
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </a>
+                </div>
+              </div>
+
+              <OpenClawHeroIllustration />
+            </div>
+          </div>
+        </section>
+
+        <section id="how-it-works" className="relative py-32 lg:py-44 border-y border-border bg-background-secondary">
+          <div className="w-full px-6 lg:px-16 xl:px-24">
+            <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 xl:gap-24">
+              <div className="flex flex-col items-start text-left">
+                <div className="inline-flex items-center gap-2 mb-6">
+                  <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                  <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                    How It Works
+                  </span>
+                </div>
+                <h2 className="font-mono font-normal text-2xl sm:text-4xl tracking-tight text-foreground mb-4">
+                  <ScrambleText text="Workspace-first memory pipeline for OpenClaw." delayMs={120} duration={0.8} />
+                </h2>
+                <p className="text-base sm:text-lg text-muted-foreground max-w-md leading-relaxed">
+                  The sequence is simple: onboard OpenClaw once, generate workspace artifacts from memories, then keep
+                  the workspace synced as your memory base evolves.
+                </p>
+              </div>
+
+              <div>
+                <div className="mb-5 flex items-center gap-2">
+                  <Workflow className="h-4 w-4 text-primary" />
+                  <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">Recommended flow</span>
+                </div>
+                <OpenClawSetupCommandSequence />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="features" className="py-28 border-t border-border relative overflow-hidden">
+          <div
+            className="absolute inset-0 opacity-15 dark:opacity-25 bg-cover bg-center bg-no-repeat"
+            style={{ backgroundImage: "url(/bg-texture_memories.webp)" }}
+          />
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(135deg, transparent 0%, transparent 5%, var(--background) 25%, var(--background) 75%, transparent 95%, transparent 100%)",
+            }}
+          />
+
+          <div className="relative w-full px-6 lg:px-16 xl:px-24">
+            <div className="mb-20 flex max-w-3xl flex-col items-start text-left">
+              <div className="inline-flex items-center gap-2 mb-4">
+                <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                  Why It Solves It
+                </span>
+              </div>
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
+                <ScrambleText text="Memory stability for OpenClaw at operational depth." delayMs={180} />
+              </h2>
+              <p className="mt-6 text-base sm:text-lg text-muted-foreground max-w-2xl leading-relaxed">
+                memories.sh addresses root causes of OpenClaw memory drift: fragmented files, manual sync, and
+                tool-specific lock-in.
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
+              {solvePillars.map((pillar, idx) => (
+                <div
+                  key={pillar.title}
+                  className="group p-8 lg:p-10 bg-card/30 border border-border shadow-lg dark:shadow-[0_20px_80px_rgba(0,0,0,0.45)] hover:ring-1 hover:ring-primary/30 relative overflow-hidden rounded-lg"
+                >
+                  <div className="mb-10 text-primary/60 group-hover:text-primary">
+                    {idx % 3 === 0 && <FolderSync className="h-6 w-6" />}
+                    {idx % 3 === 1 && <Database className="h-6 w-6" />}
+                    {idx % 3 === 2 && <Sparkles className="h-6 w-6" />}
+                  </div>
+
+                  <h4 className="text-lg font-bold mb-4 tracking-tight text-foreground">{pillar.title}</h4>
+                  <p className="text-[13px] text-muted-foreground leading-relaxed font-light mb-8">{pillar.detail}</p>
+
+                  <div className="flex items-center gap-2 pt-6 border-t border-border">
+                    <div className="w-1 h-1 rounded-full bg-primary/60" />
+                    <span className="text-[10px] uppercase tracking-[0.25em] font-bold text-muted-foreground">{pillar.metric}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="api" className="py-28 border-t border-border relative overflow-hidden">
+          <div
+            className="absolute inset-0 opacity-20"
+            style={{
+              background:
+                "radial-gradient(circle at 12% 18%, rgba(99,102,241,0.25), transparent 30%), radial-gradient(circle at 88% 78%, rgba(16,185,129,0.15), transparent 32%)",
+            }}
+          />
+          <div className="relative w-full px-6 lg:px-16 xl:px-24">
+            <div className="mb-20 flex max-w-3xl flex-col items-start text-left">
+              <div className="inline-flex items-center gap-2 mb-4">
+                <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                  Command Pattern
+                </span>
+              </div>
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
+                <ScrambleText text="Repeatable sync loop instead of manual drift fixes." delayMs={200} />
+              </h2>
+              <p className="mt-6 text-base sm:text-lg text-muted-foreground max-w-3xl leading-relaxed">
+                Run this when memories change to keep OpenClaw workspace instructions and skills aligned with your latest state.
+              </p>
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-[18rem_minmax(0,1fr)] items-start">
+              <div className="grid gap-2">
+                <div className="px-4 py-4 border rounded-lg border-primary/50 bg-primary/10 shadow-[0_0_30px_rgba(99,102,241,0.15)]">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-bold tracking-tight text-foreground">Sync OpenClaw workspace</span>
+                    <span className="px-2 py-0.5 border rounded font-mono text-[10px] text-sky-200 border-sky-300/30 bg-sky-500/10">
+                      CLI
+                    </span>
+                  </div>
+                  <p className="mt-2 font-mono text-[11px] text-muted-foreground break-all">/docs/integrations/openclaw</p>
+                </div>
+                <div className="px-4 py-4 border rounded-lg border-border bg-card/20">
+                  <div className="flex items-center gap-2">
+                    <ShieldCheck className="h-4 w-4 text-primary" />
+                    <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Config-safe sync</span>
+                  </div>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Use <code className="font-mono text-foreground/80">--include-config</code> when you need OpenClaw runtime
+                    config synced too.
+                  </p>
+                </div>
+              </div>
+
+              <div className="border border-border rounded-xl bg-card/20 overflow-hidden">
+                <div className="px-5 py-4 border-b border-border bg-foreground/[0.03]">
+                  <div className="flex items-center gap-3">
+                    <FileCode2 className="h-4 w-4 text-primary" />
+                    <code className="font-mono text-xs text-foreground/90 break-all">openclaw-memory-refresh.sh</code>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Canonical refresh workflow for OpenClaw workspace instructions and skills.
+                  </p>
+                </div>
+                <div className="p-5">
+                  <pre className="overflow-hidden rounded-lg border border-border bg-background px-4 py-3 text-[11px] leading-relaxed">
+                    <code className="block whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+{`cd your-project
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+memories generate agents
+if [ -d .agents/skills ]; then
+  cp -R .agents/skills/. ~/.openclaw/workspace/skills/
+fi
+
+memories files ingest --global --include-config
+memories files apply --global --include-config --force`}
+                    </code>
+                  </pre>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-14 flex flex-wrap items-center gap-3">
+              <Link
+                href="/docs/integrations/openclaw"
+                className="inline-flex items-center gap-2 px-4 py-2 border border-primary/40 bg-primary/10 text-primary text-xs uppercase tracking-[0.16em] font-bold hover:bg-primary/20 transition-colors rounded-md"
+              >
+                Read OpenClaw Integration
+                <span aria-hidden>→</span>
+              </Link>
+              <Link
+                href="/docs/cli/files"
+                className="inline-flex items-center gap-2 px-4 py-2 border border-border bg-card/30 text-muted-foreground text-xs uppercase tracking-[0.16em] font-bold hover:text-foreground hover:border-primary/30 transition-colors rounded-md"
+              >
+                File Sync Docs
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section id="integrations" className="py-28 border-t border-border">
+          <div className="w-full px-6 lg:px-16 xl:px-24">
+            <div className="mb-20 flex max-w-3xl flex-col items-start text-left">
+              <div className="inline-flex items-center gap-2 mb-4">
+                <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                  OpenClaw Workspace Coverage
+                </span>
+              </div>
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
+                <ScrambleText text="The file set that memories.sh keeps coherent." delayMs={200} />
+              </h2>
+              <p className="mt-6 text-base sm:text-lg text-muted-foreground max-w-2xl leading-relaxed">
+                OpenClaw's workspace is a contract. This is the high-value set that memories.sh can ingest and apply so runtime behavior does not fragment.
+              </p>
+            </div>
+
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
+              {workspaceFiles.map((file) => (
+                <div
+                  key={file}
+                  className="p-8 lg:p-10 bg-card/20 flex flex-col items-start border border-border shadow-md dark:shadow-[0_16px_50px_rgba(0,0,0,0.35)] rounded-lg relative overflow-hidden"
+                >
+                  <div className="absolute inset-0 opacity-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: "url(/bg-texture_memories.webp)" }} />
+                  <span className="text-[11px] font-bold uppercase tracking-[0.25em] text-muted-foreground mb-6">
+                    Synced
+                  </span>
+                  <code className="text-[13px] text-foreground/90 break-all leading-relaxed font-mono">{file}</code>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="faq" className="py-28 px-6 lg:px-16 xl:px-24 border-t border-white/10">
+          <div className="max-w-[1000px] mx-auto">
+            <div className="mb-20 flex max-w-3xl flex-col items-start text-left">
+              <div className="inline-flex items-center gap-2 mb-4">
+                <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                  FAQ
+                </span>
+              </div>
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
+                <ScrambleText text="OpenClaw memory integration, answered." delayMs={200} />
+              </h2>
+              <p className="mt-6 text-base sm:text-lg text-muted-foreground max-w-2xl leading-relaxed">
+                Practical answers for implementing and maintaining memories.sh with OpenClaw.
+              </p>
+            </div>
+
+            <div className="space-y-1">
+              {faqs.map((item) => (
+                <div key={item.q} className="glass-panel-soft rounded-lg bg-card/20 p-10">
+                  <h3 className="font-mono font-normal tracking-tight text-lg text-foreground mb-4">{item.q}</h3>
+                  <p className="text-[14px] text-muted-foreground leading-relaxed font-light">{item.a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/packages/web/src/app/openclaw/resources/page.tsx
+++ b/packages/web/src/app/openclaw/resources/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, ExternalLink } from "lucide-react";
+import { TopNav } from "@/components/TopNav";
+import { Footer } from "@/components/Footer";
+import { ScrambleText } from "@/components/animations/ScrambleText";
+
+export const metadata: Metadata = {
+  title: "OpenClaw Resource Guide",
+  description:
+    "Task-focused OpenClaw resource map for setup, security hardening, workspace sync, providers, skills, and troubleshooting.",
+  openGraph: {
+    title: "OpenClaw Resource Guide",
+    description:
+      "A practical guide map for running OpenClaw with stable memory workflows powered by memories.sh.",
+    url: "https://memories.sh/openclaw/resources",
+    type: "website",
+  },
+};
+
+const officialReferences = [
+  { label: "OpenClaw Integration (memories docs)", href: "/docs/integrations/openclaw", internal: true },
+  { label: "OpenClaw Docs Home", href: "https://docs.openclaw.ai/" },
+  { label: "OpenClaw Onboarding", href: "https://docs.openclaw.ai/start/onboarding" },
+  { label: "OpenClaw Agent Workspace", href: "https://docs.openclaw.ai/concepts/agent-workspace" },
+  { label: "Gateway Security", href: "https://docs.openclaw.ai/gateway/security" },
+  { label: "OpenClaw Releases", href: "https://github.com/openclaw/openclaw/releases" },
+];
+
+const tracks = [
+  {
+    title: "Track 1: First Stable Install",
+    pages: [
+      "Run OpenClaw onboarding and validate workspace path",
+      "Generate AGENTS + skills from memories.sh",
+      "Verify workspace files are applied and read by OpenClaw",
+    ],
+  },
+  {
+    title: "Track 2: Memory Drift Prevention",
+    pages: [
+      "Use files ingest/apply for OpenClaw workspace set",
+      "Include runtime config safely with --include-config when required",
+      "Set refresh cadence after major rule/skill updates",
+    ],
+  },
+  {
+    title: "Track 3: Security and Reliability",
+    pages: [
+      "Pairing and allowlist baseline before broad channel exposure",
+      "Provider and gateway auth checks after sync changes",
+      "Runbook for no-response and auth failure scenarios",
+    ],
+  },
+  {
+    title: "Track 4: Cross-Agent Portability",
+    pages: [
+      "Reuse OpenClaw rule set in Claude Code/Cursor/Windsurf",
+      "Standardize skill definitions across ecosystems",
+      "Use one memory source for multi-agent consistency",
+    ],
+  },
+];
+
+export default function OpenClawResourcesPage(): React.JSX.Element {
+  return (
+    <div className="min-h-screen bg-background text-foreground selection:bg-primary/30">
+      <TopNav />
+
+      <main className="relative text-[15px] leading-7">
+        <section className="relative border-b border-border pt-24 pb-16">
+          <div
+            className="absolute inset-0 opacity-20"
+            style={{
+              background:
+                "radial-gradient(circle at 18% 20%, rgba(99,102,241,0.28), transparent 36%), radial-gradient(circle at 84% 16%, rgba(236,72,153,0.22), transparent 34%)",
+            }}
+          />
+          <div className="relative w-full px-6 lg:px-16 xl:px-24">
+            <Link
+              href="/openclaw"
+              className="mb-8 inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.15em] text-muted-foreground hover:text-foreground"
+            >
+              <ArrowRight className="h-3.5 w-3.5 rotate-180" />
+              Back to OpenClaw landing page
+            </Link>
+
+            <div className="mb-6 inline-flex items-center gap-2">
+              <div className="h-2 w-2 animate-pulse rounded-full bg-primary" />
+              <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                Resource Guide
+              </span>
+            </div>
+
+            <h1 className="max-w-4xl font-mono text-3xl leading-[0.95] tracking-tight text-foreground sm:text-4xl lg:text-5xl">
+              <ScrambleText text="OpenClaw + memories.sh implementation map." delayMs={160} duration={0.8} />
+            </h1>
+            <p className="mt-6 max-w-3xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              Use this guide to move from first install to stable operations. The structure mirrors the real OpenClaw
+              memory problem: workspace drift, inconsistent skill sync, and fragmented context between tools.
+            </p>
+          </div>
+        </section>
+
+        <section id="references" className="py-28 border-t border-border relative overflow-hidden">
+          <div
+            className="absolute inset-0 opacity-15 dark:opacity-25 bg-cover bg-center bg-no-repeat"
+            style={{ backgroundImage: "url(/bg-texture_memories.webp)" }}
+          />
+          <div className="relative w-full px-6 lg:px-16 xl:px-24">
+            <div className="mb-20 flex max-w-3xl flex-col items-start text-left">
+              <div className="inline-flex items-center gap-2 mb-4">
+                <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                  Official References
+                </span>
+              </div>
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
+                <ScrambleText text="Start from canonical sources." delayMs={180} />
+              </h2>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {officialReferences.map((item) =>
+                item.internal ? (
+                  <Link
+                    key={item.label}
+                    href={item.href}
+                    className="inline-flex items-center justify-between rounded-md border border-border bg-card/30 px-4 py-3 text-sm transition-colors hover:bg-card/45"
+                  >
+                    <span>{item.label}</span>
+                    <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                  </Link>
+                ) : (
+                  <a
+                    key={item.label}
+                    href={item.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-between rounded-md border border-border bg-card/30 px-4 py-3 text-sm transition-colors hover:bg-card/45"
+                  >
+                    <span>{item.label}</span>
+                    <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                  </a>
+                ),
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section id="tracks" className="py-28 border-t border-border">
+          <div className="w-full px-6 lg:px-16 xl:px-24">
+            <div className="mb-20 flex max-w-3xl flex-col items-start text-left">
+              <div className="inline-flex items-center gap-2 mb-4">
+                <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+                <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
+                  Execution Tracks
+                </span>
+              </div>
+              <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
+                <ScrambleText text="Prioritize by operational risk and impact." delayMs={180} />
+              </h2>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {tracks.map((track) => (
+                <article
+                  key={track.title}
+                  className="rounded-xl border border-border bg-card/20 p-8 shadow-md dark:shadow-[0_16px_50px_rgba(0,0,0,0.35)]"
+                >
+                  <h3 className="mb-5 text-lg font-bold tracking-tight text-foreground">{track.title}</h3>
+                  <ul className="space-y-3">
+                    {track.pages.map((page) => (
+                      <li key={page} className="flex items-start gap-3 text-[13px] text-muted-foreground leading-relaxed">
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                        <span>{page}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/packages/web/src/app/sitemap.ts
+++ b/packages/web/src/app/sitemap.ts
@@ -19,6 +19,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${BASE_URL}/openclaw`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/openclaw/resources`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
       url: `${BASE_URL}/login`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/packages/web/src/components/TopNav.tsx
+++ b/packages/web/src/components/TopNav.tsx
@@ -5,21 +5,35 @@ import Link from "next/link";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import type { User } from "@supabase/supabase-js";
+import { usePathname } from "next/navigation";
 import { ScrambleTextOnHover } from "./animations/ScrambleText";
 import { Github } from "./icons/app/Github";
 import { useUser } from "@/hooks/use-user";
 
-const navItems = [
-  { href: "#how-it-works", label: "How" },
-  { href: "#features", label: "Features" },
-  { href: "#api", label: "API" },
-  { href: "#integrations", label: "Apps" },
+type NavItem = {
+  href: string | { sectionId: string };
+  label: string;
+};
+
+const navItems: NavItem[] = [
+  { href: { sectionId: "how-it-works" }, label: "How" },
+  { href: { sectionId: "features" }, label: "Features" },
+  { href: { sectionId: "api" }, label: "API" },
+  { href: { sectionId: "integrations" }, label: "Apps" },
+  { href: "/openclaw", label: "OpenClaw" },
   { href: "/docs", label: "Docs" },
-  { href: "#faq", label: "FAQ" },
+  { href: { sectionId: "faq" }, label: "FAQ" },
 ];
+
+function resolveHref(pathname: string, href: NavItem["href"]): string {
+  if (typeof href === "string") return href;
+  const anchor = `#${href.sectionId}`;
+  return pathname === "/" ? anchor : `/${anchor}`;
+}
 
 export function TopNav({ user }: { user?: User | null }): React.JSX.Element {
   const { user: sessionUser } = useUser();
+  const pathname = usePathname() ?? "/";
   const effectiveUser = sessionUser ?? user ?? null;
   const isSignedIn = Boolean(effectiveUser);
   const primaryCtaHref = isSignedIn ? "/app" : "/docs/getting-started";
@@ -54,8 +68,8 @@ export function TopNav({ user }: { user?: User | null }): React.JSX.Element {
             <div className="hidden md:flex items-center gap-0">
               {navItems.map((item) => (
                 <Link 
-                  key={item.href}
-                  href={item.href} 
+                  key={item.label}
+                  href={resolveHref(pathname, item.href)} 
                   className="group relative px-4 py-2 flex items-center gap-2"
                 >
                   <ScrambleTextOnHover
@@ -143,13 +157,13 @@ export function TopNav({ user }: { user?: User | null }): React.JSX.Element {
                 <div className="flex flex-col gap-2">
                   {navItems.map((item, index) => (
                     <motion.div
-                      key={item.href}
+                      key={item.label}
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: index * 0.05 }}
                     >
                       <Link 
-                        href={item.href}
+                        href={resolveHref(pathname, item.href)}
                         onClick={handleLinkClick}
                         className="group flex items-center justify-between py-4 border-b border-border/50 last:border-0"
                       >

--- a/packages/web/src/components/openclaw/HeroBackground.tsx
+++ b/packages/web/src/components/openclaw/HeroBackground.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import React from "react";
+
+const ShaderBackground = dynamic(
+  () => import("@/components/ShaderBackground").then((mod) => mod.ShaderBackground),
+  { ssr: false },
+);
+
+export function OpenClawHeroBackground(): React.JSX.Element {
+  return (
+    <>
+      <ShaderBackground className="opacity-38 z-0" color="#b855f7" backgroundColor="#07080f" />
+
+      {/* Variation from homepage: layered radial wash + directional fade */}
+      <div
+        className="absolute inset-0 pointer-events-none z-[1]"
+        style={{
+          background:
+            "radial-gradient(70% 55% at 78% 24%, rgba(168,85,247,0.18), transparent 72%), radial-gradient(62% 54% at 22% 82%, rgba(16,185,129,0.10), transparent 74%)",
+        }}
+      />
+      <div className="absolute inset-0 pointer-events-none z-[1] bg-gradient-to-br from-background/90 via-background/62 to-transparent" />
+    </>
+  );
+}

--- a/packages/web/src/components/openclaw/HeroIllustration.tsx
+++ b/packages/web/src/components/openclaw/HeroIllustration.tsx
@@ -1,0 +1,662 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+const style = `
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Space+Grotesk:wght@300;400;600&display=swap');
+
+  .oc-root, .oc-root * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  .oc-root {
+    --violet: #a855f7;
+    --violet-dim: #7c3aed;
+    --violet-glow: rgba(168, 85, 247, 0.15);
+    --green: #4ade80;
+    --green-dim: rgba(74, 222, 128, 0.7);
+    --card: #0e0e16;
+    --card-border: rgba(255,255,255,0.07);
+    --text-muted: rgba(255,255,255,0.35);
+    --text-dim: rgba(255,255,255,0.55);
+
+    width: 100%;
+    font-family: 'JetBrains Mono', monospace;
+    color: #e2e8f0;
+    background: transparent;
+    position: relative;
+  }
+
+  .oc-panel-wrap {
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+    border-radius: 16px;
+  }
+
+  .oc-noise {
+    position: absolute;
+    inset: 0;
+    opacity: 0.025;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 200px 200px;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .oc-dot-grid {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px);
+    background-size: 28px 28px;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .oc-panel {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    background: var(--card);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 0 0 1px rgba(168,85,247,0.08), 0 40px 80px rgba(0,0,0,0.6), 0 0 60px rgba(88,28,135,0.1);
+    animation: oc-fadeUp 0.6s ease both, oc-glowPulse 4s ease-in-out 1s infinite;
+  }
+
+  @keyframes oc-fadeUp {
+    from { opacity: 0; transform: translateY(24px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes oc-glowPulse {
+    0%, 100% { box-shadow: 0 0 0 1px rgba(168,85,247,0.08), 0 40px 80px rgba(0,0,0,0.6), 0 0 60px rgba(88,28,135,0.1); }
+    50% { box-shadow: 0 0 0 1px rgba(168,85,247,0.12), 0 40px 80px rgba(0,0,0,0.6), 0 0 80px rgba(88,28,135,0.18); }
+  }
+
+  .oc-topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--card-border);
+    background: rgba(255,255,255,0.02);
+  }
+
+  .oc-topbar-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .oc-topbar-icon {
+    width: 18px;
+    height: 18px;
+    color: var(--violet);
+    flex-shrink: 0;
+  }
+
+  .oc-topbar-title {
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .oc-topbar-pills {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .oc-pill {
+    font-size: 9px;
+    letter-spacing: 0.05em;
+    padding: 4px 10px;
+    border-radius: 100px;
+    border: 1px solid var(--card-border);
+    background: rgba(255,255,255,0.03);
+    color: var(--text-dim);
+    white-space: nowrap;
+  }
+
+  .oc-pill-live {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 9px;
+    letter-spacing: 0.12em;
+    padding: 4px 12px;
+    border-radius: 100px;
+    border: 1px solid rgba(74,222,128,0.25);
+    background: rgba(74,222,128,0.06);
+    color: var(--green);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .oc-blink {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--green);
+    animation: oc-blink 1.4s ease-in-out infinite;
+    box-shadow: 0 0 6px var(--green);
+  }
+
+  @keyframes oc-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.2; }
+  }
+
+  .oc-node-row {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    gap: 0;
+    padding: 20px 20px 0;
+    align-items: center;
+  }
+
+  .oc-node-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid var(--card-border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    animation: oc-fadeUp 0.6s ease both;
+  }
+
+  .oc-node-card:nth-child(1) { animation-delay: 0.1s; }
+  .oc-node-card:nth-child(3) { animation-delay: 0.2s; }
+  .oc-node-card:nth-child(5) { animation-delay: 0.3s; }
+
+  .oc-node-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: rgba(168,85,247,0.15);
+    border: 1px solid rgba(168,85,247,0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 10px;
+    color: var(--violet);
+  }
+
+  .oc-node-label {
+    font-size: 8px;
+    letter-spacing: 0.15em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+
+  .oc-node-desc {
+    font-size: 9.5px;
+    color: var(--text-dim);
+    line-height: 1.5;
+  }
+
+  .oc-connector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    height: 2px;
+  }
+
+  .oc-connector-line {
+    width: 100%;
+    height: 1px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(168,85,247,0.18), rgba(168,85,247,0.58) 50%, rgba(168,85,247,0.18));
+    position: relative;
+    overflow: hidden;
+  }
+
+  .oc-connector-beam {
+    position: absolute;
+    top: 50%;
+    left: -30%;
+    transform: translateY(-50%);
+    width: 30px;
+    height: 6px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(168,85,247,0), rgba(168,85,247,0.98), rgba(168,85,247,0));
+    box-shadow: 0 0 14px rgba(168,85,247,0.85);
+    animation: oc-beamSweep 2.2s linear infinite;
+    pointer-events: none;
+  }
+
+  .oc-connector-beam-soft {
+    width: 24px;
+    opacity: 0.65;
+    filter: blur(0.35px);
+    animation-duration: 2.8s;
+  }
+
+  @keyframes oc-beamSweep {
+    0% { left: -30%; opacity: 0; }
+    10% { opacity: 1; }
+    90% { opacity: 1; }
+    100% { left: 110%; opacity: 0; }
+  }
+
+  .oc-main-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    padding: 12px 20px 20px;
+  }
+
+  .oc-section-card {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--card-border);
+    border-radius: 10px;
+    padding: 16px;
+    animation: oc-fadeUp 0.6s ease both;
+  }
+
+  .oc-section-card:nth-child(1) { animation-delay: 0.35s; }
+  .oc-section-card:nth-child(2) { animation-delay: 0.45s; }
+
+  .oc-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+
+  .oc-section-title {
+    font-size: 8px;
+    letter-spacing: 0.2em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+  }
+
+  .oc-synced-badge {
+    font-size: 8px;
+    letter-spacing: 0.1em;
+    color: rgba(168,85,247,0.7);
+    text-transform: uppercase;
+  }
+
+  .oc-file-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .oc-file-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+    cursor: default;
+  }
+
+  .oc-file-row:hover {
+    background: rgba(168,85,247,0.06);
+    border-color: rgba(168,85,247,0.15);
+  }
+
+  .oc-file-row-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .oc-file-icon {
+    width: 14px;
+    height: 14px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .oc-file-name {
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.02em;
+  }
+
+  .oc-check-icon {
+    width: 14px;
+    height: 14px;
+    color: var(--green-dim);
+    flex-shrink: 0;
+  }
+
+  .oc-trace-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .oc-trace-row {
+    animation: oc-fadeUp 0.5s ease both;
+  }
+
+  .oc-trace-row:nth-child(1) { animation-delay: 0.5s; }
+  .oc-trace-row:nth-child(2) { animation-delay: 0.6s; }
+  .oc-trace-row:nth-child(3) { animation-delay: 0.7s; }
+  .oc-trace-row:nth-child(4) { animation-delay: 0.8s; }
+
+  .oc-trace-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 5px;
+  }
+
+  .oc-trace-key {
+    font-size: 9.5px;
+    color: var(--text-dim);
+    letter-spacing: 0.03em;
+  }
+
+  .oc-trace-key span {
+    color: rgba(168,85,247,0.6);
+  }
+
+  .oc-matched {
+    font-size: 8px;
+    letter-spacing: 0.12em;
+    color: var(--green-dim);
+    text-transform: uppercase;
+  }
+
+  .oc-bar-track {
+    height: 3px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 100px;
+    overflow: hidden;
+  }
+
+  .oc-bar-fill {
+    height: 100%;
+    border-radius: 100px;
+    background: linear-gradient(90deg, var(--violet-dim), var(--violet));
+    box-shadow: 0 0 8px rgba(168,85,247,0.5);
+    animation: oc-barGrow 0.8s ease both;
+    transform-origin: left;
+  }
+
+  @keyframes oc-barGrow {
+    from { width: 0 !important; }
+  }
+
+  .oc-stats-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+    padding: 0 20px 20px;
+    animation: oc-fadeUp 0.6s 0.55s ease both;
+  }
+
+  .oc-stat-card {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--card-border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    transition: border-color 0.2s;
+  }
+
+  .oc-stat-card:hover {
+    border-color: rgba(168,85,247,0.2);
+  }
+
+  .oc-stat-value {
+    font-size: 22px;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    margin-bottom: 4px;
+    font-family: 'Space Grotesk', 'JetBrains Mono', sans-serif;
+  }
+
+  .oc-stat-label {
+    font-size: 8px;
+    letter-spacing: 0.15em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+  }
+
+  @media (max-width: 980px) {
+    .oc-topbar {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .oc-topbar-pills {
+      width: 100%;
+      justify-content: flex-start;
+    }
+    .oc-node-row {
+      grid-template-columns: 1fr;
+      gap: 10px;
+    }
+    .oc-connector {
+      display: none;
+    }
+    .oc-main-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+`;
+
+type NodeType = "workspace" | "store" | "runtime";
+
+const files = [
+  { name: "AGENTS.md" },
+  { name: "SOUL.md" },
+  { name: "TOOLS.md" },
+  { name: "memory/*.md" },
+  { name: "skills/**/*" },
+];
+
+const traces = [
+  { key: "rules", ns: "project_scope", pct: 95 },
+  { key: "facts", ns: "workspace_state", pct: 78 },
+  { key: "skills", ns: "tooling_policy", pct: 62 },
+  { key: "decisions", ns: "execution_style", pct: 88 },
+];
+
+function FileIcon(): React.JSX.Element {
+  return (
+    <svg className="oc-file-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.2">
+      <path d="M2 1.5h7l2.5 2.5v9H2z" strokeLinejoin="round" />
+      <path d="M8.5 1.5v3h3" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function CheckIcon(): React.JSX.Element {
+  return (
+    <svg className="oc-check-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <circle cx="7" cy="7" r="5.5" />
+      <path d="M4.5 7l2 2 3-3" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function NodeIcon({ type }: { type: NodeType }): React.JSX.Element {
+  if (type === "workspace") {
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
+        <rect x="1" y="1" width="12" height="12" rx="2" />
+        <path d="M1 5h12M5 5v8" />
+      </svg>
+    );
+  }
+  if (type === "store") {
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
+        <ellipse cx="7" cy="4" rx="5" ry="2" />
+        <path d="M2 4v6c0 1.1 2.24 2 5 2s5-.9 5-2V4" />
+        <path d="M2 7c0 1.1 2.24 2 5 2s5-.9 5-2" />
+      </svg>
+    );
+  }
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
+      <path d="M7 1l5 2.5v5L7 11 2 8.5v-5z" />
+      <path d="M7 11v2M2 3.5l5 3 5-3M7 6.5V9" />
+    </svg>
+  );
+}
+
+function MemoryIcon(): React.JSX.Element {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+      <circle cx="8" cy="8" r="6.5" />
+      <path d="M5 8c0-1.66 1.34-3 3-3s3 1.34 3 3-1.34 3-3 3" />
+      <circle cx="8" cy="8" r="1" />
+    </svg>
+  );
+}
+
+export function OpenClawHeroIllustration(): React.JSX.Element {
+  const [tick, setTick] = useState(0);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const timer = setInterval(() => setTick((n) => n + 1), 3000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <>
+      <style>{style}</style>
+      <div className="oc-root" ref={panelRef}>
+        <div className="oc-panel-wrap">
+          <div className="oc-noise" />
+          <div className="oc-dot-grid" />
+
+          <div className="oc-panel">
+            <div className="oc-topbar">
+              <div className="oc-topbar-left">
+                <span className="oc-topbar-icon"><MemoryIcon /></span>
+                <span className="oc-topbar-title">Memory Control Plane</span>
+              </div>
+              <div className="oc-topbar-pills">
+                <span className="oc-pill">memories files apply --force</span>
+                <span className="oc-pill">workspace hash: stable</span>
+                <span className="oc-pill">skills sync: clean</span>
+                <span className="oc-pill-live">
+                  <span className="oc-blink" />
+                  Live Sync
+                </span>
+              </div>
+            </div>
+
+            <div className="oc-node-row">
+              <div className="oc-node-card">
+                <div className="oc-node-icon"><NodeIcon type="workspace" /></div>
+                <div className="oc-node-label">OpenClaw Workspace</div>
+                <div className="oc-node-desc">AGENTS + skills + memory files</div>
+              </div>
+
+              <div className="oc-connector" style={{ width: 60, padding: "0 4px" }}>
+                <div className="oc-connector-line" style={{ width: "100%" }}>
+                  <div className="oc-connector-beam" />
+                  <div className="oc-connector-beam oc-connector-beam-soft" style={{ animationDelay: "1.1s" }} />
+                </div>
+              </div>
+
+              <div className="oc-node-card">
+                <div className="oc-node-icon"><NodeIcon type="store" /></div>
+                <div className="oc-node-label">Memories.sh Store</div>
+                <div className="oc-node-desc">durable rules, facts, decisions</div>
+              </div>
+
+              <div className="oc-connector" style={{ width: 60, padding: "0 4px" }}>
+                <div className="oc-connector-line" style={{ width: "100%" }}>
+                  <div className="oc-connector-beam" style={{ animationDelay: "1.2s" }} />
+                  <div className="oc-connector-beam oc-connector-beam-soft" style={{ animationDelay: "2.3s" }} />
+                </div>
+              </div>
+
+              <div className="oc-node-card">
+                <div className="oc-node-icon"><NodeIcon type="runtime" /></div>
+                <div className="oc-node-label">Agent Runtime</div>
+                <div className="oc-node-desc">stable context at prompt time</div>
+              </div>
+            </div>
+
+            <div className="oc-main-grid">
+              <div className="oc-section-card">
+                <div className="oc-section-header">
+                  <span className="oc-section-title">Workspace Set</span>
+                  <span className="oc-synced-badge">Synced</span>
+                </div>
+                <div className="oc-file-list">
+                  {files.map((f) => (
+                    <div className="oc-file-row" key={f.name}>
+                      <div className="oc-file-row-left">
+                        <FileIcon />
+                        <span className="oc-file-name">{f.name}</span>
+                      </div>
+                      <CheckIcon />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="oc-section-card">
+                <div className="oc-section-header">
+                  <span className="oc-section-title">Retrieval Trace</span>
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="rgba(168,85,247,0.5)" strokeWidth="1.3">
+                    <circle cx="7" cy="7" r="5.5" />
+                    <path d="M7 4v4M7 9.5v.5" strokeLinecap="round" />
+                  </svg>
+                </div>
+                <div className="oc-trace-list">
+                  {traces.map((t, i) => (
+                    <div className="oc-trace-row" key={`${tick}-${i}`}>
+                      <div className="oc-trace-header">
+                        <span className="oc-trace-key">
+                          <span>{t.key}</span>::{t.ns}
+                        </span>
+                        <span className="oc-matched">Matched</span>
+                      </div>
+                      <div className="oc-bar-track">
+                        <div
+                          className="oc-bar-fill"
+                          style={{
+                            width: `${t.pct}%`,
+                            animationDelay: `${0.5 + i * 0.1}s`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="oc-stats-row">
+              <div className="oc-stat-card">
+                <div className="oc-stat-value">10+</div>
+                <div className="oc-stat-label">Files Synced</div>
+              </div>
+              <div className="oc-stat-card">
+                <div className="oc-stat-value">1:1</div>
+                <div className="oc-stat-label">Skill Parity</div>
+              </div>
+              <div className="oc-stat-card">
+                <div className="oc-stat-value">Real<wbr />time</div>
+                <div className="oc-stat-label">Drift Checks</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/components/openclaw/SetupCommandSequence.tsx
+++ b/packages/web/src/components/openclaw/SetupCommandSequence.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import Link from "next/link";
+import { Check, Copy } from "lucide-react";
+
+type CommandStep = {
+  id: string;
+  title: string;
+  command: string;
+  hint?: React.ReactNode;
+};
+
+const commandSteps: CommandStep[] = [
+  {
+    id: "install-memories-cli",
+    title: "Install memories CLI",
+    command: "pnpm add -g @memories.sh/cli",
+  },
+  {
+    id: "onboard-openclaw",
+    title: "Initialize OpenClaw workspace",
+    command: "openclaw onboard",
+    hint: (
+      <>
+        If this command is missing, install OpenClaw first from{" "}
+        <a
+          href="https://docs.openclaw.ai/install/index"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:text-primary/80 transition-colors"
+        >
+          official install docs
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: "enter-project",
+    title: "Enter your project",
+    command: "cd your-project",
+  },
+  {
+    id: "init-memories",
+    title: "Initialize memories in project",
+    command: "memories init",
+  },
+  {
+    id: "generate-agents",
+    title: "Generate OpenClaw AGENTS workspace file",
+    command: "memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force",
+  },
+  {
+    id: "generate-skills",
+    title: "Generate skills from memories",
+    command: "memories generate agents",
+  },
+  {
+    id: "skills-dir",
+    title: "Ensure OpenClaw skills directory exists",
+    command: "mkdir -p ~/.openclaw/workspace/skills",
+  },
+  {
+    id: "copy-skills",
+    title: "Copy generated skills into OpenClaw workspace",
+    command: "if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi",
+  },
+  {
+    id: "ingest-workspace",
+    title: "Ingest workspace files (with runtime config)",
+    command: "memories files ingest --global --include-config",
+  },
+  {
+    id: "apply-workspace",
+    title: "Apply workspace files (force update)",
+    command: "memories files apply --global --include-config --force",
+  },
+];
+
+async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function OpenClawSetupCommandSequence(): React.JSX.Element {
+  const [copiedStepId, setCopiedStepId] = useState<string | null>(null);
+  const [copiedAll, setCopiedAll] = useState(false);
+  const sequenceScript = useMemo(
+    () => commandSteps.map((step) => step.command).join("\n"),
+    [],
+  );
+
+  const handleStepCopy = async (step: CommandStep) => {
+    const ok = await writeClipboard(step.command);
+    if (!ok) return;
+    setCopiedStepId(step.id);
+    setTimeout(() => setCopiedStepId((current) => (current === step.id ? null : current)), 1800);
+  };
+
+  const handleCopyAll = async () => {
+    const ok = await writeClipboard(sequenceScript);
+    if (!ok) return;
+    setCopiedAll(true);
+    setTimeout(() => setCopiedAll(false), 2000);
+  };
+
+  return (
+    <div className="glass-panel p-6 rounded-xl border border-border">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <div className="h-1.5 w-1.5 rounded-full bg-primary" />
+          <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+            Recommended Flow (CLI)
+          </span>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleCopyAll}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card/20 px-3 py-1.5 text-[10px] uppercase tracking-[0.16em] text-muted-foreground hover:text-foreground hover:border-primary/30 transition-colors"
+        >
+          {copiedAll ? <Check className="h-3.5 w-3.5 text-primary" /> : <Copy className="h-3.5 w-3.5" />}
+          {copiedAll ? "Copied" : "Copy Full Sequence"}
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        {commandSteps.map((step, index) => {
+          const isCopied = copiedStepId === step.id;
+          return (
+            <div key={step.id} className="rounded-lg border border-border bg-background/55 px-3 py-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                    Step {index + 1}: {step.title}
+                  </p>
+                  <code className="mt-1 block overflow-x-auto whitespace-nowrap text-[12px] text-foreground/90">
+                    {step.command}
+                  </code>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => handleStepCopy(step)}
+                  className="mt-0.5 shrink-0 rounded-md border border-border p-1.5 text-muted-foreground hover:text-foreground hover:border-primary/30 transition-colors"
+                  aria-label={`Copy ${step.title} command`}
+                >
+                  {isCopied ? <Check className="h-3.5 w-3.5 text-primary" /> : <Copy className="h-3.5 w-3.5" />}
+                </button>
+              </div>
+              {step.hint ? <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">{step.hint}</p> : null}
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="mt-4 text-[12px] leading-relaxed text-muted-foreground">
+        Run top to bottom. For deeper setup context, see{" "}
+        <Link href="/docs/integrations/openclaw" className="text-primary hover:text-primary/80 transition-colors">
+          OpenClaw integration docs
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary\n- add a dedicated OpenClaw landing page and supporting resource hub\n- add a dedicated OpenClaw llms.txt endpoint and hero CTA for agents\n- add an interactive copyable CLI setup sequence for first-time and ongoing workflows\n- upgrade hero visuals (shader background variant + custom control-plane illustration)\n- keep global navbar stable while adding OpenClaw route access\n- include new OpenClaw routes in sitemap\n\n## Validation\n- pnpm exec eslint src/components/TopNav.tsx src/app/openclaw/page.tsx src/app/openclaw/resources/page.tsx src/components/openclaw/HeroIllustration.tsx src/components/openclaw/HeroBackground.tsx src/components/openclaw/SetupCommandSequence.tsx src/app/sitemap.ts\n- pnpm typecheck (packages/web)\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new static pages/components and minor nav/sitemap wiring; no backend, auth, or data-handling logic changes.
> 
> **Overview**
> Adds a new `OpenClaw` section to the site: an `/openclaw` landing page explaining the memories.sh workspace-sync approach, including a **copyable CLI setup/refresh sequence**, plus a companion `/openclaw/resources` hub linking to official references and operational “tracks.”
> 
> Publishes an agent-focused runbook at `public/openclaw/llms.txt`, updates `TopNav` to support section anchors across routes (and adds an `OpenClaw` nav item), and includes the new routes in `sitemap.ts` for indexing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355308e3e5a5173879dbf5618a0e230bc03af84e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->