### PR TITLE
feat(web): async embedding pipeline for hosted SDK write paths

### DIFF
--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -308,6 +308,26 @@ export function getSdkDefaultEmbeddingModelId(): string {
   return envValue("SDK_DEFAULT_EMBEDDING_MODEL_ID") ?? "openai/text-embedding-3-small"
 }
 
+export function getSdkEmbeddingJobMaxAttempts(): number {
+  return parsePositiveInt(process.env.SDK_EMBEDDING_JOB_MAX_ATTEMPTS, 5)
+}
+
+export function getSdkEmbeddingJobRetryBaseMs(): number {
+  return parsePositiveInt(process.env.SDK_EMBEDDING_JOB_RETRY_BASE_MS, 1_000)
+}
+
+export function getSdkEmbeddingJobRetryMaxMs(): number {
+  return parsePositiveInt(process.env.SDK_EMBEDDING_JOB_RETRY_MAX_MS, 60_000)
+}
+
+export function getSdkEmbeddingJobWorkerBatchSize(): number {
+  return parsePositiveInt(process.env.SDK_EMBEDDING_JOB_WORKER_BATCH_SIZE, 2)
+}
+
+export function getSdkEmbeddingJobProcessingTimeoutMs(): number {
+  return parsePositiveInt(process.env.SDK_EMBEDDING_JOB_PROCESSING_TIMEOUT_MS, 5 * 60 * 1_000)
+}
+
 export function shouldAutoProvisionTenants(): boolean {
   const flag = process.env.SDK_AUTO_PROVISION_TENANTS
   if (!flag) return true

--- a/packages/web/src/lib/memory-service/mutations.embeddings.test.ts
+++ b/packages/web/src/lib/memory-service/mutations.embeddings.test.ts
@@ -1,0 +1,172 @@
+import { createClient } from "@libsql/client"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+type DbClient = ReturnType<typeof createClient>
+
+const {
+  mockEnqueueEmbeddingJob,
+  mockTriggerEmbeddingQueueProcessing,
+} = vi.hoisted(() => ({
+  mockEnqueueEmbeddingJob: vi.fn(),
+  mockTriggerEmbeddingQueueProcessing: vi.fn(),
+}))
+
+vi.mock("@/lib/sdk-embeddings/jobs", () => ({
+  enqueueEmbeddingJob: mockEnqueueEmbeddingJob,
+  triggerEmbeddingQueueProcessing: mockTriggerEmbeddingQueueProcessing,
+}))
+
+const originalGraphMappingEnabled = process.env.GRAPH_MAPPING_ENABLED
+const testDatabases: DbClient[] = []
+
+async function setupDb(prefix: string): Promise<DbClient> {
+  const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const db = createClient({ url: `file:${join(dbDir, "mutations-embeddings.db")}` })
+  testDatabases.push(db)
+
+  await db.execute(
+    `CREATE TABLE IF NOT EXISTS memories (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      memory_layer TEXT,
+      expires_at TEXT,
+      scope TEXT NOT NULL,
+      project_id TEXT,
+      user_id TEXT,
+      tags TEXT,
+      paths TEXT,
+      category TEXT,
+      metadata TEXT,
+      deleted_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )`
+  )
+
+  return db
+}
+
+function restoreGraphMappingFlag(): void {
+  if (originalGraphMappingEnabled === undefined) {
+    delete process.env.GRAPH_MAPPING_ENABLED
+  } else {
+    process.env.GRAPH_MAPPING_ENABLED = originalGraphMappingEnabled
+  }
+}
+
+async function loadMutationsModule() {
+  vi.resetModules()
+  process.env.GRAPH_MAPPING_ENABLED = "false"
+  return import("./mutations")
+}
+
+afterEach(() => {
+  for (const db of testDatabases.splice(0, testDatabases.length)) {
+    db.close()
+  }
+  restoreGraphMappingFlag()
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
+describe("memory mutations embedding queue integration", () => {
+  it("keeps add_memory successful when embedding enqueue fails", async () => {
+    const db = await setupDb("memories-mutations-embedding-add")
+    mockEnqueueEmbeddingJob.mockRejectedValue(new Error("queue unavailable"))
+    const { addMemoryPayload } = await loadMutationsModule()
+
+    const payload = await addMemoryPayload({
+      turso: db,
+      args: {
+        content: "Persist this memory even if queueing fails.",
+        type: "note",
+        embeddingModel: "openai/text-embedding-3-small",
+      },
+      projectId: "github.com/webrenew/memories",
+      userId: "user-1",
+      nowIso: "2026-02-20T02:00:00.000Z",
+    })
+
+    expect(payload.data.id).toBeTruthy()
+
+    const stored = await db.execute({
+      sql: "SELECT id FROM memories WHERE id = ?",
+      args: [payload.data.id],
+    })
+    expect(stored.rows).toHaveLength(1)
+    expect(mockEnqueueEmbeddingJob).toHaveBeenCalledTimes(1)
+    expect(mockTriggerEmbeddingQueueProcessing).not.toHaveBeenCalled()
+  })
+
+  it("queues embeddings on edit only when content changes", async () => {
+    const db = await setupDb("memories-mutations-embedding-edit")
+    mockEnqueueEmbeddingJob.mockResolvedValue({ jobId: "job_1" })
+
+    await db.execute({
+      sql: `INSERT INTO memories (
+              id, content, type, memory_layer, expires_at, scope, project_id, user_id,
+              tags, paths, category, metadata, deleted_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        "mem_edit",
+        "Original content",
+        "note",
+        "long_term",
+        null,
+        "project",
+        "github.com/webrenew/memories",
+        "user-2",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "2026-02-20T03:00:00.000Z",
+        "2026-02-20T03:00:00.000Z",
+      ],
+    })
+
+    const { editMemoryPayload } = await loadMutationsModule()
+
+    await editMemoryPayload({
+      turso: db,
+      args: {
+        id: "mem_edit",
+        tags: ["billing"],
+        embeddingModel: "openai/text-embedding-3-small",
+      },
+      userId: "user-2",
+      nowIso: "2026-02-20T03:01:00.000Z",
+    })
+
+    expect(mockEnqueueEmbeddingJob).not.toHaveBeenCalled()
+    expect(mockTriggerEmbeddingQueueProcessing).not.toHaveBeenCalled()
+
+    await editMemoryPayload({
+      turso: db,
+      args: {
+        id: "mem_edit",
+        content: "Updated content for embedding regeneration",
+        embeddingModel: "openai/text-embedding-3-small",
+      },
+      userId: "user-2",
+      nowIso: "2026-02-20T03:02:00.000Z",
+    })
+
+    expect(mockEnqueueEmbeddingJob).toHaveBeenCalledTimes(1)
+    expect(mockEnqueueEmbeddingJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memoryId: "mem_edit",
+        content: "Updated content for embedding regeneration",
+        modelId: "openai/text-embedding-3-small",
+        operation: "edit",
+      })
+    )
+    expect(mockTriggerEmbeddingQueueProcessing).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/packages/web/src/lib/memory-service/scope-schema.ts
+++ b/packages/web/src/lib/memory-service/scope-schema.ts
@@ -8,6 +8,7 @@ const memorySchemaEnsuredKeys = new Set<string>()
 const MEMORY_SCHEMA_STATE_TABLE = "memory_schema_state"
 const MEMORY_USER_ID_SCHEMA_STATE_KEY = "memory_user_id_v1"
 const MEMORY_EMBEDDINGS_SCHEMA_STATE_KEY = "memory_embeddings_v1"
+const MEMORY_EMBEDDING_JOBS_SCHEMA_STATE_KEY = "memory_embedding_jobs_v1"
 
 // ─── Graph Schema ─────────────────────────────────────────────────────────────
 
@@ -150,6 +151,71 @@ async function ensureEmbeddingSchema(turso: TursoClient): Promise<void> {
   await turso.execute("CREATE INDEX IF NOT EXISTS idx_memory_embeddings_updated_at ON memory_embeddings(updated_at)")
 }
 
+async function ensureEmbeddingJobSchema(turso: TursoClient): Promise<void> {
+  // Rollback path: DROP TABLE memory_embedding_jobs;
+  // DROP TABLE memory_embedding_job_metrics;
+  // then clear marker: DELETE FROM memory_schema_state WHERE key = 'memory_embedding_jobs_v1';
+  await turso.execute(
+    `CREATE TABLE IF NOT EXISTS memory_embedding_jobs (
+      id TEXT PRIMARY KEY,
+      memory_id TEXT NOT NULL,
+      operation TEXT NOT NULL,
+      model TEXT NOT NULL,
+      content TEXT NOT NULL,
+      model_version TEXT,
+      status TEXT NOT NULL DEFAULT 'queued',
+      attempt_count INTEGER NOT NULL DEFAULT 0,
+      max_attempts INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts > 0),
+      next_attempt_at TEXT NOT NULL DEFAULT (datetime('now')),
+      claimed_by TEXT,
+      claimed_at TEXT,
+      last_error TEXT,
+      dead_letter_reason TEXT,
+      dead_letter_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(memory_id, model)
+    )`
+  )
+
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_memory_embedding_jobs_status_next_attempt ON memory_embedding_jobs(status, next_attempt_at)"
+  )
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_memory_embedding_jobs_memory_status ON memory_embedding_jobs(memory_id, status)"
+  )
+  await turso.execute("CREATE INDEX IF NOT EXISTS idx_memory_embedding_jobs_claimed_at ON memory_embedding_jobs(claimed_at)")
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_memory_embedding_jobs_dead_letter_at ON memory_embedding_jobs(dead_letter_at)"
+  )
+
+  await turso.execute(
+    `CREATE TABLE IF NOT EXISTS memory_embedding_job_metrics (
+      id TEXT PRIMARY KEY,
+      job_id TEXT NOT NULL,
+      memory_id TEXT NOT NULL,
+      operation TEXT NOT NULL,
+      model TEXT NOT NULL,
+      attempt INTEGER NOT NULL CHECK (attempt > 0),
+      outcome TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+      error_code TEXT,
+      error_message TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`
+  )
+
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_memory_embedding_job_metrics_job_created_at ON memory_embedding_job_metrics(job_id, created_at)"
+  )
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_memory_embedding_job_metrics_outcome_created_at ON memory_embedding_job_metrics(outcome, created_at)"
+  )
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_memory_embedding_job_metrics_created_at ON memory_embedding_job_metrics(created_at)"
+  )
+}
+
 // ─── Schema State Helpers ─────────────────────────────────────────────────────
 
 async function ensureSchemaStateTable(turso: TursoClient): Promise<void> {
@@ -259,6 +325,10 @@ export async function ensureMemoryUserIdSchema(
   await ensureEmbeddingSchema(turso)
   if (!(await isMemorySchemaMarked(turso, MEMORY_EMBEDDINGS_SCHEMA_STATE_KEY))) {
     await markMemorySchemaApplied(turso, MEMORY_EMBEDDINGS_SCHEMA_STATE_KEY)
+  }
+  await ensureEmbeddingJobSchema(turso)
+  if (!(await isMemorySchemaMarked(turso, MEMORY_EMBEDDING_JOBS_SCHEMA_STATE_KEY))) {
+    await markMemorySchemaApplied(turso, MEMORY_EMBEDDING_JOBS_SCHEMA_STATE_KEY)
   }
 
   memorySchemaEnsuredClients.add(turso)

--- a/packages/web/src/lib/sdk-embeddings/jobs.test.ts
+++ b/packages/web/src/lib/sdk-embeddings/jobs.test.ts
@@ -1,0 +1,252 @@
+import { createClient } from "@libsql/client"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope-schema"
+import { enqueueEmbeddingJob, processDueEmbeddingJobs } from "./jobs"
+
+type DbClient = ReturnType<typeof createClient>
+
+const testDatabases: DbClient[] = []
+
+const originalAiGatewayApiKey = process.env.AI_GATEWAY_API_KEY
+const originalAiGatewayBaseUrl = process.env.AI_GATEWAY_BASE_URL
+const originalRetryBaseMs = process.env.SDK_EMBEDDING_JOB_RETRY_BASE_MS
+const originalRetryMaxMs = process.env.SDK_EMBEDDING_JOB_RETRY_MAX_MS
+
+async function setupDb(prefix: string): Promise<DbClient> {
+  const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const db = createClient({ url: `file:${join(dbDir, "embedding-jobs.db")}` })
+  testDatabases.push(db)
+
+  await db.execute(
+    `CREATE TABLE memories (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      project_id TEXT,
+      paths TEXT,
+      category TEXT,
+      metadata TEXT,
+      tags TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )`
+  )
+
+  await ensureMemoryUserIdSchema(db, { cacheKey: `jobs:${prefix}:${Date.now()}` })
+  return db
+}
+
+async function insertMemory(
+  db: DbClient,
+  params: { id: string; content: string; nowIso?: string; deletedAt?: string | null }
+): Promise<void> {
+  const nowIso = params.nowIso ?? "2026-02-20T00:00:00.000Z"
+  await db.execute({
+    sql: `INSERT INTO memories (
+            id, content, type, memory_layer, expires_at, scope, project_id, user_id,
+            tags, paths, category, metadata, deleted_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      params.id,
+      params.content,
+      "note",
+      "long_term",
+      null,
+      "global",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      params.deletedAt ?? null,
+      nowIso,
+      nowIso,
+    ],
+  })
+}
+
+function blobByteLength(value: unknown): number {
+  if (value instanceof Uint8Array) return value.byteLength
+  if (value instanceof ArrayBuffer) return value.byteLength
+  if (ArrayBuffer.isView(value)) return value.byteLength
+  return 0
+}
+
+afterEach(() => {
+  for (const db of testDatabases.splice(0, testDatabases.length)) {
+    db.close()
+  }
+  vi.unstubAllGlobals()
+  if (originalAiGatewayApiKey === undefined) {
+    delete process.env.AI_GATEWAY_API_KEY
+  } else {
+    process.env.AI_GATEWAY_API_KEY = originalAiGatewayApiKey
+  }
+  if (originalAiGatewayBaseUrl === undefined) {
+    delete process.env.AI_GATEWAY_BASE_URL
+  } else {
+    process.env.AI_GATEWAY_BASE_URL = originalAiGatewayBaseUrl
+  }
+  if (originalRetryBaseMs === undefined) {
+    delete process.env.SDK_EMBEDDING_JOB_RETRY_BASE_MS
+  } else {
+    process.env.SDK_EMBEDDING_JOB_RETRY_BASE_MS = originalRetryBaseMs
+  }
+  if (originalRetryMaxMs === undefined) {
+    delete process.env.SDK_EMBEDDING_JOB_RETRY_MAX_MS
+  } else {
+    process.env.SDK_EMBEDDING_JOB_RETRY_MAX_MS = originalRetryMaxMs
+  }
+})
+
+beforeEach(() => {
+  process.env.AI_GATEWAY_API_KEY = "test_gateway_key"
+  process.env.AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh"
+  process.env.SDK_EMBEDDING_JOB_RETRY_BASE_MS = "1000"
+  process.env.SDK_EMBEDDING_JOB_RETRY_MAX_MS = "1000"
+})
+
+describe("sdk embedding jobs", () => {
+  it("processes queued embedding jobs and upserts memory embeddings", async () => {
+    const db = await setupDb("memories-embedding-jobs-success")
+    await insertMemory(db, { id: "mem_success", content: "The queue should persist this memory." })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ embedding: [0.12, -0.33, 0.48] }],
+            model: "openai/text-embedding-3-small",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      )
+    )
+
+    await enqueueEmbeddingJob({
+      turso: db,
+      memoryId: "mem_success",
+      content: "The queue should persist this memory.",
+      modelId: "openai/text-embedding-3-small",
+      operation: "add",
+      nowIso: "2026-02-20T00:00:00.000Z",
+    })
+
+    const summary = await processDueEmbeddingJobs({
+      turso: db,
+      maxJobs: 1,
+      nowIso: "2026-02-20T00:00:00.000Z",
+    })
+
+    expect(summary).toEqual({
+      processed: 1,
+      success: 1,
+      retries: 0,
+      deadLetters: 0,
+      skipped: 0,
+    })
+
+    const embeddingResult = await db.execute({
+      sql: "SELECT memory_id, model, model_version, dimension, embedding FROM memory_embeddings WHERE memory_id = ?",
+      args: ["mem_success"],
+    })
+    expect(embeddingResult.rows).toHaveLength(1)
+    const embeddingRow = embeddingResult.rows[0] as Record<string, unknown>
+    expect(String(embeddingRow.memory_id)).toBe("mem_success")
+    expect(String(embeddingRow.model)).toBe("openai/text-embedding-3-small")
+    expect(String(embeddingRow.model_version)).toBe("openai/text-embedding-3-small")
+    expect(Number(embeddingRow.dimension)).toBe(3)
+    expect(blobByteLength(embeddingRow.embedding)).toBe(12)
+
+    const jobResult = await db.execute({
+      sql: "SELECT status, attempt_count FROM memory_embedding_jobs WHERE memory_id = ?",
+      args: ["mem_success"],
+    })
+    expect(String(jobResult.rows[0]?.status ?? "")).toBe("succeeded")
+    expect(Number(jobResult.rows[0]?.attempt_count ?? -1)).toBe(1)
+
+    const metricsResult = await db.execute({
+      sql: "SELECT outcome FROM memory_embedding_job_metrics WHERE memory_id = ?",
+      args: ["mem_success"],
+    })
+    expect(metricsResult.rows).toHaveLength(1)
+    expect(String(metricsResult.rows[0]?.outcome ?? "")).toBe("success")
+  })
+
+  it("retries retryable failures and dead-letters after max attempts", async () => {
+    const db = await setupDb("memories-embedding-jobs-retry")
+    await insertMemory(db, { id: "mem_retry", content: "Retry this embedding job until dead-letter." })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response("gateway unavailable", {
+          status: 503,
+          headers: { "content-type": "text/plain" },
+        })
+      )
+    )
+
+    await enqueueEmbeddingJob({
+      turso: db,
+      memoryId: "mem_retry",
+      content: "Retry this embedding job until dead-letter.",
+      modelId: "openai/text-embedding-3-small",
+      operation: "edit",
+      maxAttempts: 2,
+      nowIso: "2026-02-20T01:00:00.000Z",
+    })
+
+    const firstRun = await processDueEmbeddingJobs({
+      turso: db,
+      maxJobs: 1,
+      nowIso: "2026-02-20T01:00:00.000Z",
+    })
+    expect(firstRun.processed).toBe(1)
+    expect(firstRun.retries).toBe(1)
+
+    const afterFirstFailure = await db.execute({
+      sql: "SELECT status, attempt_count FROM memory_embedding_jobs WHERE memory_id = ?",
+      args: ["mem_retry"],
+    })
+    expect(String(afterFirstFailure.rows[0]?.status ?? "")).toBe("queued")
+    expect(Number(afterFirstFailure.rows[0]?.attempt_count ?? -1)).toBe(1)
+
+    await db.execute({
+      sql: "UPDATE memory_embedding_jobs SET next_attempt_at = ? WHERE memory_id = ?",
+      args: ["2026-02-20T00:59:00.000Z", "mem_retry"],
+    })
+
+    const secondRun = await processDueEmbeddingJobs({
+      turso: db,
+      maxJobs: 1,
+      nowIso: "2026-02-20T01:01:00.000Z",
+    })
+    expect(secondRun.processed).toBe(1)
+    expect(secondRun.deadLetters).toBe(1)
+
+    const deadLetterJob = await db.execute({
+      sql: "SELECT status, attempt_count, dead_letter_at FROM memory_embedding_jobs WHERE memory_id = ?",
+      args: ["mem_retry"],
+    })
+    expect(String(deadLetterJob.rows[0]?.status ?? "")).toBe("dead_letter")
+    expect(Number(deadLetterJob.rows[0]?.attempt_count ?? -1)).toBe(2)
+    expect(String(deadLetterJob.rows[0]?.dead_letter_at ?? "")).toContain("2026-02-20")
+
+    const metrics = await db.execute({
+      sql: "SELECT outcome FROM memory_embedding_job_metrics WHERE memory_id = ? ORDER BY created_at ASC",
+      args: ["mem_retry"],
+    })
+    expect(metrics.rows.map((row) => String(row.outcome))).toEqual(["retry", "dead_letter"])
+  })
+})

