### PR TITLE
feat(web): backfill worker for existing SDK embeddings

### DIFF
--- a/packages/web/src/app/api/sdk/v1/management/embeddings/backfill/__tests__/route.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/embeddings/backfill/__tests__/route.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+const {
+  mockResolveManagementIdentity,
+  mockResolveTursoForScope,
+  mockEnsureMemoryUserIdSchema,
+  mockGetEmbeddingBackfillStatus,
+  mockRunEmbeddingBackfillBatch,
+  mockSetEmbeddingBackfillPaused,
+} = vi.hoisted(() => ({
+  mockResolveManagementIdentity: vi.fn(),
+  mockResolveTursoForScope: vi.fn(),
+  mockEnsureMemoryUserIdSchema: vi.fn(),
+  mockGetEmbeddingBackfillStatus: vi.fn(),
+  mockRunEmbeddingBackfillBatch: vi.fn(),
+  mockSetEmbeddingBackfillPaused: vi.fn(),
+}))
+
+vi.mock("@/app/api/sdk/v1/management/identity", () => ({
+  resolveManagementIdentity: mockResolveManagementIdentity,
+}))
+
+vi.mock("@/lib/memory-service/scope", () => ({
+  ensureMemoryUserIdSchema: mockEnsureMemoryUserIdSchema,
+}))
+
+vi.mock("@/lib/sdk-embeddings/backfill", () => ({
+  getEmbeddingBackfillStatus: mockGetEmbeddingBackfillStatus,
+  runEmbeddingBackfillBatch: mockRunEmbeddingBackfillBatch,
+  setEmbeddingBackfillPaused: mockSetEmbeddingBackfillPaused,
+}))
+
+vi.mock("@/lib/sdk-api/runtime", () => ({
+  resolveTursoForScope: mockResolveTursoForScope,
+  successResponse: (endpoint: string, requestId: string, data: unknown, status = 200) =>
+    new Response(
+      JSON.stringify({
+        ok: true,
+        data,
+        error: null,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-20T00:00:00.000Z" },
+      }),
+      { status, headers: { "content-type": "application/json" } }
+    ),
+  errorResponse: (endpoint: string, requestId: string, detail: unknown) =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: detail,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-20T00:00:00.000Z" },
+      }),
+      { status: 500, headers: { "content-type": "application/json" } }
+    ),
+  invalidRequestResponse: (endpoint: string, requestId: string, message = "Invalid request payload") =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: {
+          type: "validation_error",
+          code: "INVALID_REQUEST",
+          message,
+          status: 400,
+          retryable: false,
+        },
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-20T00:00:00.000Z" },
+      }),
+      { status: 400, headers: { "content-type": "application/json" } }
+    ),
+}))
+
+import { GET, POST } from "../route"
+
+describe("/api/sdk/v1/management/embeddings/backfill", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockResolveManagementIdentity.mockResolvedValue({
+      userId: "user-1",
+      apiKeyHash: "hash-1",
+      authMode: "api_key",
+    })
+
+    mockResolveTursoForScope.mockResolvedValue({ execute: vi.fn() })
+    mockEnsureMemoryUserIdSchema.mockResolvedValue(undefined)
+
+    mockGetEmbeddingBackfillStatus.mockResolvedValue({
+      scopeKey: "openai/text-embedding-3-small|*|*",
+      modelId: "openai/text-embedding-3-small",
+      projectId: null,
+      userId: null,
+      status: "idle",
+      checkpointCreatedAt: null,
+      checkpointMemoryId: null,
+      scannedCount: 0,
+      enqueuedCount: 0,
+      estimatedTotal: 0,
+      estimatedRemaining: 0,
+      estimatedCompletionSeconds: 0,
+      batchLimit: 100,
+      throttleMs: 25,
+      startedAt: null,
+      lastRunAt: null,
+      completedAt: null,
+      updatedAt: null,
+      lastError: null,
+    })
+
+    mockRunEmbeddingBackfillBatch.mockResolvedValue({
+      status: {
+        scopeKey: "openai/text-embedding-3-small|*|*",
+        modelId: "openai/text-embedding-3-small",
+        projectId: null,
+        userId: null,
+        status: "running",
+        checkpointCreatedAt: "2026-02-20T00:00:00.000Z",
+        checkpointMemoryId: "mem-1",
+        scannedCount: 1,
+        enqueuedCount: 1,
+        estimatedTotal: 10,
+        estimatedRemaining: 9,
+        estimatedCompletionSeconds: 90,
+        batchLimit: 1,
+        throttleMs: 0,
+        startedAt: "2026-02-20T00:00:00.000Z",
+        lastRunAt: "2026-02-20T00:00:00.000Z",
+        completedAt: null,
+        updatedAt: "2026-02-20T00:00:00.000Z",
+        lastError: null,
+      },
+      batch: {
+        scanned: 1,
+        enqueued: 1,
+        durationMs: 120,
+      },
+    })
+
+    mockSetEmbeddingBackfillPaused.mockResolvedValue({
+      scopeKey: "openai/text-embedding-3-small|*|*",
+      modelId: "openai/text-embedding-3-small",
+      projectId: null,
+      userId: null,
+      status: "paused",
+      checkpointCreatedAt: null,
+      checkpointMemoryId: null,
+      scannedCount: 0,
+      enqueuedCount: 0,
+      estimatedTotal: 0,
+      estimatedRemaining: 0,
+      estimatedCompletionSeconds: 0,
+      batchLimit: 100,
+      throttleMs: 25,
+      startedAt: null,
+      lastRunAt: null,
+      completedAt: null,
+      updatedAt: "2026-02-20T00:00:00.000Z",
+      lastError: null,
+    })
+  })
+
+  it("returns backfill status on GET", async () => {
+    const response = await GET(
+      new NextRequest("https://example.com/api/sdk/v1/management/embeddings/backfill?modelId=openai/text-embedding-3-small")
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.status).toBe("idle")
+    expect(mockGetEmbeddingBackfillStatus).toHaveBeenCalled()
+  })
+
+  it("runs a backfill batch on POST action=run", async () => {
+    const response = await POST(
+      new NextRequest("https://example.com/api/sdk/v1/management/embeddings/backfill", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "run",
+          modelId: "openai/text-embedding-3-small",
+          batchLimit: 1,
+          throttleMs: 0,
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.action).toBe("run")
+    expect(body.data.batch.scanned).toBe(1)
+    expect(mockRunEmbeddingBackfillBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: "openai/text-embedding-3-small",
+        batchLimit: 1,
+        throttleMs: 0,
+      })
+    )
+  })
+
+  it("pauses backfill on POST action=pause", async () => {
+    const response = await POST(
+      new NextRequest("https://example.com/api/sdk/v1/management/embeddings/backfill", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "pause",
+          modelId: "openai/text-embedding-3-small",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.action).toBe("pause")
+    expect(body.data.status.status).toBe("paused")
+    expect(mockSetEmbeddingBackfillPaused).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paused: true,
+      })
+    )
+  })
+
+  it("returns validation envelope for invalid POST payload", async () => {
+    const response = await POST(
+      new NextRequest("https://example.com/api/sdk/v1/management/embeddings/backfill", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "run",
+          batchLimit: 0,
+        }),
+      })
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("INVALID_REQUEST")
+  })
+})
+

