### PR TITLE
Enforce hashed CLI token auth and remove plaintext fallback

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -8,6 +8,8 @@ description: Product and documentation updates.
 - Removed legacy tenant management routes `/api/mcp/tenants` and `/api/sdk/v1/management/tenants`.
 - Removed legacy tenant compatibility wrapper code and telemetry write-paths now that traffic is zero.
 - Updated tenant-routing and SDK endpoint contract docs to reference only `/api/sdk/v1/management/tenant-overrides`.
+- Enforced hashed-only CLI bearer token auth by removing plaintext `cli_token` runtime fallback in `authenticateRequest`.
+- Added migration `20260220053000_backfill_cli_token_hashes.sql` to backfill `cli_token_hash` from legacy `cli_token` and clear plaintext values.
 - Added hosted SDK embeddings docs at `/docs/sdk/embeddings` with write-path model selection, retrieval strategy controls, and migration guidance.
 - Added embeddings endpoint contract documentation for:
   - `GET /api/sdk/v1/embeddings/models`

--- a/packages/web/src/lib/__tests__/auth.test.ts
+++ b/packages/web/src/lib/__tests__/auth.test.ts
@@ -56,7 +56,6 @@ describe("authenticateRequest", () => {
       const mockMaybeSingle = vi
         .fn()
         .mockResolvedValueOnce({ data: null, error: null })
-        .mockResolvedValueOnce({ data: null, error: null })
       const mockAdmin = {
         from: vi.fn().mockReturnValue({
           select: vi.fn().mockReturnValue({
@@ -72,21 +71,16 @@ describe("authenticateRequest", () => {
       const result = await authenticateRequest(request)
 
       expect(result).toBeNull()
-      expect(mockMaybeSingle).toHaveBeenCalledTimes(2)
+      expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
     })
 
-    it("should fall back to legacy plaintext token when hash column is unavailable", async () => {
+    it("should return null when hashed token lookup errors", async () => {
       const mockMaybeSingle = vi
         .fn()
         .mockResolvedValueOnce({
           data: null,
           error: { message: "column users.cli_token_hash does not exist" },
         })
-        .mockResolvedValueOnce({
-          data: { id: "legacy-user", email: "legacy@example.com" },
-          error: null,
-        })
-
       const mockAdmin = {
         from: vi.fn().mockReturnValue({
           select: vi.fn().mockReturnValue({
@@ -101,8 +95,8 @@ describe("authenticateRequest", () => {
       const request = makeRequest({ authorization: "Bearer cli_legacy_token" })
       const result = await authenticateRequest(request)
 
-      expect(result).toEqual({ userId: "legacy-user", email: "legacy@example.com" })
-      expect(mockMaybeSingle).toHaveBeenCalledTimes(2)
+      expect(result).toBeNull()
+      expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/supabase/migrations/20260220053000_backfill_cli_token_hashes.sql
+++ b/supabase/migrations/20260220053000_backfill_cli_token_hashes.sql
@@ -1,0 +1,14 @@
+-- Enforce hashed-only CLI auth by migrating any remaining plaintext tokens.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+UPDATE public.users
+SET cli_token_hash = COALESCE(
+  cli_token_hash,
+  encode(extensions.digest(convert_to(cli_token, 'UTF8'), 'sha256'), 'hex')
+)
+WHERE cli_token IS NOT NULL;
+
+UPDATE public.users
+SET cli_token = NULL
+WHERE cli_token IS NOT NULL
+  AND cli_token_hash IS NOT NULL;


### PR DESCRIPTION
## Summary
- remove plaintext `cli_token` fallback from `authenticateRequest` and enforce hashed token lookup only
- add migration `20260220053000_backfill_cli_token_hashes.sql` to backfill hashes for any remaining plaintext CLI tokens and then null plaintext tokens
- update auth tests to validate hashed-token-only success/failure behavior
- add changelog migration/release note

## Validation
- `pnpm --filter @memories.sh/web test -- src/lib/__tests__/auth.test.ts src/app/api/auth/cli/__tests__/route.test.ts`
- `pnpm --filter @memories.sh/web typecheck`

Closes #207

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and token validation behavior; users with only legacy plaintext tokens (or missing `cli_token_hash`) will be unable to authenticate until the migration is applied.
> 
> **Overview**
> **Enforces hashed-only CLI bearer token authentication** by removing the runtime fallback that matched against plaintext `users.cli_token`; any hash lookup error now fails closed.
> 
> Adds a Supabase migration to backfill `users.cli_token_hash` from any remaining plaintext `cli_token` values and then clears the plaintext column, and updates auth tests + changelog to reflect the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1885c20968ea798ea392378d50298e20aa615fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->