### PR TITLE
fix(web): harden embeddings observability scoping and usage accuracy

### DIFF
--- a/packages/web/src/lib/memory-service/scope-schema.test.ts
+++ b/packages/web/src/lib/memory-service/scope-schema.test.ts
@@ -173,6 +173,22 @@ describe("ensureMemoryUserIdSchema", () => {
     const embeddingBackfillMetricIndexNames = new Set(embeddingBackfillMetricIndexes.rows.map((row) => String(row.name)))
     expect(embeddingBackfillMetricIndexNames.has("idx_memory_embedding_backfill_metrics_scope_ran_at")).toBe(true)
     expect(embeddingBackfillMetricIndexNames.has("idx_memory_embedding_backfill_metrics_status_ran_at")).toBe(true)
+
+    const rolloutMetricColumns = await db.execute("PRAGMA table_info(graph_rollout_metrics)")
+    const rolloutMetricColumnNames = new Set(rolloutMetricColumns.rows.map((row) => String(row.name)))
+    expect(rolloutMetricColumnNames.has("project_id")).toBe(true)
+    expect(rolloutMetricColumnNames.has("user_id")).toBe(true)
+    expect(rolloutMetricColumnNames.has("semantic_model")).toBe(true)
+    expect(rolloutMetricColumnNames.has("duration_ms")).toBe(true)
+
+    const rolloutMetricIndexes = await db.execute({
+      sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?",
+      args: ["graph_rollout_metrics"],
+    })
+    const rolloutMetricIndexNames = new Set(rolloutMetricIndexes.rows.map((row) => String(row.name)))
+    expect(rolloutMetricIndexNames.has("idx_graph_rollout_metrics_project_created_at")).toBe(true)
+    expect(rolloutMetricIndexNames.has("idx_graph_rollout_metrics_user_created_at")).toBe(true)
+    expect(rolloutMetricIndexNames.has("idx_graph_rollout_metrics_model_created_at")).toBe(true)
   })
 
   it("upgrades embedding schema for tenants already marked on the user-id migration", async () => {

--- a/packages/web/src/lib/memory-service/scope-schema.ts
+++ b/packages/web/src/lib/memory-service/scope-schema.ts
@@ -86,13 +86,51 @@ async function ensureGraphSchema(turso: TursoClient): Promise<void> {
       total_candidates INTEGER NOT NULL DEFAULT 0,
       fallback_triggered INTEGER NOT NULL DEFAULT 0,
       fallback_reason TEXT,
+      project_id TEXT,
+      user_id TEXT,
+      semantic_model TEXT,
       duration_ms INTEGER NOT NULL DEFAULT 0
     )`
   )
 
   const rolloutMetricColumns = await turso.execute("PRAGMA table_info(graph_rollout_metrics)")
   const rolloutColumnRows = Array.isArray(rolloutMetricColumns.rows) ? rolloutMetricColumns.rows : []
+  const hasProjectIdColumn = rolloutColumnRows.some((row) => String((row as { name?: unknown }).name ?? "") === "project_id")
+  const hasUserIdColumn = rolloutColumnRows.some((row) => String((row as { name?: unknown }).name ?? "") === "user_id")
+  const hasSemanticModelColumn = rolloutColumnRows.some(
+    (row) => String((row as { name?: unknown }).name ?? "") === "semantic_model"
+  )
   const hasDurationColumn = rolloutColumnRows.some((row) => String((row as { name?: unknown }).name ?? "") === "duration_ms")
+  if (!hasProjectIdColumn) {
+    try {
+      await turso.execute("ALTER TABLE graph_rollout_metrics ADD COLUMN project_id TEXT")
+    } catch (error) {
+      const message = error instanceof Error ? error.message.toLowerCase() : ""
+      if (!message.includes("duplicate column name")) {
+        throw error
+      }
+    }
+  }
+  if (!hasUserIdColumn) {
+    try {
+      await turso.execute("ALTER TABLE graph_rollout_metrics ADD COLUMN user_id TEXT")
+    } catch (error) {
+      const message = error instanceof Error ? error.message.toLowerCase() : ""
+      if (!message.includes("duplicate column name")) {
+        throw error
+      }
+    }
+  }
+  if (!hasSemanticModelColumn) {
+    try {
+      await turso.execute("ALTER TABLE graph_rollout_metrics ADD COLUMN semantic_model TEXT")
+    } catch (error) {
+      const message = error instanceof Error ? error.message.toLowerCase() : ""
+      if (!message.includes("duplicate column name")) {
+        throw error
+      }
+    }
+  }
   if (!hasDurationColumn) {
     try {
       await turso.execute("ALTER TABLE graph_rollout_metrics ADD COLUMN duration_ms INTEGER NOT NULL DEFAULT 0")
@@ -110,6 +148,15 @@ async function ensureGraphSchema(turso: TursoClient): Promise<void> {
   await turso.execute("CREATE INDEX IF NOT EXISTS idx_graph_rollout_metrics_mode ON graph_rollout_metrics(mode)")
   await turso.execute(
     "CREATE INDEX IF NOT EXISTS idx_graph_rollout_metrics_fallback ON graph_rollout_metrics(fallback_triggered, created_at)"
+  )
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_graph_rollout_metrics_project_created_at ON graph_rollout_metrics(project_id, created_at)"
+  )
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_graph_rollout_metrics_user_created_at ON graph_rollout_metrics(user_id, created_at)"
+  )
+  await turso.execute(
+    "CREATE INDEX IF NOT EXISTS idx_graph_rollout_metrics_model_created_at ON graph_rollout_metrics(semantic_model, created_at)"
   )
 }
 


### PR DESCRIPTION
## Summary
- make embedding usage summaries complete even when `limit` is set by paginating source rows and applying `limit` only to returned breakdown rows
- extend usage filters with optional `userId` + `modelId` and add `summaryOnly` for observability cost snapshots
- scope retrieval observability by `project_id`, `user_id`, and `semantic_model` in `graph_rollout_metrics`
- add scoped rollout metric columns (`project_id`, `user_id`, `semantic_model`) + indexes with backward-compatible schema upgrades
- record retrieval scope/model metadata during context retrieval metric writes
- align backfill metrics scoping with project/user filters by joining `memory_embedding_backfill_state`
- evaluate retrieval fallback SLO against hybrid-request volume (not total request volume)
- add regression coverage for scoped retrieval observability + fallback denominator and schema/index guarantees

## Validation
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm --filter @memories.sh/web exec vitest run src/lib/sdk-embedding-billing.test.ts src/lib/sdk-embeddings/observability.test.ts src/lib/memory-service/scope-schema.test.ts src/lib/memory-service/queries.semantic.test.ts src/app/api/sdk/v1/management/embeddings/observability/__tests__/route.test.ts src/app/api/sdk/v1/management/embeddings/usage/__tests__/route.test.ts src/lib/memory-service/graph/status.test.ts src/lib/memory-service/queries.graph.test.ts`
- `pnpm --filter @memories.sh/web exec eslint src/lib/memory-service/graph/rollout.ts src/lib/memory-service/queries.ts src/lib/memory-service/scope-schema.ts src/lib/memory-service/scope-schema.test.ts src/lib/sdk-embedding-billing.ts src/lib/sdk-embedding-billing.test.ts src/lib/sdk-embeddings/observability.ts src/lib/sdk-embeddings/observability.test.ts src/lib/turso.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production observability/billing aggregation logic and introduces schema migrations/indexes; main risk is incorrect scoping or query behavior impacting dashboards and cost reporting, though changes are backward-compatible and covered by tests.
> 
> **Overview**
> **Improves embeddings observability accuracy and scoping.** Retrieval health now filters `graph_rollout_metrics` by `project_id`, `user_id`, and `semantic_model`, and computes fallback rate (and SLO evaluation) using *hybrid-request volume* as the denominator rather than all requests.
> 
> Graph rollout metric storage is extended to persist `project_id`, `user_id`, and `semantic_model` (with backward-compatible `ALTER TABLE` upgrades plus new indexes), and context retrieval now records the semantic embedding model used in its trace/metrics. SDK embedding usage aggregation is hardened by paginating source meter-event rows (so summaries are complete even with `limit`), adding optional `userId`/`modelId` filters, and supporting `summaryOnly` for cost snapshots; backfill metrics scoping is aligned by joining backfill metrics to state for project/user filtering. Tests are updated/added to cover schema/index guarantees, scoped retrieval metrics, and the new usage pagination behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9fbd04197032bf9bc92719312569a3e7d5a264d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->