### PR TITLE
feat: add embeddings observability endpoint, alerts, and operations runbook

### DIFF
--- a/packages/web/content/docs/sdk/embedding-operations-runbook.mdx
+++ b/packages/web/content/docs/sdk/embedding-operations-runbook.mdx
@@ -1,0 +1,94 @@
+---
+title: Embedding Operations Runbook
+description: Operate and triage hosted embedding generation and retrieval regressions.
+---
+
+This runbook covers queue health, worker failures, retrieval latency/fallback regressions, and rollback procedures for hosted embeddings.
+
+## Quick Health Checks
+
+Fetch the observability snapshot:
+
+```bash
+curl -s -H "Authorization: Bearer $MEMORIES_API_KEY" \
+  "https://memories.sh/api/sdk/v1/management/embeddings/observability?windowHours=24" | jq
+```
+
+Check backfill status for a scoped model:
+
+```bash
+curl -s -H "Authorization: Bearer $MEMORIES_API_KEY" \
+  "https://memories.sh/api/sdk/v1/management/embeddings/backfill?modelId=openai/text-embedding-3-small" | jq
+```
+
+Review monthly usage/cost summary:
+
+```bash
+curl -s -H "Authorization: Bearer $MEMORIES_API_KEY" \
+  "https://memories.sh/api/sdk/v1/management/embeddings/usage?usageMonth=2026-02-01" | jq
+```
+
+## Alert Thresholds
+
+Current SLO thresholds emitted in observability payload:
+
+- Queue lag warning `>= 120000ms` (2m), critical `>= 600000ms` (10m)
+- Dead-letter rate warning `>= 2%`, critical `>= 5%` (after at least 20 attempts)
+- Retrieval fallback rate warning `>= 5%`, critical `>= 15%` (after at least 20 requests)
+- Retrieval p95 latency warning `>= 1200ms`, critical `>= 2500ms` (after at least 10 samples)
+- Backfill error runs warning `>= 1`, critical `>= 5` in window
+
+## Triage Flow
+
+1. Check `health` and `alarms` in `/management/embeddings/observability`.
+2. If queue alarms fire, inspect `queueLagMs`, `staleProcessingCount`, and `deadLetterCount`.
+3. If worker alarms fire, inspect `worker.topErrorCodes` and dead-letter ratio.
+4. If retrieval alarms fire, inspect fallback reason trends and graph rollout mode.
+5. Confirm cost impact by comparing `cost.customerCostUsd` with usage trends.
+
+## Rollback + Feature Flags
+
+### 1) Retrieval rollback (high fallback/latency)
+
+Move graph rollout to `shadow` immediately:
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $MEMORIES_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://memories.sh/api/sdk/v1/graph/rollout" \
+  -d '{"mode":"shadow"}' | jq
+```
+
+If incident persists, move to `off` and serve baseline retrieval only.
+
+### 2) Embedding model rollback (provider/model regressions)
+
+Pin the workspace/project to the last known good model via embedding config endpoint/UI.
+
+- Verify default model and allowlist from `/api/sdk/v1/embeddings/models`
+- Remove failing model from allowlist for affected tenant/project
+- Resume backfill only after queue lag and dead-letter rates normalize
+
+### 3) Worker pressure rollback (queue saturation)
+
+- Pause backfill for affected scope:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $MEMORIES_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://memories.sh/api/sdk/v1/management/embeddings/backfill" \
+  -d '{"action":"pause","modelId":"openai/text-embedding-3-small"}' | jq
+```
+
+- Let realtime write-path jobs drain
+- Resume with smaller `batchLimit` and higher `throttleMs`
+
+## Incident Checklist
+
+1. Capture observability payload and active alarms.
+2. Capture backfill state (`status`, `estimatedRemaining`, `lastError`).
+3. Record top worker error codes and fallback reason distribution.
+4. Apply rollback (rollout mode/model pin/backfill pause) based on dominant alarm.
+5. Confirm alarms clear for at least one full window before restoring canary settings.

--- a/packages/web/content/docs/sdk/meta.json
+++ b/packages/web/content/docs/sdk/meta.json
@@ -10,6 +10,7 @@
     "client",
     "endpoint-contract",
     "graph-architecture",
-    "graph-operations-runbook"
+    "graph-operations-runbook",
+    "embedding-operations-runbook"
   ]
 }

