### PR TITLE
refactor: harden auth, rate limits, and provisioning safety

### DIFF
--- a/packages/web/src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts
@@ -10,6 +10,7 @@ const {
   mockResolveSdkProjectBillingContext,
   mockCountActiveProjectsForBillingContext,
   mockRecordGrowthProjectMeterEvent,
+  mockDeleteDatabase,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockCheckRateLimit: vi.fn(),
@@ -20,6 +21,7 @@ const {
   mockResolveSdkProjectBillingContext: vi.fn(),
   mockCountActiveProjectsForBillingContext: vi.fn(),
   mockRecordGrowthProjectMeterEvent: vi.fn(),
+  mockDeleteDatabase: vi.fn(),
 }))
 
 vi.mock("@/lib/auth", () => ({
@@ -61,6 +63,7 @@ vi.mock("@/lib/sdk-api/runtime", async () => {
 vi.mock("@/lib/turso", () => ({
   createDatabase: vi.fn(),
   createDatabaseToken: vi.fn(),
+  deleteDatabase: mockDeleteDatabase,
   initSchema: vi.fn(),
 }))
 
@@ -75,6 +78,7 @@ import { DELETE, GET, POST } from "../route"
 describe("/api/sdk/v1/management/tenant-overrides", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockDeleteDatabase.mockResolvedValue(undefined)
 
     mockGetApiKey.mockReturnValue("mem_test_key")
     mockAuthenticateApiKey.mockResolvedValue({

--- a/packages/web/src/lib/cli-token.ts
+++ b/packages/web/src/lib/cli-token.ts
@@ -1,0 +1,11 @@
+import { createHash, randomBytes } from "node:crypto"
+
+export const CLI_AUTH_CODE_TTL_MS = 10 * 60 * 1000
+
+export function generateCliToken(): string {
+  return `cli_${randomBytes(32).toString("hex")}`
+}
+
+export function hashCliToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex")
+}

--- a/packages/web/src/lib/rate-limit.ts
+++ b/packages/web/src/lib/rate-limit.ts
@@ -1,7 +1,8 @@
 import { Ratelimit } from "@upstash/ratelimit"
 import { Redis } from "@upstash/redis"
 import { NextResponse } from "next/server"
-import { getUpstashRedisConfig } from "@/lib/env"
+import { isIP } from "node:net"
+import { getUpstashRedisConfig, parseBooleanFlag } from "@/lib/env"
 
 interface RateLimitResult {
   success: boolean
@@ -16,14 +17,46 @@ interface RateLimiter {
 
 class InMemorySlidingWindowLimiter implements RateLimiter {
   private readonly buckets = new Map<string, { count: number; reset: number }>()
+  private readonly maxBuckets: number
+  private lastCleanupAt = 0
 
   constructor(
     private readonly max: number,
-    private readonly windowMs: number
-  ) {}
+    private readonly windowMs: number,
+    maxBuckets = 10_000
+  ) {
+    this.maxBuckets = Math.max(1_000, maxBuckets)
+  }
+
+  private cleanup(now: number): void {
+    if (this.buckets.size < this.maxBuckets && now - this.lastCleanupAt < this.windowMs) {
+      return
+    }
+
+    this.lastCleanupAt = now
+
+    for (const [identifier, bucket] of this.buckets) {
+      if (bucket.reset <= now) {
+        this.buckets.delete(identifier)
+      }
+    }
+
+    if (this.buckets.size <= this.maxBuckets) {
+      return
+    }
+
+    const overflow = this.buckets.size - this.maxBuckets
+    const sortedByExpiry = [...this.buckets.entries()].sort((a, b) => a[1].reset - b[1].reset)
+    for (let i = 0; i < overflow; i += 1) {
+      const entry = sortedByExpiry[i]
+      if (!entry) break
+      this.buckets.delete(entry[0])
+    }
+  }
 
   async limit(identifier: string): Promise<RateLimitResult> {
     const now = Date.now()
+    this.cleanup(now)
     const bucket = this.buckets.get(identifier)
 
     if (!bucket || bucket.reset <= now) {
@@ -135,22 +168,42 @@ export async function checkPreAuthApiRateLimit(request: Request): Promise<NextRe
  * Extract client IP from request headers for public endpoint rate limiting.
  */
 export function getClientIp(request: Request): string {
-  const forwardedFor = request.headers.get("x-forwarded-for")
-  if (forwardedFor) {
-    const primaryForwardedIp = forwardedFor
-      .split(",")
-      .map((segment) => segment.trim())
-      .find((segment) => segment.length > 0)
+  const platformHeaders = [
+    "x-vercel-ip",
+    "cf-connecting-ip",
+    "fly-client-ip",
+    "fastly-client-ip",
+    "x-client-ip",
+  ]
 
-    if (primaryForwardedIp) {
-      return primaryForwardedIp
-    }
+  for (const header of platformHeaders) {
+    const value = normalizeClientIpCandidate(request.headers.get(header))
+    if (value) return value
   }
 
-  const realIp = request.headers.get("x-real-ip")?.trim()
-  if (realIp && realIp.length > 0) {
-    return realIp
+  const trustProxyHeaders = parseBooleanFlag(process.env.TRUST_PROXY_HEADERS, false)
+  if (trustProxyHeaders) {
+    const forwardedFor = request.headers.get("x-forwarded-for")
+    if (forwardedFor) {
+      const primaryForwardedIp = forwardedFor
+        .split(",")
+        .map((segment) => normalizeClientIpCandidate(segment))
+        .find((segment): segment is string => Boolean(segment))
+      if (primaryForwardedIp) {
+        return primaryForwardedIp
+      }
+    }
+
+    const realIp = normalizeClientIpCandidate(request.headers.get("x-real-ip"))
+    if (realIp) return realIp
   }
 
   return "unknown"
+}
+
+function normalizeClientIpCandidate(value: string | null | undefined): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return isIP(trimmed) ? trimmed : null
 }

--- a/packages/web/src/lib/turso.ts
+++ b/packages/web/src/lib/turso.ts
@@ -34,6 +34,15 @@ async function api<T>(
     throw new Error(`Turso API error (${res.status}): ${text}`)
   }
 
+  if (res.status === 204) {
+    return {} as T
+  }
+
+  const contentType = res.headers.get("content-type") ?? ""
+  if (!contentType.includes("application/json")) {
+    return {} as T
+  }
+
   return res.json() as Promise<T>
 }
 
@@ -68,6 +77,10 @@ export async function createDatabaseToken(
     { method: "POST" }
   )
   return jwt
+}
+
+export async function deleteDatabase(org: string, dbName: string): Promise<void> {
+  await api(`/organizations/${org}/databases/${dbName}`, { method: "DELETE" })
 }
 
 /**

--- a/supabase/migrations/20260218000100_harden_cli_token_storage.sql
+++ b/supabase/migrations/20260218000100_harden_cli_token_storage.sql
@@ -1,0 +1,9 @@
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS cli_token_hash TEXT;
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS cli_auth_expires_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_cli_token_hash
+  ON public.users(cli_token_hash)
+  WHERE cli_token_hash IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_cli_auth_expires_at
+  ON public.users(cli_auth_expires_at);


### PR DESCRIPTION
## Summary\n- harden CLI auth by hashing CLI tokens and adding auth code expiry semantics\n- harden rate limiting by tightening client IP trust rules and bounding in-memory limiter growth\n- add compensating Turso cleanup and retry backoff for auto/manual provisioning paths\n- fix invite acceptance ordering so billing runs after membership commit\n- refactor account deletion ordering for safer cleanup and auth/profile consistency\n\n## Validation\n- pnpm vitest run src/lib/__tests__/auth.test.ts src/app/api/auth/cli/__tests__/route.test.ts src/lib/__tests__/rate-limit.test.ts src/lib/memory-service/scope.test.ts src/app/api/db/provision/__tests__/route.test.ts src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts src/app/api/invites/accept/route.test.ts src/app/api/account/__tests__/route.test.ts\n- pnpm typecheck (packages/web)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, rate limiting, and Stripe/Turso cleanup flows; logic changes are safety-focused but could impact login/provisioning behavior and error handling if edge cases were missed.
> 
> **Overview**
> **Security & auth hardening:** CLI login now uses expiring auth codes and issues one-time CLI tokens that are *stored hashed* (new `cli_token_hash` + `cli_auth_expires_at` migration + `cli-token` helpers), with `authenticateRequest` preferring hashed lookup and a temporary legacy plaintext fallback.
> 
> **Operational safety improvements:** Rate limiting now validates/limits client IP extraction (trusted platform headers first; `x-forwarded-for` only when `TRUST_PROXY_HEADERS` is enabled) and bounds in-memory limiter bucket growth. Turso provisioning paths (`/api/db/provision`, SDK tenant overrides, and SDK auto-provisioning) add best-effort `deleteDatabase` cleanup on failures plus retry backoff metadata for repeated auto-provision errors.
> 
> **Flow/order changes:** Invite acceptance bills (adds team seat) only after membership is committed, and account deletion now fails fast on external cleanup errors (502), deletes the auth user before best-effort profile deletion, and returns `profileCleanupPending` when profile cleanup fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3e8bb50a3711999e9cdc15b523402a62ce53503. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->