### PR TITLE
Simplify onboarding with minimal local mode and stronger diagnostics

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,9 @@ Global installs automatically bootstrap `SKILLS.md` guidance in detected tool co
 # Initialize in your project (auto-detects tools, configures MCP, imports existing project skills)
 memories setup
 
+# Minimal local mode (no cloud/workspace dependency)
+memories setup --minimal-local -y
+
 # Pick scope explicitly when needed
 memories setup --scope project   # or --scope global
 
@@ -34,6 +37,9 @@ memories generate
 
 # Start the MCP server
 memories serve
+
+# Local-only diagnostics
+memories doctor --local-only
 ```
 
 ## Features

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -98,4 +98,12 @@ describe("doctor checks", () => {
     const unique = new Set(report.nextSteps);
     expect(unique.size).toBe(report.nextSteps.length);
   });
+
+  it("should mark cloud integration healthy in explicit local-only mode", async () => {
+    const report = await runDoctorChecks({ localOnly: true });
+    const cloudCheck = report.checks.find((check) => check.id === "cloud_integration");
+    expect(cloudCheck).toBeDefined();
+    expect(cloudCheck?.status).toBe("pass");
+    expect(cloudCheck?.message).toContain("Skipped cloud checks");
+  });
 });

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -25,6 +25,9 @@ description: Product and documentation updates.
 - Clarified retrieval `trace` diagnostics and fallback semantics to support phased semantic/hybrid rollout.
 - Set graph retrieval feature flag default to enabled (`GRAPH_RETRIEVAL_ENABLED=true` fallback) and added rollout decision payloads with SLO/gap metrics (`rolloutPlan`) on `GET|POST|PATCH /api/sdk/v1/graph/rollout`.
 - Added graph default-on rollout policy docs with explicit go/no-go thresholds, baseline gap reporting, and `GRAPH_ROLLOUT_AUTOPILOT_ENABLED` behavior.
+- Added `memories setup --minimal-local` preset for local-only onboarding with no cloud/workspace dependency.
+- Added `memories doctor --local-only` to skip cloud checks and provide cleaner local-mode diagnostics.
+- Documented a 10-minute local happy path (`setup -> doctor --local-only -> add -> search`) across CLI and Getting Started docs.
 
 ## February 16, 2026
 

--- a/packages/web/content/docs/cli/doctor.mdx
+++ b/packages/web/content/docs/cli/doctor.mdx
@@ -15,6 +15,7 @@ Run deterministic diagnostic checks across local DB, MCP wiring, project detecti
 |--------|-------------|
 | `--fix` | Attempt to fix issues found |
 | `--json` | Output machine-readable report (stable schema) |
+| `--local-only` | Skip cloud health checks and validate local mode only |
 | `--strict` | Exit with code `1` when warnings or failures exist |
 
 ## Checks Performed
@@ -58,6 +59,12 @@ Machine-readable report for CI/automation:
 
 ```bash
 memories doctor --json --strict
+```
+
+Local-only validation (no login/workspace requirement):
+
+```bash
+memories doctor --local-only
 ```
 
 `--json` now returns:

--- a/packages/web/content/docs/cli/init.mdx
+++ b/packages/web/content/docs/cli/init.mdx
@@ -36,6 +36,7 @@ Initialize the memories database and automatically set up MCP integration for de
 | `--skip-mcp` | Skip automatic MCP configuration |
 | `--skip-generate` | Skip generating instruction files |
 | `--skip-skill-ingest` | Skip importing existing project skills into memories |
+| `--minimal-local` | Apply local-only setup preset (no cloud/workspace dependency checks) |
 | `-y, --yes` | Auto-confirm all prompts |
 
 ### Setup mode
@@ -43,6 +44,7 @@ Initialize the memories database and automatically set up MCP integration for de
 - `auto` (default): prompts for local vs cloud guidance in interactive sessions
 - `local`: skips login/workspace provisioning prompts
 - `cloud`: runs guided login + workspace checks/provisioning
+- `--minimal-local`: forces local mode and local-only verification defaults
 
 ### Memory scope
 
@@ -127,6 +129,20 @@ Auto-confirms all prompts — useful for scripts or CI.
 ```bash
 # Only create database, don't configure tools or skill import
 memories setup --skip-mcp --skip-generate --skip-skill-ingest
+```
+
+### 10-minute minimal local happy path
+
+```bash
+# Local-only setup with no cloud/workspace dependency
+memories setup --minimal-local -y
+
+# Verify local checks (cloud intentionally skipped)
+memories doctor --local-only
+
+# Confirm first memory round-trip
+memories add --rule "Local setup smoke test"
+memories search "Local setup smoke test"
 ```
 
 ### Initialize with starter rules

--- a/packages/web/content/docs/getting-started.mdx
+++ b/packages/web/content/docs/getting-started.mdx
@@ -74,11 +74,23 @@ memories setup --skip-generate
 # Auto-confirm all prompts
 memories setup -y
 
+# Minimal local mode (no cloud/workspace dependency)
+memories setup --minimal-local -y
+
 # Initialize with starter rules
 memories setup --rule "Use TypeScript strict mode" --rule "Prefer pnpm"
 
 # Initialize global memories (apply to all projects)
 memories setup --global
+```
+
+### 10-minute local happy path
+
+```bash
+memories setup --minimal-local -y
+memories doctor --local-only
+memories add --rule "Local setup smoke test"
+memories search "Local setup smoke test"
 ```
 
 ## Add Your First Memory


### PR DESCRIPTION
## Summary
- add `memories setup --minimal-local` as a local-only onboarding preset with no cloud/workspace dependency
- add `memories doctor --local-only` to skip cloud health checks and improve local-mode diagnostics/remediation
- run setup verification in local mode with cloud checks disabled to reduce false warning noise
- document a 10-minute local happy path from install to first memory round-trip across CLI docs + Getting Started

## Validation
- pnpm --filter @memories.sh/cli test
- pnpm --filter @memories.sh/cli typecheck
- pnpm --filter @memories.sh/cli lint

Closes #210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive CLI flags and documentation, with a small behavioral tweak to skip cloud health checks during local verification; impact is limited to setup/diagnostics flow.
> 
> **Overview**
> Adds a new local-first onboarding path via `memories setup --minimal-local`, which forces `local` mode and avoids any login/workspace dependency while keeping post-setup verification.
> 
> Extends `memories doctor` with `--local-only`, making the `cloud_integration` check explicitly *pass* (skipped) and updating remediation to point users at the local-only mode; `setup` now runs verification with cloud checks disabled when in local mode. Documentation is updated across CLI README and web docs to highlight the minimal local flow and a short “happy path” (`setup -> doctor --local-only -> add -> search`), and a new test locks in the local-only doctor behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 436422befbf2e7d0fb44f8ec5ee9cc24c3451530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->