--- a/packages/web/src/app/api/sdk/v1/management/embeddings/observability/__tests__/route.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/embeddings/observability/__tests__/route.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockResolveManagementIdentity,
+  mockResolveTursoForScope,
+  mockEnsureMemoryUserIdSchema,
+  mockGetEmbeddingObservabilitySnapshot,
+} = vi.hoisted(() => ({
+  mockResolveManagementIdentity: vi.fn(),
+  mockResolveTursoForScope: vi.fn(),
+  mockEnsureMemoryUserIdSchema: vi.fn(),
+  mockGetEmbeddingObservabilitySnapshot: vi.fn(),
+}))
+
+vi.mock("@/app/api/sdk/v1/management/identity", () => ({
+  resolveManagementIdentity: mockResolveManagementIdentity,
+}))
+
+vi.mock("@/lib/memory-service/scope", () => ({
+  ensureMemoryUserIdSchema: mockEnsureMemoryUserIdSchema,
+}))
+
+vi.mock("@/lib/sdk-embeddings/observability", () => ({
+  getEmbeddingObservabilitySnapshot: mockGetEmbeddingObservabilitySnapshot,
+}))
+
+vi.mock("@/lib/sdk-api/runtime", () => ({
+  resolveTursoForScope: mockResolveTursoForScope,
+  successResponse: (endpoint: string, requestId: string, data: unknown, status = 200) =>
+    new Response(
+      JSON.stringify({
+        ok: true,
+        data,
+        error: null,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-20T00:00:00.000Z" },
+      }),
+      { status, headers: { "content-type": "application/json" } }
+    ),
+  errorResponse: (endpoint: string, requestId: string, detail: unknown) =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: detail,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-20T00:00:00.000Z" },
+      }),
+      { status: 500, headers: { "content-type": "application/json" } }
+    ),
+  invalidRequestResponse: (endpoint: string, requestId: string, message = "Invalid request payload") =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: {
+          type: "validation_error",
+          code: "INVALID_REQUEST",
+          message,
+          status: 400,
+          retryable: false,
+        },
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-20T00:00:00.000Z" },
+      }),
+      { status: 400, headers: { "content-type": "application/json" } }
+    ),
+}))
+
+import { GET } from "../route"
+
+describe("/api/sdk/v1/management/embeddings/observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockResolveManagementIdentity.mockResolvedValue({
+      userId: "user-1",
+      apiKeyHash: "hash_123",
+      authMode: "api_key",
+    })
+
+    mockResolveTursoForScope.mockResolvedValue({ execute: vi.fn() })
+    mockEnsureMemoryUserIdSchema.mockResolvedValue(undefined)
+    mockGetEmbeddingObservabilitySnapshot.mockResolvedValue({
+      sampledAt: "2026-02-20T00:00:00.000Z",
+      windowHours: 24,
+      scope: {
+        tenantId: "tenant-a",
+        projectId: "project-a",
+        userId: null,
+        modelId: "openai/text-embedding-3-small",
+      },
+      slos: {},
+      queue: {
+        queuedCount: 3,
+        processingCount: 1,
+        deadLetterCount: 0,
+        staleProcessingCount: 0,
+        oldestDueAt: "2026-02-19T23:58:00.000Z",
+        oldestClaimedAt: null,
+        queueLagMs: 120000,
+      },
+      worker: {
+        attempts: 10,
+        successCount: 9,
+        retryCount: 1,
+        deadLetterCount: 0,
+        skippedCount: 0,
+        failureRate: 0,
+        retryRate: 0.1,
+        avgDurationMs: 280,
+        p50DurationMs: 240,
+        p95DurationMs: 600,
+        durationSampleCount: 10,
+        topErrorCodes: [],
+      },
+      backfill: {
+        runs: 3,
+        scannedCount: 320,
+        enqueuedCount: 320,
+        errorRuns: 0,
+        avgDurationMs: 150,
+        lastRunAt: "2026-02-20T00:00:00.000Z",
+        activeScopes: 0,
+        runningScopes: 0,
+        pausedScopes: 0,
+      },
+      retrieval: {
+        totalRequests: 40,
+        hybridRequested: 20,
+        fallbackCount: 1,
+        fallbackRate: 0.025,
+        avgLatencyMs: 300,
+        p50LatencyMs: 220,
+        p95LatencyMs: 810,
+        latencySampleCount: 40,
+        lastFallbackAt: "2026-02-20T00:00:00.000Z",
+        lastFallbackReason: "shadow_mode",
+      },
+      cost: {
+        usageMonth: "2026-02-01",
+        requestCount: 320,
+        inputTokens: 64_000,
+        gatewayCostUsd: 0.128,
+        marketCostUsd: 0.12,
+        customerCostUsd: 0.138,
+        customerCostPerRequestUsd: 0.00043125,
+      },
+      alarms: [],
+      health: "healthy",
+    })
+  })
+
+  it("returns embedding observability snapshot", async () => {
+    const response = await GET(
+      new Request(
+        "https://example.com/api/sdk/v1/management/embeddings/observability?tenantId=tenant-a&projectId=project-a&modelId=openai/text-embedding-3-small&windowHours=24"
+      ) as never
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.health).toBe("healthy")
+    expect(body.data.queue.queuedCount).toBe(3)
+    expect(mockGetEmbeddingObservabilitySnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerUserId: "user-1",
+        tenantId: "tenant-a",
+        projectId: "project-a",
+        modelId: "openai/text-embedding-3-small",
+        windowHours: 24,
+      })
+    )
+  })
+
+  it("returns validation envelope for invalid query", async () => {
+    const response = await GET(
+      new Request("https://example.com/api/sdk/v1/management/embeddings/observability?windowHours=0") as never
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("INVALID_REQUEST")
+  })
+
+  it("returns internal error envelope when lookup fails", async () => {
+    mockGetEmbeddingObservabilitySnapshot.mockRejectedValue(new Error("db down"))
+
+    const response = await GET(
+      new Request("https://example.com/api/sdk/v1/management/embeddings/observability") as never
+    )
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("EMBEDDING_OBSERVABILITY_LOOKUP_FAILED")
+  })
+})

