### PR TITLE
Automate default retrieval strategy promotion

### DIFF
--- a/packages/core/src/client-schemas.ts
+++ b/packages/core/src/client-schemas.ts
@@ -80,6 +80,11 @@ export const contextStructuredSchema = z.object({
         z.literal("baseline"),
         z.literal("hybrid_graph"),
       ]),
+      retrievalPolicyDefaultStrategy: z.union([z.literal("lexical"), z.literal("hybrid")]).optional(),
+      retrievalPolicyAppliedStrategy: z.union([z.literal("lexical"), z.literal("hybrid")]).optional(),
+      retrievalPolicySelection: z.union([z.literal("request"), z.literal("policy_default")]).optional(),
+      retrievalPolicyReadyForDefaultOn: z.boolean().optional(),
+      retrievalPolicyBlockerCodes: z.array(z.string()).optional(),
       semanticStrategyRequested: z
         .union([z.literal("lexical"), z.literal("semantic"), z.literal("hybrid")])
         .optional(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,11 @@ export interface ContextResult {
   trace?: {
     requestedStrategy?: ContextStrategy
     strategy: ContextStrategy
+    retrievalPolicyDefaultStrategy?: "lexical" | "hybrid"
+    retrievalPolicyAppliedStrategy?: "lexical" | "hybrid"
+    retrievalPolicySelection?: "request" | "policy_default"
+    retrievalPolicyReadyForDefaultOn?: boolean
+    retrievalPolicyBlockerCodes?: string[]
     semanticStrategyRequested?: RetrievalStrategy
     semanticStrategyApplied?: RetrievalStrategy
     lexicalCandidates?: number

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -25,6 +25,9 @@ description: Product and documentation updates.
 - Clarified retrieval `trace` diagnostics and fallback semantics to support phased semantic/hybrid rollout.
 - Set graph retrieval feature flag default to enabled (`GRAPH_RETRIEVAL_ENABLED=true` fallback) and added rollout decision payloads with SLO/gap metrics (`rolloutPlan`) on `GET|POST|PATCH /api/sdk/v1/graph/rollout`.
 - Added graph default-on rollout policy docs with explicit go/no-go thresholds, baseline gap reporting, and `GRAPH_ROLLOUT_AUTOPILOT_ENABLED` behavior.
+- Added default retrieval strategy policy autopilot (`GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED`, default `true`) with two-window promotion (`lexical -> hybrid`) and automatic rollback on gate regression.
+- Updated `context/get` and `graph/trace` to apply policy defaults when `strategy` is omitted and return retrieval-policy trace diagnostics.
+- Added `retrievalPolicy` snapshot payload to `GET|POST|PATCH /api/sdk/v1/graph/rollout`.
 - Added `memories setup --minimal-local` preset for local-only onboarding with no cloud/workspace dependency.
 - Added `memories doctor --local-only` to skip cloud checks and provide cleaner local-mode diagnostics.
 - Documented a 10-minute local happy path (`setup -> doctor --local-only -> add -> search`) across CLI and Getting Started docs.

--- a/packages/web/content/docs/sdk/endpoint-contract.mdx
+++ b/packages/web/content/docs/sdk/endpoint-contract.mdx
@@ -209,7 +209,7 @@ Defaults:
 - `includeRules`: `true`
 - `includeSkillFiles`: `true`
 - `mode`: `all`
-- `strategy`: `lexical`
+- `strategy`: policy default (`lexical` until rollout policy promotes to `hybrid`)
 - `graphDepth`: `1`
 - `graphLimit`: `8`
 
@@ -226,7 +226,7 @@ Response `data`:
 - `skillFiles[]`
 - `workingMemories[]`
 - `longTermMemories[]`
-- `trace` (strategy, rollout mode, fallback details, candidate counts)
+- `trace` (strategy, rollout mode, fallback details, candidate counts, retrieval policy diagnostics)
 
 ### `POST /api/sdk/v1/memories/add`
 
@@ -533,7 +533,7 @@ Trace retrieval behavior and graph expansion decisions.
 
 Request is similar to `context/get`, but defaults differ:
 
-- `strategy` default: `hybrid_graph`
+- `strategy` default: policy default (`baseline` for lexical policy, `hybrid_graph` for hybrid policy)
 - `limit` default: `10`
 
 Response `data` includes:
@@ -541,6 +541,12 @@ Response `data` includes:
 - `mode`, `includeRules`, `query`
 - `strategy`: `{ requested, applied }`
 - `trace`: rollout/fallback/candidate metrics
+  - includes retrieval policy diagnostics:
+    - `retrievalPolicyDefaultStrategy`
+    - `retrievalPolicyAppliedStrategy`
+    - `retrievalPolicySelection`
+    - `retrievalPolicyReadyForDefaultOn`
+    - `retrievalPolicyBlockerCodes`
 - `tiers`: rule/working/long-term ID lists
 - `recall[]`: rank + source (`baseline` or `graph_expansion`) + graph explainability
 - `rules[]`, `memories[]`
@@ -590,6 +596,13 @@ Successful response `data` includes:
   - `baseline` (gap-to-goal metrics)
   - `slo` thresholds and sample requirements
   - `autopilot` (`enabled`, `applied`)
+- `retrievalPolicy`
+  - `defaultStrategy`
+  - `readyWindowStreak`
+  - `lastDecision`
+  - `lastEvaluatedAt`
+  - `updatedAt`
+  - `updatedBy`
 - `scope`
 
 ## Health Contract

--- a/packages/web/content/docs/sdk/graph-default-on-rollout.mdx
+++ b/packages/web/content/docs/sdk/graph-default-on-rollout.mdx
@@ -55,6 +55,24 @@ Autopilot flag:
 - `GRAPH_ROLLOUT_AUTOPILOT_ENABLED=false` by default
 - when enabled, `GET /api/sdk/v1/graph/rollout` may auto-advance mode based on the plan
 
+## Default Strategy Autopilot
+
+Default retrieval strategy is managed by a separate policy record (`graph_retrieval_policy`) and evaluated on each request:
+
+- `GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED=true` by default
+- promotion threshold: `2` consecutive windows where `rolloutPlan.readyForDefaultOn === true`
+- promotion behavior: `lexical -> hybrid`
+- rollback behavior: if current default is `hybrid` and gate regresses (`readyForDefaultOn === false`), revert to `lexical`
+
+`POST /api/sdk/v1/context/get` and `POST /api/sdk/v1/graph/trace` now use this policy default when `strategy` is omitted.
+Both endpoints return trace metadata so clients can audit how strategy was selected:
+
+- `retrievalPolicyDefaultStrategy`
+- `retrievalPolicyAppliedStrategy`
+- `retrievalPolicySelection`
+- `retrievalPolicyReadyForDefaultOn`
+- `retrievalPolicyBlockerCodes`
+
 ## Default Behavior Decision
 
 Current decision in zero-sample state: `hold_lexical_default`.

--- a/packages/web/src/app/api/sdk/v1/graph/rollout/route.ts
+++ b/packages/web/src/app/api/sdk/v1/graph/rollout/route.ts
@@ -1,5 +1,5 @@
 import {
-  evaluateGraphRolloutPlan,
+  evaluateGraphRetrievalPolicy,
   evaluateGraphRolloutQuality,
   setGraphRolloutConfig,
   type GraphRolloutMode,
@@ -117,7 +117,7 @@ async function buildRolloutResponse(params: {
     })
   }
 
-  const rolloutSnapshot = await evaluateGraphRolloutPlan(turso, {
+  const rolloutSnapshot = await evaluateGraphRetrievalPolicy(turso, {
     nowIso,
     windowHours: 24,
     updatedBy: updatedBy ?? null,
@@ -129,6 +129,7 @@ async function buildRolloutResponse(params: {
     shadowMetrics: rolloutSnapshot.shadowMetrics,
     qualityGate: rolloutSnapshot.qualityGate,
     rolloutPlan: rolloutSnapshot.plan,
+    retrievalPolicy: rolloutSnapshot.policy,
     scope,
   })
 }

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -279,6 +279,10 @@ export const GRAPH_MAPPING_ENABLED = parseBooleanFlag(process.env.GRAPH_MAPPING_
 export const GRAPH_RETRIEVAL_ENABLED = parseBooleanFlag(process.env.GRAPH_RETRIEVAL_ENABLED, true)
 export const GRAPH_LLM_EXTRACTION_ENABLED = parseBooleanFlag(process.env.GRAPH_LLM_EXTRACTION_ENABLED, false)
 export const GRAPH_ROLLOUT_AUTOPILOT_ENABLED = parseBooleanFlag(process.env.GRAPH_ROLLOUT_AUTOPILOT_ENABLED, false)
+export const GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED = parseBooleanFlag(
+  process.env.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED,
+  true
+)
 
 // ── Other ────────────────────────────────────────────────────────────
 

--- a/packages/web/src/lib/memory-service/types.test.ts
+++ b/packages/web/src/lib/memory-service/types.test.ts
@@ -5,6 +5,7 @@ const originalFlags = {
   GRAPH_RETRIEVAL_ENABLED: process.env.GRAPH_RETRIEVAL_ENABLED,
   GRAPH_LLM_EXTRACTION_ENABLED: process.env.GRAPH_LLM_EXTRACTION_ENABLED,
   GRAPH_ROLLOUT_AUTOPILOT_ENABLED: process.env.GRAPH_ROLLOUT_AUTOPILOT_ENABLED,
+  GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED: process.env.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED,
 }
 
 function restoreGraphFlags(): void {
@@ -33,12 +34,14 @@ describe("graph feature flags", () => {
     delete process.env.GRAPH_RETRIEVAL_ENABLED
     delete process.env.GRAPH_LLM_EXTRACTION_ENABLED
     delete process.env.GRAPH_ROLLOUT_AUTOPILOT_ENABLED
+    delete process.env.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED
 
     const mod = await loadTypesModule()
     expect(mod.GRAPH_MAPPING_ENABLED).toBe(false)
     expect(mod.GRAPH_RETRIEVAL_ENABLED).toBe(true)
     expect(mod.GRAPH_LLM_EXTRACTION_ENABLED).toBe(false)
     expect(mod.GRAPH_ROLLOUT_AUTOPILOT_ENABLED).toBe(false)
+    expect(mod.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED).toBe(true)
   })
 
   it("parses enabled values for graph flags", async () => {
@@ -46,12 +49,14 @@ describe("graph feature flags", () => {
     process.env.GRAPH_RETRIEVAL_ENABLED = "1"
     process.env.GRAPH_LLM_EXTRACTION_ENABLED = "yes"
     process.env.GRAPH_ROLLOUT_AUTOPILOT_ENABLED = "on"
+    process.env.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED = "on"
 
     const mod = await loadTypesModule()
     expect(mod.GRAPH_MAPPING_ENABLED).toBe(true)
     expect(mod.GRAPH_RETRIEVAL_ENABLED).toBe(true)
     expect(mod.GRAPH_LLM_EXTRACTION_ENABLED).toBe(true)
     expect(mod.GRAPH_ROLLOUT_AUTOPILOT_ENABLED).toBe(true)
+    expect(mod.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED).toBe(true)
   })
 
   it("falls back to false for invalid flag values", async () => {
@@ -59,11 +64,13 @@ describe("graph feature flags", () => {
     process.env.GRAPH_RETRIEVAL_ENABLED = "enabled"
     process.env.GRAPH_LLM_EXTRACTION_ENABLED = "nah"
     process.env.GRAPH_ROLLOUT_AUTOPILOT_ENABLED = "enabled"
+    process.env.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED = "enabled"
 
     const mod = await loadTypesModule()
     expect(mod.GRAPH_MAPPING_ENABLED).toBe(false)
     expect(mod.GRAPH_RETRIEVAL_ENABLED).toBe(true)
     expect(mod.GRAPH_LLM_EXTRACTION_ENABLED).toBe(false)
     expect(mod.GRAPH_ROLLOUT_AUTOPILOT_ENABLED).toBe(false)
+    expect(mod.GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED).toBe(true)
   })
 })

--- a/packages/web/src/lib/memory-service/types.ts
+++ b/packages/web/src/lib/memory-service/types.ts
@@ -10,6 +10,7 @@ export {
   GRAPH_RETRIEVAL_ENABLED,
   GRAPH_LLM_EXTRACTION_ENABLED,
   GRAPH_ROLLOUT_AUTOPILOT_ENABLED,
+  GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED,
 } from "@/lib/env"
 
 export const DEFAULT_RESPONSE_SCHEMA_VERSION = "2026-02-10"
@@ -90,6 +91,11 @@ export interface GraphExplainability {
 export interface ContextTrace {
   requestedStrategy: ContextRetrievalStrategy
   strategy: ContextRetrievalStrategy
+  retrievalPolicyDefaultStrategy?: "lexical" | "hybrid"
+  retrievalPolicyAppliedStrategy?: "lexical" | "hybrid"
+  retrievalPolicySelection?: "request" | "policy_default"
+  retrievalPolicyReadyForDefaultOn?: boolean
+  retrievalPolicyBlockerCodes?: string[]
   semanticStrategyRequested?: "lexical" | "semantic" | "hybrid"
   semanticStrategyApplied?: "lexical" | "semantic" | "hybrid"
   lexicalCandidates?: number


### PR DESCRIPTION
## Summary\n- implement a persisted retrieval policy that tracks default strategy and readiness streak\n- auto-promote lexical -> hybrid after sustained rollout readiness and roll back on regression\n- apply policy defaults in context + graph trace endpoints, expose retrieval policy metadata, and document the contract\n\n## Validation\n- pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/types.test.ts src/lib/memory-service/graph/rollout.plan.test.ts src/app/api/sdk/v1/context/get/__tests__/route.test.ts src/app/api/sdk/v1/graph/__tests__/routes.test.ts\n- pnpm --filter @memories.sh/web typecheck\n- pnpm --filter @memories.sh/web lint\n- pnpm --filter @memories.sh/core typecheck\n- pnpm --filter @memories.sh/core test\n\nCloses #217

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-time retrieval behavior for `context/get` and `graph/trace` based on persisted policy and introduces new DB state (`graph_retrieval_policy`), so misconfiguration or policy bugs could shift default strategies unexpectedly across tenants.
> 
> **Overview**
> Adds a **persisted graph retrieval policy** (new `graph_retrieval_policy` table) and `evaluateGraphRetrievalPolicy()` to automatically promote the default retrieval strategy from *lexical* to *hybrid* after sustained `readyForDefaultOn` windows, with automatic rollback on readiness regression (gated by `GRAPH_DEFAULT_STRATEGY_AUTOPILOT_ENABLED`, default `true`).
> 
> Updates `POST /api/sdk/v1/context/get` and `POST /api/sdk/v1/graph/trace` to use the policy default when `strategy` is omitted and to return new retrieval-policy diagnostics in `trace` (default/applied strategy, selection source, readiness flag, blocker codes). `GET|POST|PATCH /api/sdk/v1/graph/rollout` now returns a `retrievalPolicy` snapshot alongside the existing rollout plan, and core/client schemas + docs are updated to reflect the expanded contract and defaults; tests are updated/added to cover policy selection and promotion/rollback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a547983286ff8bdb12946c612ac0f68a7a3cc4f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->