### PR TITLE
fix(web): prevent mobile overflow on OpenClaw landing

### DIFF
--- a/packages/web/src/app/openclaw/page.tsx
+++ b/packages/web/src/app/openclaw/page.tsx
@@ -163,7 +163,7 @@ export default function OpenClawPage(): React.JSX.Element {
         <section id="how-it-works" className="relative py-32 lg:py-44 border-y border-border bg-background-secondary">
           <div className="w-full px-6 lg:px-16 xl:px-24">
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 xl:gap-24">
-              <div className="flex flex-col items-start text-left">
+              <div className="min-w-0 flex flex-col items-start text-left">
                 <div className="inline-flex items-center gap-2 mb-6">
                   <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
                   <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
@@ -179,7 +179,7 @@ export default function OpenClawPage(): React.JSX.Element {
                 </p>
               </div>
 
-              <div>
+              <div className="min-w-0">
                 <div className="mb-5 flex items-center gap-2">
                   <Workflow className="h-4 w-4 text-primary" />
                   <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">Recommended flow</span>

--- a/packages/web/src/components/openclaw/SetupCommandSequence.tsx
+++ b/packages/web/src/components/openclaw/SetupCommandSequence.tsx
@@ -110,9 +110,9 @@ export function OpenClawSetupCommandSequence(): React.JSX.Element {
   };
 
   return (
-    <div className="glass-panel p-6 rounded-xl border border-border">
-      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
+    <div className="glass-panel min-w-0 max-w-full rounded-xl border border-border p-6">
+      <div className="mb-5 flex min-w-0 flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0 flex items-center gap-2">
           <div className="h-1.5 w-1.5 rounded-full bg-primary" />
           <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
             Recommended Flow (CLI)
@@ -129,17 +129,17 @@ export function OpenClawSetupCommandSequence(): React.JSX.Element {
         </button>
       </div>
 
-      <div className="space-y-2">
+      <div className="min-w-0 space-y-2">
         {commandSteps.map((step, index) => {
           const isCopied = copiedStepId === step.id;
           return (
-            <div key={step.id} className="rounded-lg border border-border bg-background/55 px-3 py-3">
-              <div className="flex items-start justify-between gap-3">
+            <div key={step.id} className="min-w-0 rounded-lg border border-border bg-background/55 px-3 py-3">
+              <div className="flex min-w-0 items-start justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                     Step {index + 1}: {step.title}
                   </p>
-                  <code className="mt-1 block overflow-x-auto whitespace-nowrap text-[12px] text-foreground/90">
+                  <code className="mt-1 block max-w-full overflow-x-auto whitespace-nowrap text-[12px] text-foreground/90">
                     {step.command}
                   </code>
                 </div>


### PR DESCRIPTION
## Summary
- fix horizontal overflow on `/openclaw` at mobile viewport widths
- enforce shrink-safe grid/flex behavior (`min-w-0`) in the "How it works" section
- constrain command sequence panel and rows with `min-w-0 max-w-full` so long CLI commands scroll inside the code line instead of expanding page width

## Files Changed
- `packages/web/src/app/openclaw/page.tsx`
- `packages/web/src/components/openclaw/SetupCommandSequence.tsx`

## Verification
- lint passed via pre-commit (`npx eslint --max-warnings 0`)
- mobile check with Playwright (`agent-browser`) at `390x844`:
  - before: `scrollWidth=785`, `innerWidth=390`, `overflow=true`
  - after: `scrollWidth=390`, `innerWidth=390`, `overflow=false`
  - overflow offender scan after fix: `offenderCount=0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS utility-class changes only, limited to layout/overflow behavior on a single landing page component.
> 
> **Overview**
> Fixes horizontal scrolling on the `/openclaw` landing page at mobile widths by enforcing shrink-safe grid/flex behavior (`min-w-0`) in the “How it works” section.
> 
> Updates `OpenClawSetupCommandSequence` styling to constrain the panel/rows (`min-w-0`, `max-w-full`) and ensure long CLI commands stay within the component via horizontal code-line scrolling rather than expanding page width.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82451b405fb2901fe3eafa052e94b3e779c1957d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->