--- a/packages/web/src/app/api/sdk/v1/management/embeddings/backfill/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/embeddings/backfill/route.ts
@@ -1,0 +1,219 @@
+import { resolveManagementIdentity } from "@/app/api/sdk/v1/management/identity"
+import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope"
+import { apiError } from "@/lib/memory-service/tools"
+import {
+  getEmbeddingBackfillStatus,
+  runEmbeddingBackfillBatch,
+  setEmbeddingBackfillPaused,
+} from "@/lib/sdk-embeddings/backfill"
+import { errorResponse, invalidRequestResponse, resolveTursoForScope, successResponse } from "@/lib/sdk-api/runtime"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+const ENDPOINT = "/api/sdk/v1/management/embeddings/backfill"
+
+const querySchema = z.object({
+  tenantId: z.string().trim().min(1).max(120).optional(),
+  projectId: z.string().trim().min(1).max(240).optional(),
+  userId: z.string().trim().min(1).max(120).optional(),
+  modelId: z.string().trim().min(1).max(160).optional(),
+})
+
+const postSchema = z.object({
+  action: z.enum(["run", "pause", "resume"]).default("run"),
+  tenantId: z.string().trim().min(1).max(120).optional(),
+  projectId: z.string().trim().min(1).max(240).optional(),
+  userId: z.string().trim().min(1).max(120).optional(),
+  modelId: z.string().trim().min(1).max(160).optional(),
+  batchLimit: z.number().int().min(1).max(10_000).optional(),
+  throttleMs: z.number().int().min(0).max(5_000).optional(),
+})
+
+function parseQuery(request: NextRequest): z.input<typeof querySchema> {
+  const url = new URL(request.url)
+  return {
+    tenantId: url.searchParams.get("tenantId") ?? undefined,
+    projectId: url.searchParams.get("projectId") ?? undefined,
+    userId: url.searchParams.get("userId") ?? undefined,
+    modelId: url.searchParams.get("modelId") ?? undefined,
+  }
+}
+
+async function resolveBackfillTurso(params: {
+  endpoint: string
+  requestId: string
+  ownerUserId: string
+  apiKeyHash: string
+  tenantId: string | null
+  projectId: string | null
+}): Promise<ReturnType<typeof resolveTursoForScope> | NextResponse> {
+  const turso = await resolveTursoForScope({
+    ownerUserId: params.ownerUserId,
+    apiKeyHash: params.apiKeyHash,
+    tenantId: params.tenantId,
+    projectId: params.projectId,
+    endpoint: params.endpoint,
+    requestId: params.requestId,
+  })
+
+  if (turso instanceof NextResponse) {
+    return turso
+  }
+
+  await ensureMemoryUserIdSchema(turso)
+  return turso
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const identity = await resolveManagementIdentity({
+    endpoint: ENDPOINT,
+    request,
+    requestId,
+    method: "GET",
+    missingApiKeyMessage: "Generate an API key before viewing embedding backfill status",
+    expiredApiKeyMessage: "API key expired. Generate a new key before viewing embedding backfill status.",
+    apiKeyMetadataLookupLogContext: "Failed to load API key metadata for embedding backfill status:",
+  })
+  if (identity instanceof NextResponse) return identity
+
+  const parsed = querySchema.safeParse(parseQuery(request))
+  if (!parsed.success) {
+    return invalidRequestResponse(
+      ENDPOINT,
+      requestId,
+      parsed.error.issues[0]?.message ?? "Invalid request payload"
+    )
+  }
+
+  const tenantId = parsed.data.tenantId ?? null
+  const projectId = parsed.data.projectId ?? null
+
+  try {
+    const turso = await resolveBackfillTurso({
+      endpoint: ENDPOINT,
+      requestId,
+      ownerUserId: identity.userId,
+      apiKeyHash: identity.apiKeyHash,
+      tenantId,
+      projectId,
+    })
+    if (turso instanceof NextResponse) {
+      return turso
+    }
+
+    const status = await getEmbeddingBackfillStatus({
+      turso,
+      modelId: parsed.data.modelId,
+      projectId,
+      userId: parsed.data.userId ?? null,
+    })
+
+    return successResponse(ENDPOINT, requestId, status)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load embedding backfill status"
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "EMBEDDING_BACKFILL_STATUS_FAILED",
+        message,
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const identity = await resolveManagementIdentity({
+    endpoint: ENDPOINT,
+    request,
+    requestId,
+    method: "POST",
+    missingApiKeyMessage: "Generate an API key before running embedding backfill",
+    expiredApiKeyMessage: "API key expired. Generate a new key before running embedding backfill.",
+    apiKeyMetadataLookupLogContext: "Failed to load API key metadata for embedding backfill:",
+  })
+  if (identity instanceof NextResponse) return identity
+
+  const parsed = postSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return invalidRequestResponse(
+      ENDPOINT,
+      requestId,
+      parsed.error.issues[0]?.message ?? "Invalid request payload"
+    )
+  }
+
+  const tenantId = parsed.data.tenantId ?? null
+  const projectId = parsed.data.projectId ?? null
+
+  try {
+    const turso = await resolveBackfillTurso({
+      endpoint: ENDPOINT,
+      requestId,
+      ownerUserId: identity.userId,
+      apiKeyHash: identity.apiKeyHash,
+      tenantId,
+      projectId,
+    })
+    if (turso instanceof NextResponse) {
+      return turso
+    }
+
+    if (parsed.data.action === "pause") {
+      const status = await setEmbeddingBackfillPaused({
+        turso,
+        paused: true,
+        modelId: parsed.data.modelId,
+        projectId,
+        userId: parsed.data.userId ?? null,
+      })
+      return successResponse(ENDPOINT, requestId, { action: "pause", status })
+    }
+
+    if (parsed.data.action === "resume") {
+      const status = await setEmbeddingBackfillPaused({
+        turso,
+        paused: false,
+        modelId: parsed.data.modelId,
+        projectId,
+        userId: parsed.data.userId ?? null,
+      })
+      return successResponse(ENDPOINT, requestId, { action: "resume", status })
+    }
+
+    const result = await runEmbeddingBackfillBatch({
+      turso,
+      modelId: parsed.data.modelId,
+      projectId,
+      userId: parsed.data.userId ?? null,
+      batchLimit: parsed.data.batchLimit,
+      throttleMs: parsed.data.throttleMs,
+    })
+
+    return successResponse(ENDPOINT, requestId, {
+      action: "run",
+      ...result,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to run embedding backfill"
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "EMBEDDING_BACKFILL_RUN_FAILED",
+        message,
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+}
+

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -10,6 +10,11 @@ export function parsePositiveInt(value: string | undefined, fallback: number): n
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+export function parseNonNegativeInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
 export function parseBooleanFlag(value: string | undefined, fallback = false): boolean {
   if (!value) return fallback
   const normalized = value.trim().toLowerCase()
@@ -326,6 +331,14 @@ export function getSdkEmbeddingJobWorkerBatchSize(): number {
 
 export function getSdkEmbeddingJobProcessingTimeoutMs(): number {
   return parsePositiveInt(process.env.SDK_EMBEDDING_JOB_PROCESSING_TIMEOUT_MS, 5 * 60 * 1_000)
+}
+
+export function getSdkEmbeddingBackfillBatchSize(): number {
+  return parsePositiveInt(process.env.SDK_EMBEDDING_BACKFILL_BATCH_SIZE, 100)
+}
+
+export function getSdkEmbeddingBackfillThrottleMs(): number {
+  return parseNonNegativeInt(process.env.SDK_EMBEDDING_BACKFILL_THROTTLE_MS, 25)
 }
 
 export function shouldAutoProvisionTenants(): boolean {

--- a/packages/web/src/lib/memory-service/scope-schema.test.ts
+++ b/packages/web/src/lib/memory-service/scope-schema.test.ts
@@ -67,6 +67,12 @@ describe("ensureMemoryUserIdSchema", () => {
     })
     expect(String(embeddingJobsMarker.rows[0]?.value ?? "")).toBe("1")
 
+    const embeddingBackfillMarker = await db.execute({
+      sql: "SELECT value FROM memory_schema_state WHERE key = ?",
+      args: ["memory_embedding_backfill_v1"],
+    })
+    expect(String(embeddingBackfillMarker.rows[0]?.value ?? "")).toBe("1")
+
     const embeddingColumns = await db.execute("PRAGMA table_info(memory_embeddings)")
     const embeddingColumnNames = new Set(embeddingColumns.rows.map((row) => String(row.name)))
     expect(embeddingColumnNames.has("memory_id")).toBe(true)
@@ -126,6 +132,47 @@ describe("ensureMemoryUserIdSchema", () => {
     expect(embeddingMetricIndexNames.has("idx_memory_embedding_job_metrics_job_created_at")).toBe(true)
     expect(embeddingMetricIndexNames.has("idx_memory_embedding_job_metrics_outcome_created_at")).toBe(true)
     expect(embeddingMetricIndexNames.has("idx_memory_embedding_job_metrics_created_at")).toBe(true)
+
+    const embeddingBackfillStateColumns = await db.execute("PRAGMA table_info(memory_embedding_backfill_state)")
+    const embeddingBackfillStateColumnNames = new Set(embeddingBackfillStateColumns.rows.map((row) => String(row.name)))
+    expect(embeddingBackfillStateColumnNames.has("scope_key")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("model")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("status")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("checkpoint_created_at")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("checkpoint_memory_id")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("scanned_count")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("enqueued_count")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("estimated_total")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("estimated_remaining")).toBe(true)
+    expect(embeddingBackfillStateColumnNames.has("estimated_completion_seconds")).toBe(true)
+
+    const embeddingBackfillStateIndexes = await db.execute({
+      sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?",
+      args: ["memory_embedding_backfill_state"],
+    })
+    const embeddingBackfillStateIndexNames = new Set(embeddingBackfillStateIndexes.rows.map((row) => String(row.name)))
+    expect(embeddingBackfillStateIndexNames.has("idx_memory_embedding_backfill_state_status_updated")).toBe(true)
+
+    const embeddingBackfillMetricColumns = await db.execute("PRAGMA table_info(memory_embedding_backfill_metrics)")
+    const embeddingBackfillMetricColumnNames = new Set(embeddingBackfillMetricColumns.rows.map((row) => String(row.name)))
+    expect(embeddingBackfillMetricColumnNames.has("id")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("scope_key")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("model")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("batch_scanned")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("batch_enqueued")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("total_scanned")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("total_enqueued")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("estimated_total")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("estimated_remaining")).toBe(true)
+    expect(embeddingBackfillMetricColumnNames.has("status")).toBe(true)
+
+    const embeddingBackfillMetricIndexes = await db.execute({
+      sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?",
+      args: ["memory_embedding_backfill_metrics"],
+    })
+    const embeddingBackfillMetricIndexNames = new Set(embeddingBackfillMetricIndexes.rows.map((row) => String(row.name)))
+    expect(embeddingBackfillMetricIndexNames.has("idx_memory_embedding_backfill_metrics_scope_ran_at")).toBe(true)
+    expect(embeddingBackfillMetricIndexNames.has("idx_memory_embedding_backfill_metrics_status_ran_at")).toBe(true)
   })
 
   it("upgrades embedding schema for tenants already marked on the user-id migration", async () => {
@@ -174,6 +221,12 @@ describe("ensureMemoryUserIdSchema", () => {
     })
     expect(String(embeddingJobsMarker.rows[0]?.value ?? "")).toBe("1")
 
+    const embeddingBackfillMarker = await db.execute({
+      sql: "SELECT value FROM memory_schema_state WHERE key = ?",
+      args: ["memory_embedding_backfill_v1"],
+    })
+    expect(String(embeddingBackfillMarker.rows[0]?.value ?? "")).toBe("1")
+
     const embeddingsTable = await db.execute({
       sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
       args: ["memory_embeddings"],
@@ -185,5 +238,17 @@ describe("ensureMemoryUserIdSchema", () => {
       args: ["memory_embedding_jobs"],
     })
     expect(embeddingJobsTable.rows).toHaveLength(1)
+
+    const embeddingBackfillStateTable = await db.execute({
+      sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+      args: ["memory_embedding_backfill_state"],
+    })
+    expect(embeddingBackfillStateTable.rows).toHaveLength(1)
+
+    const embeddingBackfillMetricTable = await db.execute({
+      sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+      args: ["memory_embedding_backfill_metrics"],
+    })
+    expect(embeddingBackfillMetricTable.rows).toHaveLength(1)
   })
 })

--- a/packages/web/src/lib/sdk-embeddings/backfill.test.ts
+++ b/packages/web/src/lib/sdk-embeddings/backfill.test.ts
@@ -1,0 +1,178 @@
+import { createClient } from "@libsql/client"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope-schema"
+import { getEmbeddingBackfillStatus, runEmbeddingBackfillBatch, setEmbeddingBackfillPaused } from "./backfill"
+
+type DbClient = ReturnType<typeof createClient>
+
+const testDatabases: DbClient[] = []
+
+async function setupDb(prefix: string): Promise<DbClient> {
+  const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const db = createClient({ url: `file:${join(dbDir, "embedding-backfill.db")}` })
+  testDatabases.push(db)
+
+  await db.execute(
+    `CREATE TABLE memories (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      project_id TEXT,
+      paths TEXT,
+      category TEXT,
+      metadata TEXT,
+      tags TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )`
+  )
+
+  await ensureMemoryUserIdSchema(db, { cacheKey: `backfill:${prefix}:${Date.now()}` })
+  return db
+}
+
+async function insertMemory(db: DbClient, params: { id: string; content: string; createdAt: string }): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO memories (
+            id, content, type, memory_layer, expires_at, scope, project_id, user_id,
+            tags, paths, category, metadata, deleted_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      params.id,
+      params.content,
+      "note",
+      "long_term",
+      null,
+      "global",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      params.createdAt,
+      params.createdAt,
+    ],
+  })
+}
+
+afterEach(() => {
+  for (const db of testDatabases.splice(0, testDatabases.length)) {
+    db.close()
+  }
+})
+
+describe("sdk embedding backfill", () => {
+  it("tracks checkpointed progress across batches and completes idempotently", async () => {
+    const db = await setupDb("memories-embedding-backfill-progress")
+    await insertMemory(db, { id: "mem-1", content: "First memory", createdAt: "2026-02-20T00:00:00.000Z" })
+    await insertMemory(db, { id: "mem-2", content: "Second memory", createdAt: "2026-02-20T00:00:01.000Z" })
+    await insertMemory(db, { id: "mem-3", content: "Third memory", createdAt: "2026-02-20T00:00:02.000Z" })
+    await insertMemory(db, { id: "mem-4", content: "Fourth memory", createdAt: "2026-02-20T00:00:03.000Z" })
+
+    const firstBatch = await runEmbeddingBackfillBatch({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      batchLimit: 2,
+      throttleMs: 0,
+      nowIso: "2026-02-20T00:10:00.000Z",
+    })
+
+    expect(firstBatch.batch.scanned).toBe(2)
+    expect(firstBatch.batch.enqueued).toBe(2)
+    expect(firstBatch.status.status).toBe("running")
+    expect(firstBatch.status.checkpointMemoryId).toBe("mem-2")
+    expect(firstBatch.status.estimatedRemaining).toBe(2)
+
+    const queueAfterFirst = await db.execute("SELECT COUNT(*) as count FROM memory_embedding_jobs")
+    expect(Number(queueAfterFirst.rows[0]?.count ?? 0)).toBe(2)
+
+    const secondBatch = await runEmbeddingBackfillBatch({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      batchLimit: 2,
+      throttleMs: 0,
+      nowIso: "2026-02-20T00:11:00.000Z",
+    })
+
+    expect(secondBatch.batch.scanned).toBe(2)
+    expect(secondBatch.batch.enqueued).toBe(2)
+    expect(secondBatch.status.status).toBe("completed")
+    expect(secondBatch.status.estimatedRemaining).toBe(0)
+    expect(secondBatch.status.estimatedCompletionSeconds).toBe(0)
+
+    const queueAfterSecond = await db.execute("SELECT COUNT(*) as count FROM memory_embedding_jobs")
+    expect(Number(queueAfterSecond.rows[0]?.count ?? 0)).toBe(4)
+
+    const thirdBatch = await runEmbeddingBackfillBatch({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      batchLimit: 2,
+      throttleMs: 0,
+      nowIso: "2026-02-20T00:12:00.000Z",
+    })
+    expect(thirdBatch.batch.scanned).toBe(0)
+    expect(thirdBatch.batch.enqueued).toBe(0)
+    expect(thirdBatch.status.status).toBe("completed")
+
+    const queueAfterThird = await db.execute("SELECT COUNT(*) as count FROM memory_embedding_jobs")
+    expect(Number(queueAfterThird.rows[0]?.count ?? 0)).toBe(4)
+  })
+
+  it("supports pausing and resuming backfill runs", async () => {
+    const db = await setupDb("memories-embedding-backfill-pause")
+    await insertMemory(db, { id: "mem-a", content: "Only memory", createdAt: "2026-02-20T01:00:00.000Z" })
+
+    const paused = await setEmbeddingBackfillPaused({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      paused: true,
+      nowIso: "2026-02-20T01:05:00.000Z",
+    })
+    expect(paused.status).toBe("paused")
+
+    const pausedRun = await runEmbeddingBackfillBatch({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      batchLimit: 10,
+      throttleMs: 0,
+      nowIso: "2026-02-20T01:06:00.000Z",
+    })
+    expect(pausedRun.batch.scanned).toBe(0)
+    expect(pausedRun.batch.enqueued).toBe(0)
+    expect(pausedRun.status.status).toBe("paused")
+
+    const resumed = await setEmbeddingBackfillPaused({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      paused: false,
+      nowIso: "2026-02-20T01:07:00.000Z",
+    })
+    expect(resumed.status).toBe("idle")
+
+    const resumedRun = await runEmbeddingBackfillBatch({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+      batchLimit: 10,
+      throttleMs: 0,
+      nowIso: "2026-02-20T01:08:00.000Z",
+    })
+    expect(resumedRun.batch.scanned).toBe(1)
+    expect(resumedRun.batch.enqueued).toBe(1)
+    expect(resumedRun.status.status).toBe("completed")
+
+    const status = await getEmbeddingBackfillStatus({
+      turso: db,
+      modelId: "openai/text-embedding-3-small",
+    })
+    expect(status.enqueuedCount).toBe(1)
+    expect(status.estimatedRemaining).toBe(0)
+  })
+})
+

--- a/packages/web/src/lib/sdk-embeddings/backfill.ts
+++ b/packages/web/src/lib/sdk-embeddings/backfill.ts
@@ -1,0 +1,671 @@
+import { getSdkDefaultEmbeddingModelId, getSdkEmbeddingBackfillBatchSize, getSdkEmbeddingBackfillThrottleMs } from "@/lib/env"
+import type { TursoClient } from "@/lib/memory-service/types"
+import { enqueueEmbeddingJob, triggerEmbeddingQueueProcessing } from "./jobs"
+import { setTimeout as delay } from "node:timers/promises"
+
+export type EmbeddingBackfillStatusValue = "idle" | "running" | "paused" | "completed"
+
+interface EmbeddingBackfillScope {
+  modelId: string
+  projectId: string | null
+  userId: string | null
+}
+
+interface EmbeddingBackfillStateRow {
+  scopeKey: string
+  modelId: string
+  projectId: string | null
+  userId: string | null
+  status: EmbeddingBackfillStatusValue
+  checkpointCreatedAt: string | null
+  checkpointMemoryId: string | null
+  scannedCount: number
+  enqueuedCount: number
+  estimatedTotal: number
+  estimatedRemaining: number
+  estimatedCompletionSeconds: number | null
+  batchLimit: number
+  throttleMs: number
+  startedAt: string | null
+  lastRunAt: string | null
+  completedAt: string | null
+  updatedAt: string
+  lastError: string | null
+}
+
+interface MissingMemoryRow {
+  id: string
+  content: string
+  createdAt: string
+}
+
+export interface GetEmbeddingBackfillStatusInput {
+  turso: TursoClient
+  modelId?: string | null
+  projectId?: string | null
+  userId?: string | null
+}
+
+export interface SetEmbeddingBackfillPausedInput extends GetEmbeddingBackfillStatusInput {
+  paused: boolean
+  nowIso?: string
+}
+
+export interface RunEmbeddingBackfillBatchInput extends GetEmbeddingBackfillStatusInput {
+  batchLimit?: number
+  throttleMs?: number
+  nowIso?: string
+}
+
+export interface EmbeddingBackfillStatus {
+  scopeKey: string
+  modelId: string
+  projectId: string | null
+  userId: string | null
+  status: EmbeddingBackfillStatusValue
+  checkpointCreatedAt: string | null
+  checkpointMemoryId: string | null
+  scannedCount: number
+  enqueuedCount: number
+  estimatedTotal: number
+  estimatedRemaining: number
+  estimatedCompletionSeconds: number | null
+  batchLimit: number
+  throttleMs: number
+  startedAt: string | null
+  lastRunAt: string | null
+  completedAt: string | null
+  updatedAt: string | null
+  lastError: string | null
+}
+
+export interface RunEmbeddingBackfillBatchResult {
+  status: EmbeddingBackfillStatus
+  batch: {
+    scanned: number
+    enqueued: number
+    durationMs: number
+  }
+}
+
+function parseStatus(value: unknown): EmbeddingBackfillStatusValue {
+  const normalized = typeof value === "string" ? value : ""
+  if (normalized === "running" || normalized === "paused" || normalized === "completed") {
+    return normalized
+  }
+  return "idle"
+}
+
+function parseNonNegativeInt(value: unknown, fallback: number): number {
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return Math.floor(parsed)
+  }
+  return fallback
+}
+
+function parsePositiveInt(value: unknown, fallback: number): number {
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed)
+  }
+  return fallback
+}
+
+function trimNullable(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeScope(input: { modelId?: string | null; projectId?: string | null; userId?: string | null }): EmbeddingBackfillScope {
+  return {
+    modelId: trimNullable(input.modelId) ?? getSdkDefaultEmbeddingModelId(),
+    projectId: trimNullable(input.projectId),
+    userId: trimNullable(input.userId),
+  }
+}
+
+function buildScopeKey(scope: EmbeddingBackfillScope): string {
+  return [scope.modelId, scope.projectId ?? "*", scope.userId ?? "*"].join("|")
+}
+
+function buildScopeFilter(scope: EmbeddingBackfillScope): { clause: string; args: string[] } {
+  const clauses = ["m.deleted_at IS NULL", "TRIM(m.content) <> ''"]
+  const args: string[] = []
+
+  if (scope.projectId) {
+    clauses.push("m.project_id = ?")
+    args.push(scope.projectId)
+  }
+  if (scope.userId) {
+    clauses.push("m.user_id = ?")
+    args.push(scope.userId)
+  }
+
+  return {
+    clause: clauses.join(" AND "),
+    args,
+  }
+}
+
+function truncateError(error: string, max = 1_200): string {
+  if (error.length <= max) return error
+  if (max <= 3) return error.slice(0, max)
+  return `${error.slice(0, max - 3)}...`
+}
+
+function toBackfillState(row: Record<string, unknown>): EmbeddingBackfillStateRow {
+  return {
+    scopeKey: String(row.scope_key ?? ""),
+    modelId: String(row.model ?? ""),
+    projectId: typeof row.project_id === "string" ? row.project_id : null,
+    userId: typeof row.user_id === "string" ? row.user_id : null,
+    status: parseStatus(row.status),
+    checkpointCreatedAt: typeof row.checkpoint_created_at === "string" ? row.checkpoint_created_at : null,
+    checkpointMemoryId: typeof row.checkpoint_memory_id === "string" ? row.checkpoint_memory_id : null,
+    scannedCount: parseNonNegativeInt(row.scanned_count, 0),
+    enqueuedCount: parseNonNegativeInt(row.enqueued_count, 0),
+    estimatedTotal: parseNonNegativeInt(row.estimated_total, 0),
+    estimatedRemaining: parseNonNegativeInt(row.estimated_remaining, 0),
+    estimatedCompletionSeconds:
+      row.estimated_completion_seconds === null || row.estimated_completion_seconds === undefined
+        ? null
+        : parseNonNegativeInt(row.estimated_completion_seconds, 0),
+    batchLimit: parsePositiveInt(row.batch_limit, getSdkEmbeddingBackfillBatchSize()),
+    throttleMs: parseNonNegativeInt(row.throttle_ms, getSdkEmbeddingBackfillThrottleMs()),
+    startedAt: typeof row.started_at === "string" ? row.started_at : null,
+    lastRunAt: typeof row.last_run_at === "string" ? row.last_run_at : null,
+    completedAt: typeof row.completed_at === "string" ? row.completed_at : null,
+    updatedAt: typeof row.updated_at === "string" ? row.updated_at : new Date().toISOString(),
+    lastError: typeof row.last_error === "string" ? row.last_error : null,
+  }
+}
+
+function toStatusPayload(state: EmbeddingBackfillStateRow): EmbeddingBackfillStatus {
+  return {
+    scopeKey: state.scopeKey,
+    modelId: state.modelId,
+    projectId: state.projectId,
+    userId: state.userId,
+    status: state.status,
+    checkpointCreatedAt: state.checkpointCreatedAt,
+    checkpointMemoryId: state.checkpointMemoryId,
+    scannedCount: state.scannedCount,
+    enqueuedCount: state.enqueuedCount,
+    estimatedTotal: state.estimatedTotal,
+    estimatedRemaining: state.estimatedRemaining,
+    estimatedCompletionSeconds: state.estimatedCompletionSeconds,
+    batchLimit: state.batchLimit,
+    throttleMs: state.throttleMs,
+    startedAt: state.startedAt,
+    lastRunAt: state.lastRunAt,
+    completedAt: state.completedAt,
+    updatedAt: state.updatedAt,
+    lastError: state.lastError,
+  }
+}
+
+async function loadBackfillState(turso: TursoClient, scopeKey: string): Promise<EmbeddingBackfillStateRow | null> {
+  const result = await turso.execute({
+    sql: `SELECT scope_key, model, project_id, user_id, status, checkpoint_created_at, checkpoint_memory_id,
+                 scanned_count, enqueued_count, estimated_total, estimated_remaining, estimated_completion_seconds,
+                 batch_limit, throttle_ms, started_at, last_run_at, completed_at, updated_at, last_error
+          FROM memory_embedding_backfill_state
+          WHERE scope_key = ?
+          LIMIT 1`,
+    args: [scopeKey],
+  })
+
+  if (!Array.isArray(result.rows) || result.rows.length === 0) {
+    return null
+  }
+  return toBackfillState(result.rows[0] as Record<string, unknown>)
+}
+
+async function ensureBackfillStateRow(params: {
+  turso: TursoClient
+  scope: EmbeddingBackfillScope
+  scopeKey: string
+  batchLimit: number
+  throttleMs: number
+  nowIso: string
+}): Promise<void> {
+  await params.turso.execute({
+    sql: `INSERT OR IGNORE INTO memory_embedding_backfill_state (
+            scope_key, model, project_id, user_id, status, scanned_count, enqueued_count,
+            estimated_total, estimated_remaining, estimated_completion_seconds,
+            batch_limit, throttle_ms, started_at, last_run_at, completed_at, updated_at, last_error
+          ) VALUES (?, ?, ?, ?, 'idle', 0, 0, 0, 0, NULL, ?, ?, NULL, NULL, NULL, ?, NULL)`,
+    args: [
+      params.scopeKey,
+      params.scope.modelId,
+      params.scope.projectId,
+      params.scope.userId,
+      params.batchLimit,
+      params.throttleMs,
+      params.nowIso,
+    ],
+  })
+}
+
+async function countMissingEmbeddings(turso: TursoClient, scope: EmbeddingBackfillScope): Promise<number> {
+  const scopeFilter = buildScopeFilter(scope)
+  const result = await turso.execute({
+    sql: `SELECT COUNT(*) AS count
+          FROM memories m
+          LEFT JOIN memory_embeddings e ON e.memory_id = m.id
+          WHERE ${scopeFilter.clause}
+            AND (e.memory_id IS NULL OR e.model != ?)`,
+    args: [...scopeFilter.args, scope.modelId],
+  })
+  return parseNonNegativeInt(result.rows[0]?.count, 0)
+}
+
+async function countRemainingAfterCheckpoint(params: {
+  turso: TursoClient
+  scope: EmbeddingBackfillScope
+  checkpointCreatedAt: string | null
+  checkpointMemoryId: string | null
+}): Promise<number> {
+  const scopeFilter = buildScopeFilter(params.scope)
+  const checkpointAvailable = Boolean(params.checkpointCreatedAt && params.checkpointMemoryId)
+  let sql = `SELECT COUNT(*) AS count
+             FROM memories m
+             LEFT JOIN memory_embeddings e ON e.memory_id = m.id
+             WHERE ${scopeFilter.clause}
+               AND (e.memory_id IS NULL OR e.model != ?)`
+  const args: (string | number)[] = [...scopeFilter.args, params.scope.modelId]
+
+  if (checkpointAvailable) {
+    sql += " AND (m.created_at > ? OR (m.created_at = ? AND m.id > ?))"
+    args.push(
+      params.checkpointCreatedAt as string,
+      params.checkpointCreatedAt as string,
+      params.checkpointMemoryId as string
+    )
+  }
+
+  const result = await params.turso.execute({ sql, args })
+  return parseNonNegativeInt(result.rows[0]?.count, 0)
+}
+
+async function listMissingCandidates(params: {
+  turso: TursoClient
+  scope: EmbeddingBackfillScope
+  checkpointCreatedAt: string | null
+  checkpointMemoryId: string | null
+  limit: number
+}): Promise<MissingMemoryRow[]> {
+  const scopeFilter = buildScopeFilter(params.scope)
+  const checkpointAvailable = Boolean(params.checkpointCreatedAt && params.checkpointMemoryId)
+  let sql = `SELECT m.id, m.content, m.created_at
+             FROM memories m
+             LEFT JOIN memory_embeddings e ON e.memory_id = m.id
+             WHERE ${scopeFilter.clause}
+               AND (e.memory_id IS NULL OR e.model != ?)`
+  const args: (string | number)[] = [...scopeFilter.args, params.scope.modelId]
+
+  if (checkpointAvailable) {
+    sql += " AND (m.created_at > ? OR (m.created_at = ? AND m.id > ?))"
+    args.push(
+      params.checkpointCreatedAt as string,
+      params.checkpointCreatedAt as string,
+      params.checkpointMemoryId as string
+    )
+  }
+
+  sql += " ORDER BY m.created_at ASC, m.id ASC LIMIT ?"
+  args.push(params.limit)
+
+  const result = await params.turso.execute({ sql, args })
+  const rows = Array.isArray(result.rows) ? result.rows : []
+  return rows.map((row) => {
+    const record = row as Record<string, unknown>
+    return {
+      id: String(record.id ?? ""),
+      content: String(record.content ?? ""),
+      createdAt: String(record.created_at ?? ""),
+    }
+  })
+}
+
+function estimateCompletionSeconds(params: { scannedCount: number; startedAt: string | null; nowIso: string; remaining: number }): number | null {
+  if (params.remaining <= 0) {
+    return 0
+  }
+  if (!params.startedAt || params.scannedCount <= 0) {
+    return null
+  }
+
+  const elapsedMs = Date.parse(params.nowIso) - Date.parse(params.startedAt)
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) {
+    return null
+  }
+
+  const ratePerSecond = params.scannedCount / (elapsedMs / 1_000)
+  if (!Number.isFinite(ratePerSecond) || ratePerSecond <= 0) {
+    return null
+  }
+
+  return Math.ceil(params.remaining / ratePerSecond)
+}
+
+async function insertBackfillMetric(params: {
+  turso: TursoClient
+  scopeKey: string
+  modelId: string
+  batchScanned: number
+  batchEnqueued: number
+  totalScanned: number
+  totalEnqueued: number
+  estimatedTotal: number
+  estimatedRemaining: number
+  estimatedCompletionSeconds: number | null
+  durationMs: number
+  status: EmbeddingBackfillStatusValue
+  error?: string | null
+  nowIso: string
+}): Promise<void> {
+  await params.turso.execute({
+    sql: `INSERT INTO memory_embedding_backfill_metrics (
+            id,
+            scope_key,
+            model,
+            batch_scanned,
+            batch_enqueued,
+            total_scanned,
+            total_enqueued,
+            estimated_total,
+            estimated_remaining,
+            estimated_completion_seconds,
+            duration_ms,
+            status,
+            error,
+            ran_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      crypto.randomUUID().replace(/-/g, ""),
+      params.scopeKey,
+      params.modelId,
+      params.batchScanned,
+      params.batchEnqueued,
+      params.totalScanned,
+      params.totalEnqueued,
+      params.estimatedTotal,
+      params.estimatedRemaining,
+      params.estimatedCompletionSeconds,
+      params.durationMs,
+      params.status,
+      params.error ?? null,
+      params.nowIso,
+    ],
+  })
+}
+
+export async function getEmbeddingBackfillStatus(input: GetEmbeddingBackfillStatusInput): Promise<EmbeddingBackfillStatus> {
+  const scope = normalizeScope(input)
+  const scopeKey = buildScopeKey(scope)
+  const existing = await loadBackfillState(input.turso, scopeKey)
+  if (existing) {
+    return toStatusPayload(existing)
+  }
+
+  const missingCount = await countMissingEmbeddings(input.turso, scope)
+  return {
+    scopeKey,
+    modelId: scope.modelId,
+    projectId: scope.projectId,
+    userId: scope.userId,
+    status: "idle",
+    checkpointCreatedAt: null,
+    checkpointMemoryId: null,
+    scannedCount: 0,
+    enqueuedCount: 0,
+    estimatedTotal: missingCount,
+    estimatedRemaining: missingCount,
+    estimatedCompletionSeconds: missingCount > 0 ? null : 0,
+    batchLimit: getSdkEmbeddingBackfillBatchSize(),
+    throttleMs: getSdkEmbeddingBackfillThrottleMs(),
+    startedAt: null,
+    lastRunAt: null,
+    completedAt: null,
+    updatedAt: null,
+    lastError: null,
+  }
+}
+
+export async function setEmbeddingBackfillPaused(input: SetEmbeddingBackfillPausedInput): Promise<EmbeddingBackfillStatus> {
+  const scope = normalizeScope(input)
+  const scopeKey = buildScopeKey(scope)
+  const nowIso = input.nowIso ?? new Date().toISOString()
+  const defaultBatchLimit = getSdkEmbeddingBackfillBatchSize()
+  const defaultThrottleMs = getSdkEmbeddingBackfillThrottleMs()
+
+  await ensureBackfillStateRow({
+    turso: input.turso,
+    scope,
+    scopeKey,
+    batchLimit: defaultBatchLimit,
+    throttleMs: defaultThrottleMs,
+    nowIso,
+  })
+
+  await input.turso.execute({
+    sql: `UPDATE memory_embedding_backfill_state
+          SET status = ?,
+              updated_at = ?,
+              last_error = NULL
+          WHERE scope_key = ?`,
+    args: [input.paused ? "paused" : "idle", nowIso, scopeKey],
+  })
+
+  const updated = await loadBackfillState(input.turso, scopeKey)
+  if (!updated) {
+    throw new Error("Failed to update embedding backfill state")
+  }
+  return toStatusPayload(updated)
+}
+
+export async function runEmbeddingBackfillBatch(input: RunEmbeddingBackfillBatchInput): Promise<RunEmbeddingBackfillBatchResult> {
+  const scope = normalizeScope(input)
+  const scopeKey = buildScopeKey(scope)
+  const nowIso = input.nowIso ?? new Date().toISOString()
+  const batchLimit = Math.max(1, input.batchLimit ?? getSdkEmbeddingBackfillBatchSize())
+  const throttleMs = Math.max(0, input.throttleMs ?? getSdkEmbeddingBackfillThrottleMs())
+
+  await ensureBackfillStateRow({
+    turso: input.turso,
+    scope,
+    scopeKey,
+    batchLimit,
+    throttleMs,
+    nowIso,
+  })
+
+  const existing = await loadBackfillState(input.turso, scopeKey)
+  if (!existing) {
+    throw new Error("Failed to load embedding backfill state")
+  }
+
+  if (existing.status === "paused") {
+    return {
+      status: toStatusPayload(existing),
+      batch: {
+        scanned: 0,
+        enqueued: 0,
+        durationMs: 0,
+      },
+    }
+  }
+
+  const runStartedAt = Date.now()
+  const startedAt = existing.startedAt ?? nowIso
+
+  await input.turso.execute({
+    sql: `UPDATE memory_embedding_backfill_state
+          SET status = 'running',
+              batch_limit = ?,
+              throttle_ms = ?,
+              started_at = ?,
+              updated_at = ?,
+              last_error = NULL
+          WHERE scope_key = ?`,
+    args: [batchLimit, throttleMs, startedAt, nowIso, scopeKey],
+  })
+
+  let batchScanned = 0
+  let batchEnqueued = 0
+  let checkpointCreatedAt = existing.checkpointCreatedAt
+  let checkpointMemoryId = existing.checkpointMemoryId
+
+  try {
+    const estimatedTotal = await countMissingEmbeddings(input.turso, scope)
+    const candidates = await listMissingCandidates({
+      turso: input.turso,
+      scope,
+      checkpointCreatedAt: existing.checkpointCreatedAt,
+      checkpointMemoryId: existing.checkpointMemoryId,
+      limit: batchLimit,
+    })
+
+    for (let index = 0; index < candidates.length; index += 1) {
+      const candidate = candidates[index]
+      batchScanned += 1
+      checkpointCreatedAt = candidate.createdAt
+      checkpointMemoryId = candidate.id
+
+      const queued = await enqueueEmbeddingJob({
+        turso: input.turso,
+        memoryId: candidate.id,
+        content: candidate.content,
+        modelId: scope.modelId,
+        operation: "backfill",
+        nowIso,
+      })
+      if (queued) {
+        batchEnqueued += 1
+      }
+
+      if (throttleMs > 0 && index < candidates.length - 1) {
+        await delay(throttleMs)
+      }
+    }
+
+    const totalScanned = existing.scannedCount + batchScanned
+    const totalEnqueued = existing.enqueuedCount + batchEnqueued
+    const remaining = await countRemainingAfterCheckpoint({
+      turso: input.turso,
+      scope,
+      checkpointCreatedAt,
+      checkpointMemoryId,
+    })
+    const status: EmbeddingBackfillStatusValue = remaining === 0 ? "completed" : "running"
+    const estimatedCompletionSeconds = estimateCompletionSeconds({
+      scannedCount: totalScanned,
+      startedAt,
+      nowIso,
+      remaining,
+    })
+
+    await input.turso.execute({
+      sql: `UPDATE memory_embedding_backfill_state
+            SET status = ?,
+                checkpoint_created_at = ?,
+                checkpoint_memory_id = ?,
+                scanned_count = ?,
+                enqueued_count = ?,
+                estimated_total = ?,
+                estimated_remaining = ?,
+                estimated_completion_seconds = ?,
+                batch_limit = ?,
+                throttle_ms = ?,
+                started_at = ?,
+                last_run_at = ?,
+                completed_at = ?,
+                updated_at = ?,
+                last_error = NULL
+            WHERE scope_key = ?`,
+      args: [
+        status,
+        checkpointCreatedAt,
+        checkpointMemoryId,
+        totalScanned,
+        totalEnqueued,
+        estimatedTotal,
+        remaining,
+        estimatedCompletionSeconds,
+        batchLimit,
+        throttleMs,
+        startedAt,
+        nowIso,
+        status === "completed" ? nowIso : null,
+        nowIso,
+        scopeKey,
+      ],
+    })
+
+    await insertBackfillMetric({
+      turso: input.turso,
+      scopeKey,
+      modelId: scope.modelId,
+      batchScanned,
+      batchEnqueued,
+      totalScanned,
+      totalEnqueued,
+      estimatedTotal,
+      estimatedRemaining: remaining,
+      estimatedCompletionSeconds,
+      durationMs: Date.now() - runStartedAt,
+      status,
+      nowIso,
+    })
+
+    if (batchEnqueued > 0) {
+      triggerEmbeddingQueueProcessing(input.turso)
+    }
+
+    const next = await loadBackfillState(input.turso, scopeKey)
+    if (!next) {
+      throw new Error("Failed to load updated embedding backfill state")
+    }
+
+    return {
+      status: toStatusPayload(next),
+      batch: {
+        scanned: batchScanned,
+        enqueued: batchEnqueued,
+        durationMs: Math.max(0, Date.now() - runStartedAt),
+      },
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Embedding backfill failed"
+    await input.turso.execute({
+      sql: `UPDATE memory_embedding_backfill_state
+            SET status = 'running',
+                updated_at = ?,
+                last_run_at = ?,
+                last_error = ?
+            WHERE scope_key = ?`,
+      args: [nowIso, nowIso, truncateError(message), scopeKey],
+    })
+    await insertBackfillMetric({
+      turso: input.turso,
+      scopeKey,
+      modelId: scope.modelId,
+      batchScanned,
+      batchEnqueued,
+      totalScanned: existing.scannedCount + batchScanned,
+      totalEnqueued: existing.enqueuedCount + batchEnqueued,
+      estimatedTotal: existing.estimatedTotal,
+      estimatedRemaining: existing.estimatedRemaining,
+      estimatedCompletionSeconds: existing.estimatedCompletionSeconds,
+      durationMs: Date.now() - runStartedAt,
+      status: "running",
+      error: truncateError(message),
+      nowIso,
+    })
+    throw error
+  }
+}
+

--- a/packages/web/src/lib/turso.ts
+++ b/packages/web/src/lib/turso.ts
@@ -289,6 +289,61 @@ export async function initSchema(url: string, token: string): Promise<void> {
   )
 
   await db.execute(
+    `CREATE TABLE IF NOT EXISTS memory_embedding_backfill_state (
+      scope_key TEXT PRIMARY KEY,
+      model TEXT NOT NULL,
+      project_id TEXT,
+      user_id TEXT,
+      status TEXT NOT NULL DEFAULT 'idle',
+      checkpoint_created_at TEXT,
+      checkpoint_memory_id TEXT,
+      scanned_count INTEGER NOT NULL DEFAULT 0 CHECK (scanned_count >= 0),
+      enqueued_count INTEGER NOT NULL DEFAULT 0 CHECK (enqueued_count >= 0),
+      estimated_total INTEGER NOT NULL DEFAULT 0 CHECK (estimated_total >= 0),
+      estimated_remaining INTEGER NOT NULL DEFAULT 0 CHECK (estimated_remaining >= 0),
+      estimated_completion_seconds INTEGER,
+      batch_limit INTEGER NOT NULL DEFAULT 100 CHECK (batch_limit > 0),
+      throttle_ms INTEGER NOT NULL DEFAULT 25 CHECK (throttle_ms >= 0),
+      started_at TEXT,
+      last_run_at TEXT,
+      completed_at TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_error TEXT
+    )`
+  )
+  await db.execute(
+    `CREATE INDEX IF NOT EXISTS idx_memory_embedding_backfill_state_status_updated
+     ON memory_embedding_backfill_state(status, updated_at)`
+  )
+
+  await db.execute(
+    `CREATE TABLE IF NOT EXISTS memory_embedding_backfill_metrics (
+      id TEXT PRIMARY KEY,
+      scope_key TEXT NOT NULL,
+      model TEXT NOT NULL,
+      batch_scanned INTEGER NOT NULL DEFAULT 0 CHECK (batch_scanned >= 0),
+      batch_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (batch_enqueued >= 0),
+      total_scanned INTEGER NOT NULL DEFAULT 0 CHECK (total_scanned >= 0),
+      total_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (total_enqueued >= 0),
+      estimated_total INTEGER NOT NULL DEFAULT 0 CHECK (estimated_total >= 0),
+      estimated_remaining INTEGER NOT NULL DEFAULT 0 CHECK (estimated_remaining >= 0),
+      estimated_completion_seconds INTEGER,
+      duration_ms INTEGER NOT NULL DEFAULT 0 CHECK (duration_ms >= 0),
+      status TEXT NOT NULL,
+      error TEXT,
+      ran_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`
+  )
+  await db.execute(
+    `CREATE INDEX IF NOT EXISTS idx_memory_embedding_backfill_metrics_scope_ran_at
+     ON memory_embedding_backfill_metrics(scope_key, ran_at)`
+  )
+  await db.execute(
+    `CREATE INDEX IF NOT EXISTS idx_memory_embedding_backfill_metrics_status_ran_at
+     ON memory_embedding_backfill_metrics(status, ran_at)`
+  )
+
+  await db.execute(
     `CREATE TABLE IF NOT EXISTS skill_files (
       id TEXT PRIMARY KEY,
       path TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- add SDK embeddings backfill state + metrics tables to scope schema and initSchema
- implement backfill engine with resumable checkpoints, pause/resume, batching, throttling, and per-batch metrics
- add management endpoint at /api/sdk/v1/management/embeddings/backfill for status + run/pause/resume
- add tests for schema provisioning, backfill logic, and management endpoint contracts

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Closes #185

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persistent tables and a management API that can enqueue large volumes of embedding jobs; correctness/performance depends on the new checkpointing, batching, and scope filtering behaving as intended in production.
> 
> **Overview**
> Adds a new management endpoint `GET/POST /api/sdk/v1/management/embeddings/backfill` to fetch backfill status and to `run`/`pause`/`resume` backfill batches, including request validation and identity/Turso scope resolution.
> 
> Introduces a new backfill engine (`lib/sdk-embeddings/backfill.ts`) that scans memories missing embeddings, enqueues `backfill` embedding jobs in batches with optional throttling, persists checkpointed progress/state and per-batch metrics, and supports pausing/resuming.
> 
> Extends schema provisioning (`memory-service/scope-schema.ts` and `turso.initSchema`) to create/mark new `memory_embedding_backfill_state` and `memory_embedding_backfill_metrics` tables, adds env controls for default batch size/throttle, and adds Vitest coverage for schema, backfill behavior, and the management route contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281ce50a19bc3d07b51de6c8cfdd035f7d1ca830. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->