### PR TITLE
feat(openclaw): publish distributable skill and docs links

### DIFF
--- a/packages/web/content/docs/integrations/openclaw.mdx
+++ b/packages/web/content/docs/integrations/openclaw.mdx
@@ -88,6 +88,12 @@ fi
 - `memories generate agents` only creates `.agents/skills` when skills exist in your memory store, so copying skills should be conditional.
 - If you changed your workspace path in `~/.openclaw/openclaw.json` (for example `agent.workspace` or `agents.defaults.workspace`), replace `~/.openclaw/workspace` with your configured path.
 
+## OpenClaw Agent Skill (GitHub)
+
+The distributable OpenClaw skill lives in this repository and can be referenced directly:
+
+- [skills/openclaw/SKILL.md](https://github.com/webrenew/memories/tree/main/skills/openclaw)
+
 ## OpenClaw References
 
 - [Getting Started](https://docs.openclaw.ai/start/getting-started)

--- a/packages/web/src/app/openclaw/resources/page.tsx
+++ b/packages/web/src/app/openclaw/resources/page.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
 
 const officialReferences = [
   { label: "OpenClaw Integration (memories docs)", href: "/docs/integrations/openclaw", internal: true },
+  { label: "OpenClaw Agent Skill (GitHub)", href: "https://github.com/webrenew/memories/tree/main/skills/openclaw" },
   { label: "OpenClaw Docs Home", href: "https://docs.openclaw.ai/" },
   { label: "OpenClaw Onboarding", href: "https://docs.openclaw.ai/start/onboarding" },
   { label: "OpenClaw Agent Workspace", href: "https://docs.openclaw.ai/concepts/agent-workspace" },

--- a/skills/openclaw/SKILL.md
+++ b/skills/openclaw/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: openclaw
+description: "OpenClaw integration workflows for memories.sh. Use when: (1) Setting up OpenClaw with memories.sh (`openclaw onboard`, `memories init`), (2) Syncing OpenClaw workspace contracts (`~/.openclaw/workspace/AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, memory files, and skills), (3) Running repeatable refresh flows after memory updates, (4) Troubleshooting OpenClaw workspace drift, missing skills, or path/config mismatches, (5) Updating OpenClaw runbooks or `llms.txt` guidance."
+---
+
+# openclaw
+
+Canonical setup and operational guidance for OpenClaw + memories.sh.
+
+## Quick Start
+
+```bash
+# First-time setup
+openclaw onboard
+cd your-project
+memories init
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+memories generate agents
+mkdir -p ~/.openclaw/workspace/skills
+if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi
+memories files ingest --global --include-config
+memories files apply --global --include-config --force
+```
+
+## Workflow Decision Tree
+
+- If `openclaw` is missing, stop and direct the user to official OpenClaw install docs.
+- If OpenClaw was not onboarded on this machine, run first-time setup.
+- If setup exists and memories changed, run the ongoing refresh sequence.
+- If behavior appears stale, run verification checks and troubleshooting in order.
+- If workspace path is custom, read `~/.openclaw/openclaw.json` and replace default `~/.openclaw/workspace` paths.
+
+## Ongoing Refresh
+
+```bash
+cd your-project
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+memories generate agents
+if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi
+memories files ingest --global --include-config
+memories files apply --global --include-config --force
+```
+
+## Guardrails
+
+- Prefer deterministic generate + ingest/apply flows over manual workspace edits.
+- Keep skills copy conditional so missing `.agents/skills` does not fail the flow.
+- Do not delete user workspace files unless explicitly requested.
+- Treat project docs and official OpenClaw docs as source of truth.
+
+## Reference Files
+
+- **Operational workflows**: See [references/workflows.md](references/workflows.md) for setup, verification, and troubleshooting.

--- a/skills/openclaw/references/workflows.md
+++ b/skills/openclaw/references/workflows.md
@@ -1,0 +1,102 @@
+# OpenClaw + memories.sh Workflows
+
+Use these sequences exactly as written unless the user provides a custom workspace path.
+
+## Path A: First-time setup (recommended)
+
+```bash
+# 1) Install memories CLI
+pnpm add -g @memories.sh/cli
+
+# 2) Initialize OpenClaw workspace
+openclaw onboard
+
+# 3) Move to your project
+cd your-project
+
+# 4) Initialize memories in project
+memories init
+
+# 5) Generate OpenClaw AGENTS workspace file
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+
+# 6) Generate skills from memories
+memories generate agents
+
+# 7) Ensure OpenClaw skills directory exists
+mkdir -p ~/.openclaw/workspace/skills
+
+# 8) Copy generated skills into OpenClaw workspace
+if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi
+
+# 9) Ingest workspace files (include runtime config)
+memories files ingest --global --include-config
+
+# 10) Apply workspace files
+memories files apply --global --include-config --force
+```
+
+## Path B: Ongoing refresh
+
+```bash
+cd your-project
+memories generate claude -o ~/.openclaw/workspace/AGENTS.md --force
+memories generate agents
+if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi
+memories files ingest --global --include-config
+memories files apply --global --include-config --force
+```
+
+## Expected workspace artifacts
+
+- `~/.openclaw/workspace/AGENTS.md`
+- `~/.openclaw/workspace/SOUL.md`
+- `~/.openclaw/workspace/TOOLS.md`
+- `~/.openclaw/workspace/IDENTITY.md`
+- `~/.openclaw/workspace/USER.md`
+- `~/.openclaw/workspace/HEARTBEAT.md`
+- `~/.openclaw/workspace/BOOTSTRAP.md`
+- `~/.openclaw/workspace/BOOT.md` (if present)
+- `~/.openclaw/workspace/MEMORY.md` or `~/.openclaw/workspace/memory.md`
+- `~/.openclaw/workspace/memory/*.md`
+- `~/.openclaw/workspace/skills/**/*`
+
+Optional config sync:
+- `~/.openclaw/openclaw.json` via `--include-config`
+
+## Verification checklist
+
+```bash
+# Workspace exists
+ls -la ~/.openclaw/workspace
+
+# AGENTS file exists and was refreshed
+ls -la ~/.openclaw/workspace/AGENTS.md
+
+# Skills folder exists
+ls -la ~/.openclaw/workspace/skills
+
+# Generated skills exist locally (if expected)
+ls -la .agents/skills
+```
+
+## Troubleshooting
+
+### `openclaw: command not found`
+
+- Install OpenClaw first: `https://docs.openclaw.ai/install/index`
+
+### Skills did not copy
+
+- Confirm `memories generate agents` ran.
+- Keep copy conditional:
+  - `if [ -d .agents/skills ]; then cp -R .agents/skills/. ~/.openclaw/workspace/skills/; fi`
+
+### Wrong workspace path
+
+- Inspect `~/.openclaw/openclaw.json`.
+- Replace `~/.openclaw/workspace` with configured path in all commands.
+
+### Stale runtime behavior
+
+- Re-run Path B in order from the correct project directory.


### PR DESCRIPTION
## Summary
- add a distributable OpenClaw skill under `skills/openclaw` for GitHub discovery and skill-directory consumption
- add canonical OpenClaw setup/refresh/troubleshooting workflows in a reference file
- link the GitHub skill path from OpenClaw integration docs and the OpenClaw resource guide page

## Files
- `skills/openclaw/SKILL.md`
- `skills/openclaw/references/workflows.md`
- `packages/web/content/docs/integrations/openclaw.mdx`
- `packages/web/src/app/openclaw/resources/page.tsx`

## Validation
- eslint: `packages/web/src/app/openclaw/resources/page.tsx`
- pre-commit lint-staged checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/content-only changes plus new markdown skill files; no runtime logic or data-handling behavior is modified.
> 
> **Overview**
> Publishes a new distributable OpenClaw skill under `skills/openclaw` with a `SKILL.md` entrypoint and a referenced `references/workflows.md` runbook covering setup, refresh, verification, and troubleshooting commands.
> 
> Updates the OpenClaw integration docs and the `/openclaw/resources` page to link directly to the GitHub-hosted skill for easier discovery and reuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27178e92fd51dc65074fd7aaaa5ff7c6353cb11d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->