--- a/packages/web/src/app/api/sdk/v1/management/embeddings/observability/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/embeddings/observability/route.ts
@@ -1,0 +1,97 @@
+import { resolveManagementIdentity } from "@/app/api/sdk/v1/management/identity"
+import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope"
+import { apiError } from "@/lib/memory-service/tools"
+import { errorResponse, invalidRequestResponse, resolveTursoForScope, successResponse } from "@/lib/sdk-api/runtime"
+import { getEmbeddingObservabilitySnapshot } from "@/lib/sdk-embeddings/observability"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+const ENDPOINT = "/api/sdk/v1/management/embeddings/observability"
+
+const querySchema = z.object({
+  tenantId: z.string().trim().min(1).max(120).optional(),
+  projectId: z.string().trim().min(1).max(240).optional(),
+  userId: z.string().trim().min(1).max(120).optional(),
+  modelId: z.string().trim().min(1).max(160).optional(),
+  usageMonth: z.string().trim().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  windowHours: z.coerce.number().int().min(1).max(24 * 7).optional(),
+})
+
+function parseQuery(request: NextRequest): z.input<typeof querySchema> {
+  const url = new URL(request.url)
+  return {
+    tenantId: url.searchParams.get("tenantId") ?? undefined,
+    projectId: url.searchParams.get("projectId") ?? undefined,
+    userId: url.searchParams.get("userId") ?? undefined,
+    modelId: url.searchParams.get("modelId") ?? undefined,
+    usageMonth: url.searchParams.get("usageMonth") ?? undefined,
+    windowHours: url.searchParams.get("windowHours") ?? undefined,
+  }
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const identity = await resolveManagementIdentity({
+    endpoint: ENDPOINT,
+    request,
+    requestId,
+    method: "GET",
+    missingApiKeyMessage: "Generate an API key before viewing embedding observability metrics",
+    expiredApiKeyMessage: "API key expired. Generate a new key before viewing embedding observability metrics.",
+    apiKeyMetadataLookupLogContext: "Failed to load API key metadata for embedding observability:",
+  })
+  if (identity instanceof NextResponse) return identity
+
+  const parsed = querySchema.safeParse(parseQuery(request))
+  if (!parsed.success) {
+    return invalidRequestResponse(
+      ENDPOINT,
+      requestId,
+      parsed.error.issues[0]?.message ?? "Invalid request payload"
+    )
+  }
+
+  const tenantId = parsed.data.tenantId ?? null
+  const projectId = parsed.data.projectId ?? null
+
+  try {
+    const turso = await resolveTursoForScope({
+      ownerUserId: identity.userId,
+      apiKeyHash: identity.apiKeyHash,
+      tenantId,
+      projectId,
+      endpoint: ENDPOINT,
+      requestId,
+    })
+    if (turso instanceof NextResponse) return turso
+
+    await ensureMemoryUserIdSchema(turso)
+
+    const snapshot = await getEmbeddingObservabilitySnapshot({
+      turso,
+      ownerUserId: identity.userId,
+      tenantId,
+      projectId,
+      userId: parsed.data.userId ?? null,
+      modelId: parsed.data.modelId ?? null,
+      usageMonth: parsed.data.usageMonth,
+      windowHours: parsed.data.windowHours,
+    })
+
+    return successResponse(ENDPOINT, requestId, snapshot)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load embedding observability snapshot"
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "EMBEDDING_OBSERVABILITY_LOOKUP_FAILED",
+        message,
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+}

--- a/packages/web/src/lib/memory-service/queries.ts
+++ b/packages/web/src/lib/memory-service/queries.ts
@@ -623,6 +623,7 @@ export async function getContextPayload(params: {
     trace: ContextTrace
   }
 }> {
+  const retrievalStartedAt = Date.now()
   const {
     turso,
     projectId,
@@ -917,6 +918,7 @@ export async function getContextPayload(params: {
       totalCandidates: relevantMemories.length,
       fallbackTriggered,
       fallbackReason: fallbackTriggered ? fallbackReason : null,
+      durationMs: Date.now() - retrievalStartedAt,
     })
   } catch (err) {
     console.error("Failed to record graph rollout metric:", err)

--- a/packages/web/src/lib/sdk-embeddings/observability.test.ts
+++ b/packages/web/src/lib/sdk-embeddings/observability.test.ts
@@ -1,0 +1,316 @@
+import { createClient } from "@libsql/client"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope-schema"
+import { recordGraphRolloutMetric } from "@/lib/memory-service/graph/rollout"
+import { getEmbeddingObservabilitySnapshot } from "./observability"
+
+type DbClient = ReturnType<typeof createClient>
+
+const testDatabases: DbClient[] = []
+
+async function setupDb(prefix: string): Promise<DbClient> {
+  const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const db = createClient({ url: `file:${join(dbDir, "embedding-observability.db")}` })
+  testDatabases.push(db)
+
+  await db.execute(
+    `CREATE TABLE memories (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      project_id TEXT,
+      user_id TEXT,
+      tags TEXT,
+      paths TEXT,
+      category TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )`
+  )
+
+  await ensureMemoryUserIdSchema(db, { cacheKey: `observability:${prefix}:${Date.now()}` })
+  return db
+}
+
+async function insertMemory(db: DbClient, input: { id: string; projectId?: string | null; userId?: string | null }): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO memories (
+            id, content, type, memory_layer, expires_at, scope, project_id, user_id,
+            tags, paths, category, metadata, deleted_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      input.id,
+      `Memory ${input.id}`,
+      "note",
+      "long_term",
+      null,
+      "global",
+      input.projectId ?? null,
+      input.userId ?? null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      "2026-02-20T00:00:00.000Z",
+      "2026-02-20T00:00:00.000Z",
+    ],
+  })
+}
+
+async function insertJob(
+  db: DbClient,
+  input: {
+    id: string
+    memoryId: string
+    status: "queued" | "processing" | "dead_letter" | "succeeded"
+    nowIso: string
+    nextAttemptAt?: string
+    claimedAt?: string | null
+  }
+): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO memory_embedding_jobs (
+            id, memory_id, operation, model, content, model_version, status,
+            attempt_count, max_attempts, next_attempt_at, claimed_by, claimed_at,
+            last_error, dead_letter_reason, dead_letter_at, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      input.id,
+      input.memoryId,
+      "add",
+      "openai/text-embedding-3-small",
+      `job-${input.id}`,
+      "2026-02-01",
+      input.status,
+      1,
+      5,
+      input.nextAttemptAt ?? input.nowIso,
+      input.status === "processing" ? "worker-1" : null,
+      input.claimedAt ?? null,
+      input.status === "dead_letter" ? "failed" : null,
+      input.status === "dead_letter" ? "failed" : null,
+      input.status === "dead_letter" ? input.nowIso : null,
+      input.nowIso,
+      input.nowIso,
+    ],
+  })
+}
+
+afterEach(() => {
+  for (const db of testDatabases.splice(0, testDatabases.length)) {
+    db.close()
+  }
+})
+
+describe("getEmbeddingObservabilitySnapshot", () => {
+  it("aggregates queue, worker, backfill, retrieval, and cost signals into alarms", async () => {
+    const db = await setupDb("memories-embedding-observability-alerts")
+    const nowIso = "2026-02-20T12:00:00.000Z"
+
+    await insertMemory(db, { id: "mem-1", projectId: "project-a", userId: "user-a" })
+    await insertMemory(db, { id: "mem-2", projectId: "project-a", userId: "user-a" })
+    await insertMemory(db, { id: "mem-3", projectId: "project-a", userId: "user-a" })
+
+    await insertJob(db, {
+      id: "job-queued",
+      memoryId: "mem-1",
+      status: "queued",
+      nowIso,
+      nextAttemptAt: "2026-02-20T11:40:00.000Z",
+    })
+    await insertJob(db, {
+      id: "job-processing",
+      memoryId: "mem-2",
+      status: "processing",
+      nowIso,
+      claimedAt: "2026-02-20T11:45:00.000Z",
+    })
+    await insertJob(db, {
+      id: "job-dead",
+      memoryId: "mem-3",
+      status: "dead_letter",
+      nowIso,
+    })
+
+    for (let index = 0; index < 40; index += 1) {
+      const outcome = index < 3 ? "dead_letter" : index < 8 ? "retry" : "success"
+      await db.execute({
+        sql: `INSERT INTO memory_embedding_job_metrics (
+                id, job_id, memory_id, operation, model, attempt, outcome, duration_ms, error_code, error_message, created_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          `metric-${index}`,
+          `job-${index}`,
+          index % 2 === 0 ? "mem-1" : "mem-2",
+          "add",
+          "openai/text-embedding-3-small",
+          1,
+          outcome,
+          200 + index * 50,
+          outcome === "dead_letter" ? "EMBEDDING_GATEWAY_HTTP_500" : null,
+          outcome === "dead_letter" ? "gateway failed" : null,
+          `2026-02-20T11:${(index % 60).toString().padStart(2, "0")}:00.000Z`,
+        ],
+      })
+    }
+
+    await db.execute({
+      sql: `INSERT INTO memory_embedding_backfill_metrics (
+              id, scope_key, model, batch_scanned, batch_enqueued, total_scanned, total_enqueued,
+              estimated_total, estimated_remaining, estimated_completion_seconds, duration_ms, status, error, ran_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        "backfill-metric-1",
+        "openai/text-embedding-3-small|project-a|user-a",
+        "openai/text-embedding-3-small",
+        20,
+        20,
+        20,
+        20,
+        100,
+        80,
+        120,
+        400,
+        "running",
+        "queue busy",
+        "2026-02-20T11:55:00.000Z",
+      ],
+    })
+
+    await db.execute({
+      sql: `INSERT INTO memory_embedding_backfill_state (
+              scope_key, model, project_id, user_id, status, scanned_count, enqueued_count, estimated_total, estimated_remaining,
+              estimated_completion_seconds, batch_limit, throttle_ms, started_at, last_run_at, completed_at, updated_at, last_error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        "openai/text-embedding-3-small|project-a|user-a",
+        "openai/text-embedding-3-small",
+        "project-a",
+        "user-a",
+        "running",
+        20,
+        20,
+        100,
+        80,
+        120,
+        100,
+        25,
+        "2026-02-20T11:50:00.000Z",
+        "2026-02-20T11:55:00.000Z",
+        null,
+        "2026-02-20T11:55:00.000Z",
+        null,
+      ],
+    })
+
+    for (let index = 0; index < 30; index += 1) {
+      const fallbackTriggered = index < 6
+      await recordGraphRolloutMetric(db, {
+        nowIso: `2026-02-20T11:${index.toString().padStart(2, "0")}:30.000Z`,
+        mode: "canary",
+        requestedStrategy: "hybrid_graph",
+        appliedStrategy: fallbackTriggered ? "baseline" : "hybrid_graph",
+        shadowExecuted: false,
+        baselineCandidates: 3,
+        graphCandidates: 2,
+        graphExpandedCount: fallbackTriggered ? 0 : 1,
+        totalCandidates: fallbackTriggered ? 3 : 4,
+        fallbackTriggered,
+        fallbackReason: fallbackTriggered ? "graph_expansion_error" : null,
+        durationMs: 400 + index * 90,
+      })
+    }
+
+    const usageLoader = vi.fn().mockResolvedValue({
+      usageMonth: "2026-02-01",
+      summary: {
+        usageMonth: "2026-02-01",
+        requestCount: 120,
+        estimatedRequestCount: 0,
+        inputTokens: 60_000,
+        gatewayCostUsd: 0.3,
+        marketCostUsd: 0.28,
+        customerCostUsd: 0.34,
+      },
+      breakdown: [],
+    })
+
+    const snapshot = await getEmbeddingObservabilitySnapshot(
+      {
+        turso: db,
+        ownerUserId: "owner-1",
+        tenantId: "tenant-a",
+        projectId: "project-a",
+        userId: "user-a",
+        modelId: "openai/text-embedding-3-small",
+        nowIso,
+        windowHours: 24,
+      },
+      { usageLoader }
+    )
+
+    expect(snapshot.queue.queuedCount).toBe(1)
+    expect(snapshot.queue.staleProcessingCount).toBe(1)
+    expect(snapshot.queue.queueLagMs).toBeGreaterThanOrEqual(20 * 60 * 1_000)
+    expect(snapshot.worker.attempts).toBe(40)
+    expect(snapshot.worker.failureRate).toBeGreaterThan(0.05)
+    expect(snapshot.retrieval.totalRequests).toBe(30)
+    expect(snapshot.retrieval.fallbackRate).toBe(0.2)
+    expect(snapshot.retrieval.p95LatencyMs).toBeGreaterThan(2_500)
+    expect(snapshot.health).toBe("critical")
+    expect(snapshot.alarms).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "EMBEDDING_DEAD_LETTER_RATE_CRITICAL", severity: "critical" }),
+        expect.objectContaining({ code: "EMBEDDING_RETRIEVAL_FALLBACK_RATE_CRITICAL", severity: "critical" }),
+        expect.objectContaining({ code: "EMBEDDING_RETRIEVAL_LATENCY_CRITICAL", severity: "critical" }),
+      ])
+    )
+    expect(usageLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerUserId: "owner-1",
+        tenantId: "tenant-a",
+        projectId: "project-a",
+      })
+    )
+  })
+
+  it("returns a healthy snapshot when no signal exceeds SLOs", async () => {
+    const db = await setupDb("memories-embedding-observability-healthy")
+
+    const snapshot = await getEmbeddingObservabilitySnapshot(
+      {
+        turso: db,
+        ownerUserId: "owner-healthy",
+        nowIso: "2026-02-20T12:00:00.000Z",
+      },
+      {
+        usageLoader: async () => ({
+          usageMonth: "2026-02-01",
+          summary: {
+            usageMonth: "2026-02-01",
+            requestCount: 0,
+            estimatedRequestCount: 0,
+            inputTokens: 0,
+            gatewayCostUsd: 0,
+            marketCostUsd: 0,
+            customerCostUsd: 0,
+          },
+          breakdown: [],
+        }),
+      }
+    )
+
+    expect(snapshot.health).toBe("healthy")
+    expect(snapshot.alarms).toEqual([])
+    expect(snapshot.queue.queuedCount).toBe(0)
+    expect(snapshot.worker.attempts).toBe(0)
+    expect(snapshot.retrieval.totalRequests).toBe(0)
+  })
+})

--- a/packages/web/src/lib/sdk-embeddings/observability.ts
+++ b/packages/web/src/lib/sdk-embeddings/observability.ts
@@ -1,0 +1,774 @@
+import { getSdkEmbeddingJobProcessingTimeoutMs } from "@/lib/env"
+import type { TursoClient } from "@/lib/memory-service/types"
+import {
+  listSdkEmbeddingUsage,
+  type ListSdkEmbeddingUsageInput,
+  type ListSdkEmbeddingUsageResult,
+} from "@/lib/sdk-embedding-billing"
+
+type AlarmSeverity = "warning" | "critical"
+
+type SnapshotHealth = "healthy" | "degraded" | "critical"
+
+interface EmbeddingScope {
+  tenantId: string | null
+  projectId: string | null
+  userId: string | null
+  modelId: string | null
+}
+
+export interface EmbeddingObservabilityAlarm {
+  code: string
+  severity: AlarmSeverity
+  message: string
+  observed: number
+  threshold: number
+  unit: "ms" | "ratio" | "count"
+}
+
+export interface EmbeddingQueueHealth {
+  queuedCount: number
+  processingCount: number
+  deadLetterCount: number
+  staleProcessingCount: number
+  oldestDueAt: string | null
+  oldestClaimedAt: string | null
+  queueLagMs: number
+}
+
+export interface EmbeddingWorkerHealth {
+  attempts: number
+  successCount: number
+  retryCount: number
+  deadLetterCount: number
+  skippedCount: number
+  failureRate: number
+  retryRate: number
+  avgDurationMs: number
+  p50DurationMs: number
+  p95DurationMs: number
+  durationSampleCount: number
+  topErrorCodes: Array<{ code: string; count: number }>
+}
+
+export interface EmbeddingBackfillHealth {
+  runs: number
+  scannedCount: number
+  enqueuedCount: number
+  errorRuns: number
+  avgDurationMs: number
+  lastRunAt: string | null
+  activeScopes: number
+  runningScopes: number
+  pausedScopes: number
+}
+
+export interface EmbeddingRetrievalHealth {
+  totalRequests: number
+  hybridRequested: number
+  fallbackCount: number
+  fallbackRate: number
+  avgLatencyMs: number
+  p50LatencyMs: number
+  p95LatencyMs: number
+  latencySampleCount: number
+  lastFallbackAt: string | null
+  lastFallbackReason: string | null
+}
+
+export interface EmbeddingCostHealth {
+  usageMonth: string
+  requestCount: number
+  inputTokens: number
+  gatewayCostUsd: number
+  marketCostUsd: number
+  customerCostUsd: number
+  customerCostPerRequestUsd: number
+}
+
+export interface EmbeddingObservabilitySnapshot {
+  sampledAt: string
+  windowHours: number
+  scope: EmbeddingScope
+  slos: typeof EMBEDDING_OBSERVABILITY_SLOS
+  queue: EmbeddingQueueHealth
+  worker: EmbeddingWorkerHealth
+  backfill: EmbeddingBackfillHealth
+  retrieval: EmbeddingRetrievalHealth
+  cost: EmbeddingCostHealth
+  alarms: EmbeddingObservabilityAlarm[]
+  health: SnapshotHealth
+}
+
+export interface GetEmbeddingObservabilitySnapshotInput {
+  turso: TursoClient
+  ownerUserId: string
+  nowIso?: string
+  windowHours?: number
+  usageMonth?: string
+  tenantId?: string | null
+  projectId?: string | null
+  userId?: string | null
+  modelId?: string | null
+}
+
+interface ObservabilityDependencies {
+  usageLoader?: (input: ListSdkEmbeddingUsageInput) => Promise<ListSdkEmbeddingUsageResult>
+}
+
+const DEFAULT_WINDOW_HOURS = 24
+const MAX_WINDOW_HOURS = 24 * 7
+
+export const EMBEDDING_OBSERVABILITY_SLOS = {
+  queueLagMs: {
+    warning: 2 * 60 * 1_000,
+    critical: 10 * 60 * 1_000,
+  },
+  deadLetterRate: {
+    warning: 0.02,
+    critical: 0.05,
+    minSamples: 20,
+  },
+  retrievalFallbackRate: {
+    warning: 0.05,
+    critical: 0.15,
+    minSamples: 20,
+  },
+  retrievalP95LatencyMs: {
+    warning: 1_200,
+    critical: 2_500,
+    minSamples: 10,
+  },
+  staleProcessingCount: {
+    warning: 1,
+    critical: 5,
+  },
+  backfillErrorRuns: {
+    warning: 1,
+    critical: 5,
+  },
+} as const
+
+function trimNullable(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function toCount(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0
+  return Math.floor(parsed)
+}
+
+function toNumber(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 0
+  return parsed
+}
+
+function roundMetric(value: number, decimals = 4): number {
+  if (!Number.isFinite(value)) return 0
+  return Number(value.toFixed(decimals))
+}
+
+function percentile(sortedValues: number[], fraction: number): number {
+  if (sortedValues.length === 0) return 0
+  const clamped = Math.max(0, Math.min(1, fraction))
+  const index = (sortedValues.length - 1) * clamped
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+  if (lower === upper) return sortedValues[lower] ?? 0
+  const weight = index - lower
+  const lowerValue = sortedValues[lower] ?? 0
+  const upperValue = sortedValues[upper] ?? lowerValue
+  return lowerValue + (upperValue - lowerValue) * weight
+}
+
+function normalizeWindowHours(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_WINDOW_HOURS
+  return Math.max(1, Math.min(Math.floor(value ?? DEFAULT_WINDOW_HOURS), MAX_WINDOW_HOURS))
+}
+
+function toWindowStartIso(nowIso: string, windowHours: number): string {
+  const windowMs = windowHours * 60 * 60 * 1_000
+  return new Date(Date.parse(nowIso) - windowMs).toISOString()
+}
+
+function queueLagMs(nowIso: string, oldestDueAt: string | null): number {
+  if (!oldestDueAt) return 0
+  const nowMs = Date.parse(nowIso)
+  const dueMs = Date.parse(oldestDueAt)
+  if (!Number.isFinite(nowMs) || !Number.isFinite(dueMs)) return 0
+  return Math.max(0, nowMs - dueMs)
+}
+
+function buildJobScopeClause(scope: EmbeddingScope): {
+  fromClause: string
+  whereClause: string
+  args: string[]
+} {
+  const clauses: string[] = []
+  const args: string[] = []
+  let fromClause = "memory_embedding_jobs j"
+
+  if (scope.projectId || scope.userId) {
+    fromClause += " LEFT JOIN memories m ON m.id = j.memory_id"
+    if (scope.projectId) {
+      clauses.push("m.project_id = ?")
+      args.push(scope.projectId)
+    }
+    if (scope.userId) {
+      clauses.push("m.user_id = ?")
+      args.push(scope.userId)
+    }
+  }
+
+  if (scope.modelId) {
+    clauses.push("j.model = ?")
+    args.push(scope.modelId)
+  }
+
+  return {
+    fromClause,
+    whereClause: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    args,
+  }
+}
+
+function buildJobMetricScopeClause(scope: EmbeddingScope, windowStartIso: string): {
+  fromClause: string
+  whereClause: string
+  args: string[]
+} {
+  const clauses: string[] = ["jm.created_at >= ?"]
+  const args: string[] = [windowStartIso]
+  let fromClause = "memory_embedding_job_metrics jm"
+
+  if (scope.projectId || scope.userId) {
+    fromClause += " LEFT JOIN memories m ON m.id = jm.memory_id"
+    if (scope.projectId) {
+      clauses.push("m.project_id = ?")
+      args.push(scope.projectId)
+    }
+    if (scope.userId) {
+      clauses.push("m.user_id = ?")
+      args.push(scope.userId)
+    }
+  }
+
+  if (scope.modelId) {
+    clauses.push("jm.model = ?")
+    args.push(scope.modelId)
+  }
+
+  return {
+    fromClause,
+    whereClause: `WHERE ${clauses.join(" AND ")}`,
+    args,
+  }
+}
+
+function buildBackfillScopeClause(scope: EmbeddingScope, windowStartIso: string): {
+  whereClause: string
+  args: string[]
+} {
+  const clauses: string[] = ["ran_at >= ?"]
+  const args: string[] = [windowStartIso]
+
+  if (scope.modelId) {
+    clauses.push("model = ?")
+    args.push(scope.modelId)
+  }
+
+  return {
+    whereClause: `WHERE ${clauses.join(" AND ")}`,
+    args,
+  }
+}
+
+function buildBackfillStateScopeClause(scope: EmbeddingScope): {
+  whereClause: string
+  args: string[]
+} {
+  const clauses: string[] = []
+  const args: string[] = []
+
+  if (scope.modelId) {
+    clauses.push("model = ?")
+    args.push(scope.modelId)
+  }
+  if (scope.projectId) {
+    clauses.push("project_id = ?")
+    args.push(scope.projectId)
+  }
+  if (scope.userId) {
+    clauses.push("user_id = ?")
+    args.push(scope.userId)
+  }
+
+  return {
+    whereClause: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    args,
+  }
+}
+
+function isMissingDurationColumnError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : ""
+  return message.includes("duration_ms") && message.includes("no such column")
+}
+
+async function loadQueueHealth(turso: TursoClient, scope: EmbeddingScope, nowIso: string): Promise<EmbeddingQueueHealth> {
+  const staleBeforeIso = new Date(Date.parse(nowIso) - getSdkEmbeddingJobProcessingTimeoutMs()).toISOString()
+  const scoped = buildJobScopeClause(scope)
+  const result = await turso.execute({
+    sql: `SELECT
+            SUM(CASE WHEN j.status = 'queued' THEN 1 ELSE 0 END) AS queued_count,
+            SUM(CASE WHEN j.status = 'processing' THEN 1 ELSE 0 END) AS processing_count,
+            SUM(CASE WHEN j.status = 'dead_letter' THEN 1 ELSE 0 END) AS dead_letter_count,
+            SUM(
+              CASE
+                WHEN j.status = 'processing'
+                  AND j.claimed_at IS NOT NULL
+                  AND j.claimed_at <= ?
+                THEN 1 ELSE 0
+              END
+            ) AS stale_processing_count,
+            MIN(CASE WHEN j.status = 'queued' THEN j.next_attempt_at END) AS oldest_due_at,
+            MIN(CASE WHEN j.status = 'processing' THEN j.claimed_at END) AS oldest_claimed_at
+          FROM ${scoped.fromClause}
+          ${scoped.whereClause}`,
+    args: [staleBeforeIso, ...scoped.args],
+  })
+
+  const row = (result.rows[0] ?? {}) as Record<string, unknown>
+  const oldestDueAt = typeof row.oldest_due_at === "string" ? row.oldest_due_at : null
+
+  return {
+    queuedCount: toCount(row.queued_count),
+    processingCount: toCount(row.processing_count),
+    deadLetterCount: toCount(row.dead_letter_count),
+    staleProcessingCount: toCount(row.stale_processing_count),
+    oldestDueAt,
+    oldestClaimedAt: typeof row.oldest_claimed_at === "string" ? row.oldest_claimed_at : null,
+    queueLagMs: queueLagMs(nowIso, oldestDueAt),
+  }
+}
+
+async function loadWorkerHealth(
+  turso: TursoClient,
+  scope: EmbeddingScope,
+  windowStartIso: string
+): Promise<EmbeddingWorkerHealth> {
+  const scoped = buildJobMetricScopeClause(scope, windowStartIso)
+  const summaryResult = await turso.execute({
+    sql: `SELECT
+            COUNT(*) AS attempts,
+            SUM(CASE WHEN jm.outcome = 'success' THEN 1 ELSE 0 END) AS success_count,
+            SUM(CASE WHEN jm.outcome = 'retry' THEN 1 ELSE 0 END) AS retry_count,
+            SUM(CASE WHEN jm.outcome = 'dead_letter' THEN 1 ELSE 0 END) AS dead_letter_count,
+            SUM(CASE WHEN jm.outcome = 'skipped' THEN 1 ELSE 0 END) AS skipped_count,
+            AVG(CASE WHEN jm.duration_ms IS NOT NULL THEN jm.duration_ms END) AS avg_duration_ms
+          FROM ${scoped.fromClause}
+          ${scoped.whereClause}`,
+    args: scoped.args,
+  })
+
+  const durationsResult = await turso.execute({
+    sql: `SELECT jm.duration_ms AS duration_ms
+          FROM ${scoped.fromClause}
+          ${scoped.whereClause}
+          ORDER BY jm.duration_ms ASC`,
+    args: scoped.args,
+  })
+
+  const errorResult = await turso.execute({
+    sql: `SELECT jm.error_code AS error_code, COUNT(*) AS count
+          FROM ${scoped.fromClause}
+          ${scoped.whereClause}
+            AND jm.error_code IS NOT NULL
+            AND jm.error_code <> ''
+          GROUP BY jm.error_code
+          ORDER BY count DESC
+          LIMIT 5`,
+    args: scoped.args,
+  })
+
+  const row = (summaryResult.rows[0] ?? {}) as Record<string, unknown>
+  const attempts = toCount(row.attempts)
+  const retryCount = toCount(row.retry_count)
+  const deadLetterCount = toCount(row.dead_letter_count)
+  const durations = durationsResult.rows
+    .map((durationRow) => toNumber((durationRow as Record<string, unknown>).duration_ms))
+    .filter((value) => value >= 0)
+
+  return {
+    attempts,
+    successCount: toCount(row.success_count),
+    retryCount,
+    deadLetterCount,
+    skippedCount: toCount(row.skipped_count),
+    failureRate: attempts > 0 ? roundMetric(deadLetterCount / attempts) : 0,
+    retryRate: attempts > 0 ? roundMetric(retryCount / attempts) : 0,
+    avgDurationMs: roundMetric(toNumber(row.avg_duration_ms), 2),
+    p50DurationMs: roundMetric(percentile(durations, 0.5), 2),
+    p95DurationMs: roundMetric(percentile(durations, 0.95), 2),
+    durationSampleCount: durations.length,
+    topErrorCodes: errorResult.rows.map((errorRow) => {
+      const record = errorRow as Record<string, unknown>
+      return {
+        code: String(record.error_code ?? "UNKNOWN"),
+        count: toCount(record.count),
+      }
+    }),
+  }
+}
+
+async function loadBackfillHealth(
+  turso: TursoClient,
+  scope: EmbeddingScope,
+  windowStartIso: string
+): Promise<EmbeddingBackfillHealth> {
+  const metricsScope = buildBackfillScopeClause(scope, windowStartIso)
+  const summaryResult = await turso.execute({
+    sql: `SELECT
+            COUNT(*) AS runs,
+            SUM(batch_scanned) AS scanned_count,
+            SUM(batch_enqueued) AS enqueued_count,
+            SUM(CASE WHEN error IS NOT NULL AND TRIM(error) <> '' THEN 1 ELSE 0 END) AS error_runs,
+            AVG(CASE WHEN duration_ms IS NOT NULL THEN duration_ms END) AS avg_duration_ms,
+            MAX(ran_at) AS last_run_at
+          FROM memory_embedding_backfill_metrics
+          ${metricsScope.whereClause}`,
+    args: metricsScope.args,
+  })
+
+  const stateScope = buildBackfillStateScopeClause(scope)
+  const stateResult = await turso.execute({
+    sql: `SELECT status, COUNT(*) AS count
+          FROM memory_embedding_backfill_state
+          ${stateScope.whereClause}
+          GROUP BY status`,
+    args: stateScope.args,
+  })
+
+  const summaryRow = (summaryResult.rows[0] ?? {}) as Record<string, unknown>
+  let runningScopes = 0
+  let pausedScopes = 0
+  for (const stateRow of stateResult.rows) {
+    const record = stateRow as Record<string, unknown>
+    if (record.status === "running") runningScopes = toCount(record.count)
+    if (record.status === "paused") pausedScopes = toCount(record.count)
+  }
+
+  return {
+    runs: toCount(summaryRow.runs),
+    scannedCount: toCount(summaryRow.scanned_count),
+    enqueuedCount: toCount(summaryRow.enqueued_count),
+    errorRuns: toCount(summaryRow.error_runs),
+    avgDurationMs: roundMetric(toNumber(summaryRow.avg_duration_ms), 2),
+    lastRunAt: typeof summaryRow.last_run_at === "string" ? summaryRow.last_run_at : null,
+    activeScopes: runningScopes + pausedScopes,
+    runningScopes,
+    pausedScopes,
+  }
+}
+
+async function loadRetrievalHealth(turso: TursoClient, windowStartIso: string): Promise<EmbeddingRetrievalHealth> {
+  let summaryResult: Awaited<ReturnType<TursoClient["execute"]>>
+  let durationRows: unknown[] = []
+
+  try {
+    summaryResult = await turso.execute({
+      sql: `SELECT
+              COUNT(*) AS total_requests,
+              SUM(CASE WHEN requested_strategy = 'hybrid_graph' THEN 1 ELSE 0 END) AS hybrid_requested,
+              SUM(CASE WHEN fallback_triggered = 1 THEN 1 ELSE 0 END) AS fallback_count,
+              AVG(CASE WHEN duration_ms > 0 THEN duration_ms END) AS avg_duration_ms
+            FROM graph_rollout_metrics
+            WHERE created_at >= ?`,
+      args: [windowStartIso],
+    })
+
+    const durationsResult = await turso.execute({
+      sql: `SELECT duration_ms
+            FROM graph_rollout_metrics
+            WHERE created_at >= ?
+              AND duration_ms > 0
+            ORDER BY duration_ms ASC`,
+      args: [windowStartIso],
+    })
+    durationRows = Array.isArray(durationsResult.rows) ? durationsResult.rows : []
+  } catch (error) {
+    if (!isMissingDurationColumnError(error)) {
+      throw error
+    }
+
+    summaryResult = await turso.execute({
+      sql: `SELECT
+              COUNT(*) AS total_requests,
+              SUM(CASE WHEN requested_strategy = 'hybrid_graph' THEN 1 ELSE 0 END) AS hybrid_requested,
+              SUM(CASE WHEN fallback_triggered = 1 THEN 1 ELSE 0 END) AS fallback_count
+            FROM graph_rollout_metrics
+            WHERE created_at >= ?`,
+      args: [windowStartIso],
+    })
+
+    durationRows = []
+  }
+
+  const fallbackResult = await turso.execute({
+    sql: `SELECT created_at, fallback_reason
+          FROM graph_rollout_metrics
+          WHERE created_at >= ?
+            AND fallback_triggered = 1
+          ORDER BY created_at DESC
+          LIMIT 1`,
+    args: [windowStartIso],
+  })
+
+  const row = (summaryResult.rows[0] ?? {}) as Record<string, unknown>
+  const durations = durationRows
+    .map((durationRow) => toNumber((durationRow as Record<string, unknown>).duration_ms))
+    .filter((value) => value > 0)
+  const totalRequests = toCount(row.total_requests)
+  const fallbackCount = toCount(row.fallback_count)
+  const fallbackRow = (fallbackResult.rows[0] ?? {}) as Record<string, unknown>
+
+  return {
+    totalRequests,
+    hybridRequested: toCount(row.hybrid_requested),
+    fallbackCount,
+    fallbackRate: totalRequests > 0 ? roundMetric(fallbackCount / totalRequests) : 0,
+    avgLatencyMs: roundMetric(toNumber(row.avg_duration_ms), 2),
+    p50LatencyMs: roundMetric(percentile(durations, 0.5), 2),
+    p95LatencyMs: roundMetric(percentile(durations, 0.95), 2),
+    latencySampleCount: durations.length,
+    lastFallbackAt: typeof fallbackRow.created_at === "string" ? fallbackRow.created_at : null,
+    lastFallbackReason: typeof fallbackRow.fallback_reason === "string" ? fallbackRow.fallback_reason : null,
+  }
+}
+
+async function loadCostHealth(
+  input: GetEmbeddingObservabilitySnapshotInput,
+  usageLoader: (input: ListSdkEmbeddingUsageInput) => Promise<ListSdkEmbeddingUsageResult>
+): Promise<EmbeddingCostHealth> {
+  const usage = await usageLoader({
+    ownerUserId: input.ownerUserId,
+    usageMonth: input.usageMonth,
+    tenantId: trimNullable(input.tenantId ?? null) ?? undefined,
+    projectId: trimNullable(input.projectId ?? null) ?? undefined,
+    limit: 100,
+  })
+
+  const requestCount = Math.max(0, usage.summary.requestCount)
+  const customerCostUsd = Math.max(0, usage.summary.customerCostUsd)
+  return {
+    usageMonth: usage.usageMonth,
+    requestCount,
+    inputTokens: Math.max(0, usage.summary.inputTokens),
+    gatewayCostUsd: Math.max(0, usage.summary.gatewayCostUsd),
+    marketCostUsd: Math.max(0, usage.summary.marketCostUsd),
+    customerCostUsd,
+    customerCostPerRequestUsd: requestCount > 0 ? roundMetric(customerCostUsd / requestCount, 8) : 0,
+  }
+}
+
+function evaluateAlarms(snapshot: {
+  queue: EmbeddingQueueHealth
+  worker: EmbeddingWorkerHealth
+  backfill: EmbeddingBackfillHealth
+  retrieval: EmbeddingRetrievalHealth
+}): { alarms: EmbeddingObservabilityAlarm[]; health: SnapshotHealth } {
+  const alarms: EmbeddingObservabilityAlarm[] = []
+
+  const pushAlarm = (
+    code: string,
+    severity: AlarmSeverity,
+    message: string,
+    observed: number,
+    threshold: number,
+    unit: "ms" | "ratio" | "count"
+  ) => {
+    alarms.push({ code, severity, message, observed, threshold, unit })
+  }
+
+  if (snapshot.queue.queueLagMs >= EMBEDDING_OBSERVABILITY_SLOS.queueLagMs.critical) {
+    pushAlarm(
+      "EMBEDDING_QUEUE_LAG_CRITICAL",
+      "critical",
+      "Embedding queue lag exceeds critical SLO.",
+      snapshot.queue.queueLagMs,
+      EMBEDDING_OBSERVABILITY_SLOS.queueLagMs.critical,
+      "ms"
+    )
+  } else if (snapshot.queue.queueLagMs >= EMBEDDING_OBSERVABILITY_SLOS.queueLagMs.warning) {
+    pushAlarm(
+      "EMBEDDING_QUEUE_LAG_WARNING",
+      "warning",
+      "Embedding queue lag exceeds warning SLO.",
+      snapshot.queue.queueLagMs,
+      EMBEDDING_OBSERVABILITY_SLOS.queueLagMs.warning,
+      "ms"
+    )
+  }
+
+  if (snapshot.queue.staleProcessingCount >= EMBEDDING_OBSERVABILITY_SLOS.staleProcessingCount.critical) {
+    pushAlarm(
+      "EMBEDDING_STALE_JOBS_CRITICAL",
+      "critical",
+      "Too many embedding jobs are stuck in processing state.",
+      snapshot.queue.staleProcessingCount,
+      EMBEDDING_OBSERVABILITY_SLOS.staleProcessingCount.critical,
+      "count"
+    )
+  } else if (snapshot.queue.staleProcessingCount >= EMBEDDING_OBSERVABILITY_SLOS.staleProcessingCount.warning) {
+    pushAlarm(
+      "EMBEDDING_STALE_JOBS_WARNING",
+      "warning",
+      "Some embedding jobs appear stuck in processing state.",
+      snapshot.queue.staleProcessingCount,
+      EMBEDDING_OBSERVABILITY_SLOS.staleProcessingCount.warning,
+      "count"
+    )
+  }
+
+  if (snapshot.worker.attempts >= EMBEDDING_OBSERVABILITY_SLOS.deadLetterRate.minSamples) {
+    if (snapshot.worker.failureRate >= EMBEDDING_OBSERVABILITY_SLOS.deadLetterRate.critical) {
+      pushAlarm(
+        "EMBEDDING_DEAD_LETTER_RATE_CRITICAL",
+        "critical",
+        "Embedding dead-letter rate exceeds critical SLO.",
+        snapshot.worker.failureRate,
+        EMBEDDING_OBSERVABILITY_SLOS.deadLetterRate.critical,
+        "ratio"
+      )
+    } else if (snapshot.worker.failureRate >= EMBEDDING_OBSERVABILITY_SLOS.deadLetterRate.warning) {
+      pushAlarm(
+        "EMBEDDING_DEAD_LETTER_RATE_WARNING",
+        "warning",
+        "Embedding dead-letter rate exceeds warning SLO.",
+        snapshot.worker.failureRate,
+        EMBEDDING_OBSERVABILITY_SLOS.deadLetterRate.warning,
+        "ratio"
+      )
+    }
+  }
+
+  if (snapshot.retrieval.totalRequests >= EMBEDDING_OBSERVABILITY_SLOS.retrievalFallbackRate.minSamples) {
+    if (snapshot.retrieval.fallbackRate >= EMBEDDING_OBSERVABILITY_SLOS.retrievalFallbackRate.critical) {
+      pushAlarm(
+        "EMBEDDING_RETRIEVAL_FALLBACK_RATE_CRITICAL",
+        "critical",
+        "Retrieval fallback rate exceeds critical SLO.",
+        snapshot.retrieval.fallbackRate,
+        EMBEDDING_OBSERVABILITY_SLOS.retrievalFallbackRate.critical,
+        "ratio"
+      )
+    } else if (snapshot.retrieval.fallbackRate >= EMBEDDING_OBSERVABILITY_SLOS.retrievalFallbackRate.warning) {
+      pushAlarm(
+        "EMBEDDING_RETRIEVAL_FALLBACK_RATE_WARNING",
+        "warning",
+        "Retrieval fallback rate exceeds warning SLO.",
+        snapshot.retrieval.fallbackRate,
+        EMBEDDING_OBSERVABILITY_SLOS.retrievalFallbackRate.warning,
+        "ratio"
+      )
+    }
+  }
+
+  if (snapshot.retrieval.latencySampleCount >= EMBEDDING_OBSERVABILITY_SLOS.retrievalP95LatencyMs.minSamples) {
+    if (snapshot.retrieval.p95LatencyMs >= EMBEDDING_OBSERVABILITY_SLOS.retrievalP95LatencyMs.critical) {
+      pushAlarm(
+        "EMBEDDING_RETRIEVAL_LATENCY_CRITICAL",
+        "critical",
+        "Retrieval p95 latency exceeds critical SLO.",
+        snapshot.retrieval.p95LatencyMs,
+        EMBEDDING_OBSERVABILITY_SLOS.retrievalP95LatencyMs.critical,
+        "ms"
+      )
+    } else if (snapshot.retrieval.p95LatencyMs >= EMBEDDING_OBSERVABILITY_SLOS.retrievalP95LatencyMs.warning) {
+      pushAlarm(
+        "EMBEDDING_RETRIEVAL_LATENCY_WARNING",
+        "warning",
+        "Retrieval p95 latency exceeds warning SLO.",
+        snapshot.retrieval.p95LatencyMs,
+        EMBEDDING_OBSERVABILITY_SLOS.retrievalP95LatencyMs.warning,
+        "ms"
+      )
+    }
+  }
+
+  if (snapshot.backfill.errorRuns >= EMBEDDING_OBSERVABILITY_SLOS.backfillErrorRuns.critical) {
+    pushAlarm(
+      "EMBEDDING_BACKFILL_ERRORS_CRITICAL",
+      "critical",
+      "Backfill batch errors exceed critical threshold.",
+      snapshot.backfill.errorRuns,
+      EMBEDDING_OBSERVABILITY_SLOS.backfillErrorRuns.critical,
+      "count"
+    )
+  } else if (snapshot.backfill.errorRuns >= EMBEDDING_OBSERVABILITY_SLOS.backfillErrorRuns.warning) {
+    pushAlarm(
+      "EMBEDDING_BACKFILL_ERRORS_WARNING",
+      "warning",
+      "Backfill batch errors detected in the observation window.",
+      snapshot.backfill.errorRuns,
+      EMBEDDING_OBSERVABILITY_SLOS.backfillErrorRuns.warning,
+      "count"
+    )
+  }
+
+  const health: SnapshotHealth = alarms.some((alarm) => alarm.severity === "critical")
+    ? "critical"
+    : alarms.length > 0
+      ? "degraded"
+      : "healthy"
+
+  return { alarms, health }
+}
+
+export async function getEmbeddingObservabilitySnapshot(
+  input: GetEmbeddingObservabilitySnapshotInput,
+  dependencies: ObservabilityDependencies = {}
+): Promise<EmbeddingObservabilitySnapshot> {
+  const nowIso = input.nowIso ?? new Date().toISOString()
+  const windowHours = normalizeWindowHours(input.windowHours)
+  const windowStartIso = toWindowStartIso(nowIso, windowHours)
+  const scope: EmbeddingScope = {
+    tenantId: trimNullable(input.tenantId ?? null),
+    projectId: trimNullable(input.projectId ?? null),
+    userId: trimNullable(input.userId ?? null),
+    modelId: trimNullable(input.modelId ?? null),
+  }
+  const usageLoader = dependencies.usageLoader ?? listSdkEmbeddingUsage
+
+  const [queue, worker, backfill, retrieval, cost] = await Promise.all([
+    loadQueueHealth(input.turso, scope, nowIso),
+    loadWorkerHealth(input.turso, scope, windowStartIso),
+    loadBackfillHealth(input.turso, scope, windowStartIso),
+    loadRetrievalHealth(input.turso, windowStartIso),
+    loadCostHealth(input, usageLoader),
+  ])
+
+  const { alarms, health } = evaluateAlarms({
+    queue,
+    worker,
+    backfill,
+    retrieval,
+  })
+
+  return {
+    sampledAt: nowIso,
+    windowHours,
+    scope,
+    slos: EMBEDDING_OBSERVABILITY_SLOS,
+    queue,
+    worker,
+    backfill,
+    retrieval,
+    cost,
+    alarms,
+    health,
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/sdk/v1/management/embeddings/observability` with queue, worker, backfill, retrieval, and cost snapshots
- add SLO-based alert evaluation for queue lag, dead-letter rate, retrieval fallback/latency, and backfill errors
- instrument retrieval latency in `graph_rollout_metrics` with backward-compatible schema upgrades
- publish SDK embedding operations runbook and add it to docs navigation

## Validation
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm exec vitest run src/lib/sdk-embeddings/observability.test.ts src/app/api/sdk/v1/management/embeddings/observability/__tests__/route.test.ts src/app/api/mcp/__tests__/route.test.ts src/lib/memory-service/queries.graph.test.ts src/lib/memory-service/graph/status.test.ts`

Closes #188

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authenticated management API and adds a schema change plus extra writes on the hot retrieval path; issues could impact observability accuracy or add minor DB overhead, but changes are additive and include compatibility guards/tests.
> 
> **Overview**
> Adds a new management endpoint `GET /api/sdk/v1/management/embeddings/observability` that returns an embeddings observability snapshot (queue, worker, backfill, retrieval, and cost) and evaluates **SLO-based alarms** to classify overall health as `healthy`/`degraded`/`critical`.
> 
> Instruments retrieval to record end-to-end duration into `graph_rollout_metrics.duration_ms`, including backward-compatible schema upgrades (`ALTER TABLE` if missing) across rollout/table initialization paths, and uses that data to compute retrieval latency percentiles/fallback rates in the new snapshot. Adds unit/route tests and publishes an **Embedding Operations Runbook** doc, wiring it into the SDK docs nav.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e30d5f812f15e1af7b9f03af051c584071bdbc10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->