--- a/packages/web/src/lib/sdk-embeddings/jobs.ts
+++ b/packages/web/src/lib/sdk-embeddings/jobs.ts
@@ -1,0 +1,661 @@
+import {
+  getAiGatewayApiKey,
+  getAiGatewayBaseUrl,
+  getSdkEmbeddingJobMaxAttempts,
+  getSdkEmbeddingJobProcessingTimeoutMs,
+  getSdkEmbeddingJobRetryBaseMs,
+  getSdkEmbeddingJobRetryMaxMs,
+  getSdkEmbeddingJobWorkerBatchSize,
+} from "@/lib/env"
+import type { TursoClient } from "@/lib/memory-service/types"
+
+export type EmbeddingJobOperation = "add" | "edit" | "backfill"
+
+type EmbeddingJobOutcome = "success" | "retry" | "dead_letter" | "skipped"
+
+interface EmbeddingJobRow {
+  id: string
+  memoryId: string
+  operation: EmbeddingJobOperation
+  model: string
+  modelVersion: string | null
+  content: string
+  attemptCount: number
+  maxAttempts: number
+}
+
+interface GatewayEmbeddingResponse {
+  data?: Array<{
+    embedding?: unknown
+  }>
+  model?: unknown
+}
+
+interface EmbeddingJobErrorOptions {
+  code: string
+  retryable: boolean
+  cause?: unknown
+}
+
+export interface EnqueueEmbeddingJobInput {
+  turso: TursoClient
+  memoryId: string
+  content: string
+  modelId: string
+  operation: EmbeddingJobOperation
+  modelVersion?: string | null
+  maxAttempts?: number
+  nowIso?: string
+}
+
+export interface ProcessEmbeddingJobsInput {
+  turso: TursoClient
+  maxJobs?: number
+  nowIso?: string
+}
+
+export interface ProcessEmbeddingJobsSummary {
+  processed: number
+  success: number
+  retries: number
+  deadLetters: number
+  skipped: number
+}
+
+class EmbeddingJobError extends Error {
+  readonly code: string
+  readonly retryable: boolean
+
+  constructor(message: string, options: EmbeddingJobErrorOptions) {
+    super(message)
+    this.name = "EmbeddingJobError"
+    this.code = options.code
+    this.retryable = options.retryable
+    if (options.cause !== undefined) {
+      ;(this as Error & { cause?: unknown }).cause = options.cause
+    }
+  }
+}
+
+function getRowsAffected(result: unknown): number {
+  if (!result || typeof result !== "object") return 0
+  const rowsAffected = (result as { rowsAffected?: unknown }).rowsAffected
+  return typeof rowsAffected === "number" && Number.isFinite(rowsAffected) ? rowsAffected : 0
+}
+
+function parsePositiveInt(value: unknown, fallback: number): number {
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed)
+  }
+  return fallback
+}
+
+function parseNonNegativeInt(value: unknown, fallback: number): number {
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return Math.floor(parsed)
+  }
+  return fallback
+}
+
+function truncateText(value: string, max = 1_200): string {
+  if (value.length <= max) return value
+  if (max <= 3) {
+    return value.slice(0, max)
+  }
+  return `${value.slice(0, max - 3)}...`
+}
+
+function encodeEmbedding(values: number[]): Uint8Array {
+  if (values.length === 0) {
+    throw new EmbeddingJobError("Embedding response was empty", {
+      code: "EMBEDDING_RESPONSE_EMPTY",
+      retryable: false,
+    })
+  }
+
+  const vector = new Float32Array(values.length)
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index]
+    if (!Number.isFinite(value)) {
+      throw new EmbeddingJobError("Embedding response contained non-finite values", {
+        code: "EMBEDDING_RESPONSE_INVALID_VALUE",
+        retryable: false,
+      })
+    }
+    vector[index] = value
+  }
+
+  const copy = vector.buffer.slice(vector.byteOffset, vector.byteOffset + vector.byteLength)
+  return new Uint8Array(copy)
+}
+
+function parseEmbeddingArray(payload: GatewayEmbeddingResponse): number[] {
+  const first = Array.isArray(payload.data) && payload.data.length > 0 ? payload.data[0] : null
+  const embedding = first?.embedding
+  if (!Array.isArray(embedding)) {
+    throw new EmbeddingJobError("Embedding response did not include a vector", {
+      code: "EMBEDDING_RESPONSE_MISSING_VECTOR",
+      retryable: false,
+    })
+  }
+
+  return embedding.map((value) => Number(value))
+}
+
+function computeRetryDelayMs(attempt: number): number {
+  const baseMs = getSdkEmbeddingJobRetryBaseMs()
+  const maxMs = getSdkEmbeddingJobRetryMaxMs()
+  const safeAttempt = Math.max(1, attempt)
+  const exponential = Math.round(baseMs * Math.pow(2, safeAttempt - 1))
+  return Math.max(baseMs, Math.min(maxMs, exponential))
+}
+
+function isRetryableHttpStatus(status: number): boolean {
+  return status === 429 || status >= 500
+}
+
+function toEmbeddingJobError(error: unknown): EmbeddingJobError {
+  if (error instanceof EmbeddingJobError) {
+    return error
+  }
+
+  const message = error instanceof Error ? error.message : "Unexpected embedding worker error"
+  return new EmbeddingJobError(message, {
+    code: "EMBEDDING_JOB_FAILED",
+    retryable: true,
+    cause: error,
+  })
+}
+
+async function fetchGatewayEmbedding(params: {
+  modelId: string
+  content: string
+}): Promise<{ embedding: number[]; modelVersion: string }> {
+  let apiKey: string
+  try {
+    apiKey = getAiGatewayApiKey()
+  } catch (error) {
+    throw new EmbeddingJobError("AI Gateway API key is not configured", {
+      code: "EMBEDDING_GATEWAY_CONFIG_MISSING",
+      retryable: false,
+      cause: error,
+    })
+  }
+
+  const baseUrl = getAiGatewayBaseUrl().replace(/\/$/, "")
+  let response: Response
+  try {
+    response = await fetch(`${baseUrl}/v1/embeddings`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: params.modelId,
+        input: params.content,
+      }),
+      cache: "no-store",
+    })
+  } catch (error) {
+    throw new EmbeddingJobError("Failed to call AI Gateway embeddings endpoint", {
+      code: "EMBEDDING_GATEWAY_REQUEST_FAILED",
+      retryable: true,
+      cause: error,
+    })
+  }
+
+  if (!response.ok) {
+    const bodyText = await response.text().catch(() => "")
+    throw new EmbeddingJobError(
+      `AI Gateway embeddings request failed with status ${response.status}${bodyText ? `: ${truncateText(bodyText, 300)}` : ""}`,
+      {
+        code: `EMBEDDING_GATEWAY_HTTP_${response.status}`,
+        retryable: isRetryableHttpStatus(response.status),
+      }
+    )
+  }
+
+  const payload = (await response.json().catch(() => null)) as GatewayEmbeddingResponse | null
+  if (!payload || typeof payload !== "object") {
+    throw new EmbeddingJobError("AI Gateway embeddings response was not valid JSON", {
+      code: "EMBEDDING_RESPONSE_INVALID_JSON",
+      retryable: true,
+    })
+  }
+
+  const embedding = parseEmbeddingArray(payload)
+  const modelVersion = typeof payload.model === "string" && payload.model.trim().length > 0 ? payload.model : "gateway-v1"
+  return { embedding, modelVersion }
+}
+
+async function requeueStaleProcessingJobs(turso: TursoClient, nowIso: string): Promise<void> {
+  const timeoutMs = getSdkEmbeddingJobProcessingTimeoutMs()
+  const staleBeforeIso = new Date(Date.parse(nowIso) - timeoutMs).toISOString()
+  await turso.execute({
+    sql: `UPDATE memory_embedding_jobs
+          SET status = 'queued',
+              next_attempt_at = ?,
+              updated_at = ?,
+              claimed_by = NULL,
+              claimed_at = NULL,
+              last_error = CASE
+                WHEN last_error IS NULL OR last_error = '' THEN 'worker processing timeout'
+                ELSE last_error
+              END
+          WHERE status = 'processing'
+            AND claimed_at IS NOT NULL
+            AND claimed_at <= ?`,
+    args: [nowIso, nowIso, staleBeforeIso],
+  })
+}
+
+async function claimNextDueJob(turso: TursoClient, nowIso: string): Promise<EmbeddingJobRow | null> {
+  const claimToken = crypto.randomUUID().replace(/-/g, "")
+  const claimResult = await turso.execute({
+    sql: `UPDATE memory_embedding_jobs
+          SET status = 'processing',
+              claimed_by = ?,
+              claimed_at = ?,
+              updated_at = ?
+          WHERE id = (
+            SELECT id
+            FROM memory_embedding_jobs
+            WHERE status = 'queued'
+              AND next_attempt_at <= ?
+            ORDER BY next_attempt_at ASC, created_at ASC
+            LIMIT 1
+          )
+          AND status = 'queued'`,
+    args: [claimToken, nowIso, nowIso, nowIso],
+  })
+
+  if (getRowsAffected(claimResult) === 0) {
+    return null
+  }
+
+  const result = await turso.execute({
+    sql: `SELECT id, memory_id, operation, model, model_version, content, attempt_count, max_attempts
+          FROM memory_embedding_jobs
+          WHERE claimed_by = ?
+            AND status = 'processing'
+          LIMIT 1`,
+    args: [claimToken],
+  })
+
+  if (!Array.isArray(result.rows) || result.rows.length === 0) {
+    return null
+  }
+
+  const row = result.rows[0] as Record<string, unknown>
+  const operationValue = String(row.operation ?? "")
+  const operation: EmbeddingJobOperation =
+    operationValue === "edit" || operationValue === "backfill" ? operationValue : "add"
+
+  return {
+    id: String(row.id ?? ""),
+    memoryId: String(row.memory_id ?? ""),
+    operation,
+    model: String(row.model ?? ""),
+    modelVersion: typeof row.model_version === "string" ? row.model_version : null,
+    content: String(row.content ?? ""),
+    attemptCount: parseNonNegativeInt(row.attempt_count, 0),
+    maxAttempts: parsePositiveInt(row.max_attempts, getSdkEmbeddingJobMaxAttempts()),
+  }
+}
+
+async function markJobSucceeded(params: {
+  turso: TursoClient
+  jobId: string
+  nowIso: string
+  attempts: number
+}): Promise<void> {
+  await params.turso.execute({
+    sql: `UPDATE memory_embedding_jobs
+          SET status = 'succeeded',
+              attempt_count = ?,
+              updated_at = ?,
+              claimed_by = NULL,
+              claimed_at = NULL,
+              last_error = NULL,
+              dead_letter_reason = NULL,
+              dead_letter_at = NULL
+          WHERE id = ?`,
+    args: [params.attempts, params.nowIso, params.jobId],
+  })
+}
+
+async function markJobForRetry(params: {
+  turso: TursoClient
+  jobId: string
+  attempts: number
+  nowIso: string
+  nextAttemptAt: string
+  errorMessage: string
+}): Promise<void> {
+  await params.turso.execute({
+    sql: `UPDATE memory_embedding_jobs
+          SET status = 'queued',
+              attempt_count = ?,
+              next_attempt_at = ?,
+              updated_at = ?,
+              claimed_by = NULL,
+              claimed_at = NULL,
+              last_error = ?,
+              dead_letter_reason = NULL,
+              dead_letter_at = NULL
+          WHERE id = ?`,
+    args: [params.attempts, params.nextAttemptAt, params.nowIso, truncateText(params.errorMessage), params.jobId],
+  })
+}
+
+async function markJobDeadLetter(params: {
+  turso: TursoClient
+  jobId: string
+  attempts: number
+  nowIso: string
+  reason: string
+}): Promise<void> {
+  await params.turso.execute({
+    sql: `UPDATE memory_embedding_jobs
+          SET status = 'dead_letter',
+              attempt_count = ?,
+              updated_at = ?,
+              claimed_by = NULL,
+              claimed_at = NULL,
+              last_error = ?,
+              dead_letter_reason = ?,
+              dead_letter_at = ?
+          WHERE id = ?`,
+    args: [
+      params.attempts,
+      params.nowIso,
+      truncateText(params.reason),
+      truncateText(params.reason),
+      params.nowIso,
+      params.jobId,
+    ],
+  })
+}
+
+async function recordJobMetric(params: {
+  turso: TursoClient
+  nowIso: string
+  job: EmbeddingJobRow
+  attempt: number
+  outcome: EmbeddingJobOutcome
+  durationMs: number
+  errorCode?: string | null
+  errorMessage?: string | null
+}): Promise<void> {
+  try {
+    await params.turso.execute({
+      sql: `INSERT INTO memory_embedding_job_metrics (
+              id,
+              job_id,
+              memory_id,
+              operation,
+              model,
+              attempt,
+              outcome,
+              duration_ms,
+              error_code,
+              error_message,
+              created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        crypto.randomUUID().replace(/-/g, ""),
+        params.job.id,
+        params.job.memoryId,
+        params.job.operation,
+        params.job.model,
+        params.attempt,
+        params.outcome,
+        Math.max(0, Math.round(params.durationMs)),
+        params.errorCode ?? null,
+        params.errorMessage ? truncateText(params.errorMessage) : null,
+        params.nowIso,
+      ],
+    })
+  } catch (error) {
+    console.error("Embedding job metrics insert failed:", error)
+  }
+}
+
+async function processSingleJob(turso: TursoClient, job: EmbeddingJobRow, nowIso: string): Promise<EmbeddingJobOutcome> {
+  const startedAt = Date.now()
+  const attempts = job.attemptCount + 1
+
+  try {
+    const memoryResult = await turso.execute({
+      sql: "SELECT id, deleted_at FROM memories WHERE id = ? LIMIT 1",
+      args: [job.memoryId],
+    })
+    const memoryRow = Array.isArray(memoryResult.rows) && memoryResult.rows.length > 0
+      ? (memoryResult.rows[0] as Record<string, unknown>)
+      : null
+    const isMissing = !memoryRow
+    const isDeleted = Boolean(memoryRow?.deleted_at)
+
+    if (isMissing || isDeleted) {
+      await turso.execute({
+        sql: "DELETE FROM memory_embeddings WHERE memory_id = ?",
+        args: [job.memoryId],
+      })
+      await markJobSucceeded({
+        turso,
+        jobId: job.id,
+        nowIso,
+        attempts,
+      })
+      await recordJobMetric({
+        turso,
+        nowIso,
+        job,
+        attempt: attempts,
+        outcome: "skipped",
+        durationMs: Date.now() - startedAt,
+        errorCode: "MEMORY_NOT_ACTIVE",
+        errorMessage: "Memory no longer exists or is deleted",
+      })
+      return "skipped"
+    }
+
+    const embeddingResponse = await fetchGatewayEmbedding({
+      modelId: job.model,
+      content: job.content,
+    })
+    const encoded = encodeEmbedding(embeddingResponse.embedding)
+    const modelVersion = job.modelVersion ?? embeddingResponse.modelVersion
+
+    await turso.execute({
+      sql: `INSERT INTO memory_embeddings (
+              memory_id, embedding, model, model_version, dimension, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(memory_id) DO UPDATE SET
+              embedding = excluded.embedding,
+              model = excluded.model,
+              model_version = excluded.model_version,
+              dimension = excluded.dimension,
+              updated_at = excluded.updated_at`,
+      args: [job.memoryId, encoded, job.model, modelVersion, embeddingResponse.embedding.length, nowIso, nowIso],
+    })
+
+    await markJobSucceeded({
+      turso,
+      jobId: job.id,
+      nowIso,
+      attempts,
+    })
+    await recordJobMetric({
+      turso,
+      nowIso,
+      job,
+      attempt: attempts,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+      errorCode: null,
+      errorMessage: null,
+    })
+
+    return "success"
+  } catch (error) {
+    const embeddingError = toEmbeddingJobError(error)
+    const elapsedMs = Date.now() - startedAt
+
+    if (embeddingError.retryable && attempts < job.maxAttempts) {
+      const delayMs = computeRetryDelayMs(attempts)
+      const nextAttemptAt = new Date(Date.parse(nowIso) + delayMs).toISOString()
+      await markJobForRetry({
+        turso,
+        jobId: job.id,
+        attempts,
+        nowIso,
+        nextAttemptAt,
+        errorMessage: `${embeddingError.code}: ${embeddingError.message}`,
+      })
+      await recordJobMetric({
+        turso,
+        nowIso,
+        job,
+        attempt: attempts,
+        outcome: "retry",
+        durationMs: elapsedMs,
+        errorCode: embeddingError.code,
+        errorMessage: embeddingError.message,
+      })
+      return "retry"
+    }
+
+    await markJobDeadLetter({
+      turso,
+      jobId: job.id,
+      attempts,
+      nowIso,
+      reason: `${embeddingError.code}: ${embeddingError.message}`,
+    })
+    await recordJobMetric({
+      turso,
+      nowIso,
+      job,
+      attempt: attempts,
+      outcome: "dead_letter",
+      durationMs: elapsedMs,
+      errorCode: embeddingError.code,
+      errorMessage: embeddingError.message,
+    })
+    return "dead_letter"
+  }
+}
+
+export async function enqueueEmbeddingJob(input: EnqueueEmbeddingJobInput): Promise<{ jobId: string } | null> {
+  const memoryId = input.memoryId.trim()
+  const modelId = input.modelId.trim()
+  const content = input.content.trim()
+  if (!memoryId || !modelId || !content) {
+    return null
+  }
+
+  const nowIso = input.nowIso ?? new Date().toISOString()
+  const maxAttempts = Math.max(1, input.maxAttempts ?? getSdkEmbeddingJobMaxAttempts())
+  const modelVersion = typeof input.modelVersion === "string" && input.modelVersion.trim().length > 0
+    ? input.modelVersion.trim()
+    : null
+
+  const newJobId = crypto.randomUUID().replace(/-/g, "")
+  await input.turso.execute({
+    sql: `INSERT INTO memory_embedding_jobs (
+            id, memory_id, operation, model, content, model_version, status,
+            attempt_count, max_attempts, next_attempt_at, claimed_by, claimed_at,
+            last_error, dead_letter_reason, dead_letter_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, 'queued', 0, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?)
+          ON CONFLICT(memory_id, model) DO UPDATE SET
+            operation = excluded.operation,
+            content = excluded.content,
+            model_version = excluded.model_version,
+            status = 'queued',
+            attempt_count = 0,
+            max_attempts = excluded.max_attempts,
+            next_attempt_at = excluded.next_attempt_at,
+            claimed_by = NULL,
+            claimed_at = NULL,
+            last_error = NULL,
+            dead_letter_reason = NULL,
+            dead_letter_at = NULL,
+            updated_at = excluded.updated_at`,
+    args: [
+      newJobId,
+      memoryId,
+      input.operation,
+      modelId,
+      content,
+      modelVersion,
+      maxAttempts,
+      nowIso,
+      nowIso,
+      nowIso,
+    ],
+  })
+
+  const result = await input.turso.execute({
+    sql: `SELECT id
+          FROM memory_embedding_jobs
+          WHERE memory_id = ? AND model = ?
+          LIMIT 1`,
+    args: [memoryId, modelId],
+  })
+  const existingId = Array.isArray(result.rows) && result.rows.length > 0
+    ? String((result.rows[0] as Record<string, unknown>).id ?? newJobId)
+    : newJobId
+
+  return {
+    jobId: existingId,
+  }
+}
+
+export async function processDueEmbeddingJobs(input: ProcessEmbeddingJobsInput): Promise<ProcessEmbeddingJobsSummary> {
+  const nowIso = input.nowIso ?? new Date().toISOString()
+  const maxJobs = Math.max(1, input.maxJobs ?? getSdkEmbeddingJobWorkerBatchSize())
+  const summary: ProcessEmbeddingJobsSummary = {
+    processed: 0,
+    success: 0,
+    retries: 0,
+    deadLetters: 0,
+    skipped: 0,
+  }
+
+  await requeueStaleProcessingJobs(input.turso, nowIso)
+
+  for (let index = 0; index < maxJobs; index += 1) {
+    const job = await claimNextDueJob(input.turso, nowIso)
+    if (!job) {
+      break
+    }
+
+    const outcome = await processSingleJob(input.turso, job, nowIso)
+    summary.processed += 1
+    if (outcome === "success") {
+      summary.success += 1
+    } else if (outcome === "retry") {
+      summary.retries += 1
+    } else if (outcome === "dead_letter") {
+      summary.deadLetters += 1
+    } else if (outcome === "skipped") {
+      summary.skipped += 1
+    }
+  }
+
+  return summary
+}
+
+export function triggerEmbeddingQueueProcessing(
+  turso: TursoClient,
+  options: { maxJobs?: number } = {}
+): void {
+  const maxJobs = Math.max(1, options.maxJobs ?? getSdkEmbeddingJobWorkerBatchSize())
+  void processDueEmbeddingJobs({ turso, maxJobs }).catch((error) => {
+    console.error("Embedding queue worker failed:", error)
+  })
+}


### PR DESCRIPTION
## Summary
- add a durable memory_embedding_jobs queue and memory_embedding_job_metrics table to hosted Turso schema
- add async embedding worker (packages/web/src/lib/sdk-embeddings/jobs.ts) with claim/retry/dead-letter handling and per-attempt metrics
- enqueue embedding jobs from hosted add/edit write paths without blocking or failing memory writes
- provision queue schema in both runtime migration path and fresh DB init path
- add focused tests for queue processing, retry/dead-letter behavior, schema migration coverage, and write-path resilience

## Verification
- pnpm --filter @memories.sh/web test
- pnpm --filter @memories.sh/web lint
- pnpm --filter @memories.sh/web typecheck
- pnpm test
- pnpm typecheck
- pnpm build

Closes #184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DB tables and background job-processing logic that affects embedding generation and database writes; failures are isolated from memory writes but retry/claim behavior and schema rollout could impact throughput and operational stability.
> 
> **Overview**
> Adds an **async, durable embeddings pipeline** for hosted SDK memory writes by introducing a `memory_embedding_jobs` queue (plus `memory_embedding_job_metrics`) and a worker that claims jobs, calls the AI Gateway embeddings API, upserts `memory_embeddings`, and handles retry/backoff, stale-processing requeue, and dead-lettering.
> 
> Hosted `add_memory`/`edit_memory` now **enqueue embedding work without blocking the write** (errors are caught/logged), and edits only enqueue when `content` changes. Schema provisioning is wired into both the runtime migration path (`ensureMemoryUserIdSchema`) and fresh DB initialization (`initSchema`), with new env knobs for job attempts, retry timing, batch size, and processing timeout, plus targeted tests covering queue processing and write-path resilience.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f9d7c0de951ff958e48cfecfe2b16440a2b8221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->