### PR TITLE
Add clean-machine minimal-local onboarding smoke check

### DIFF
--- a/.github/scripts/local-onboarding-smoke.sh
+++ b/.github/scripts/local-onboarding-smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export MEMORIES_DATA_DIR="$(mktemp -d)"
+SMOKE_HOME="$(mktemp -d)"
+SMOKE_WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$MEMORIES_DATA_DIR" "$SMOKE_HOME" "$SMOKE_WORK_DIR"
+}
+trap cleanup EXIT
+
+run_step() {
+  local step_id="$1"
+  local remediation_hint="$2"
+  shift 2
+
+  local log_file="/tmp/memories-local-onboarding-${step_id}.log"
+
+  echo "::group::${step_id}"
+  set +e
+  "$@" >"$log_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "::error title=Local onboarding smoke failed::Step '${step_id}' failed. Remediation: ${remediation_hint}"
+    echo "Command: $*"
+    echo "Log file: $log_file"
+    cat "$log_file" || true
+    echo "::endgroup::"
+    exit "$exit_code"
+  fi
+
+  cat "$log_file"
+  echo "::endgroup::"
+}
+
+run_memories_step() {
+  local step_id="$1"
+  local remediation_hint="$2"
+  shift 2
+  local escaped_args
+  escaped_args="$(printf "%q " "$@")"
+  run_step \
+    "$step_id" \
+    "$remediation_hint" \
+    bash -lc "cd \"$SMOKE_WORK_DIR\" && HOME=\"$SMOKE_HOME\" XDG_CONFIG_HOME=\"$SMOKE_HOME/.config\" MEMORIES_DATA_DIR=\"$MEMORIES_DATA_DIR\" node \"$REPO_ROOT/packages/cli/dist/index.js\" ${escaped_args}"
+}
+
+cd "$REPO_ROOT"
+
+run_step \
+  "build_cli" \
+  "Run 'pnpm --filter @memories.sh/cli build' locally to inspect TypeScript/build failures before rerunning CI." \
+  pnpm --filter @memories.sh/cli build
+
+git -C "$SMOKE_WORK_DIR" init -q
+
+run_memories_step \
+  "setup_minimal_local" \
+  "Ensure setup defaults still support non-interactive local mode: 'memories setup --minimal-local -y'." \
+  setup --minimal-local -y
+
+run_memories_step \
+  "doctor_local_only" \
+  "Run 'memories doctor --local-only' and fix the reported failed check(s)." \
+  doctor --local-only
+
+run_memories_step \
+  "add_rule_smoke" \
+  "Run 'memories add --rule \"smoke\"' and verify local DB initialization/path resolution." \
+  add --rule "smoke"
+
+run_memories_step \
+  "search_smoke" \
+  "Run 'memories search \"smoke\"' and verify write/read path in local mode." \
+  search "smoke"
+
+search_log="/tmp/memories-local-onboarding-search_smoke.log"
+if grep -q "No memories found matching \"smoke\"" "$search_log"; then
+  echo "::error title=Local onboarding smoke failed::Step 'search_smoke' did not return inserted memory. Remediation: verify add/search local round-trip behavior."
+  cat "$search_log" || true
+  exit 1
+fi
+
+echo "Local onboarding smoke check passed."

--- a/.github/workflows/local-onboarding-smoke.yml
+++ b/.github/workflows/local-onboarding-smoke.yml
@@ -1,0 +1,46 @@
+name: Local Onboarding Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/cli/**"
+      - ".github/scripts/local-onboarding-smoke.sh"
+      - ".github/workflows/local-onboarding-smoke.yml"
+      - "pnpm-lock.yaml"
+      - "package.json"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/cli/**"
+      - ".github/scripts/local-onboarding-smoke.sh"
+      - ".github/workflows/local-onboarding-smoke.yml"
+      - "pnpm-lock.yaml"
+      - "package.json"
+  workflow_dispatch:
+
+concurrency:
+  group: local-onboarding-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  local-onboarding-smoke:
+    name: Local Onboarding Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run minimal-local clean machine smoke
+        run: bash .github/scripts/local-onboarding-smoke.sh

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -31,6 +31,7 @@ description: Product and documentation updates.
 - Added `memories setup --minimal-local` preset for local-only onboarding with no cloud/workspace dependency.
 - Added `memories doctor --local-only` to skip cloud checks and provide cleaner local-mode diagnostics.
 - Documented a 10-minute local happy path (`setup -> doctor --local-only -> add -> search`) across CLI and Getting Started docs.
+- Added `Local Onboarding Smoke` GitHub Actions workflow to validate clean-machine minimal-local onboarding on CLI-related PRs.
 
 ## February 16, 2026
 

--- a/packages/web/content/docs/cli/init.mdx
+++ b/packages/web/content/docs/cli/init.mdx
@@ -133,6 +133,8 @@ memories setup --skip-mcp --skip-generate --skip-skill-ingest
 
 ### 10-minute minimal local happy path
 
+[![Local Onboarding Smoke](https://github.com/webrenew/memories/actions/workflows/local-onboarding-smoke.yml/badge.svg?branch=main)](https://github.com/webrenew/memories/actions/workflows/local-onboarding-smoke.yml)
+
 ```bash
 # Local-only setup with no cloud/workspace dependency
 memories setup --minimal-local -y

--- a/packages/web/content/docs/getting-started.mdx
+++ b/packages/web/content/docs/getting-started.mdx
@@ -86,6 +86,8 @@ memories setup --global
 
 ### 10-minute local happy path
 
+[![Local Onboarding Smoke](https://github.com/webrenew/memories/actions/workflows/local-onboarding-smoke.yml/badge.svg?branch=main)](https://github.com/webrenew/memories/actions/workflows/local-onboarding-smoke.yml)
+
 ```bash
 memories setup --minimal-local -y
 memories doctor --local-only


### PR DESCRIPTION
## Summary
- add a dedicated `Local Onboarding Smoke` workflow scoped to CLI-related PR changes
- add `.github/scripts/local-onboarding-smoke.sh` that runs the minimal-local onboarding sequence on a fresh `MEMORIES_DATA_DIR`
- fail fast per step with explicit step IDs + remediation hints and assert the first add/search round-trip
- reference the smoke workflow badge in Getting Started + CLI init docs

## Validation
- `bash .github/scripts/local-onboarding-smoke.sh`

Closes #218

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation-only changes; main risk is added workflow flakiness or environment assumptions affecting PR checks.
> 
> **Overview**
> Adds a new `Local Onboarding Smoke` GitHub Actions workflow that runs on CLI-related pushes/PRs (and manually) to validate clean-machine local onboarding.
> 
> Introduces `.github/scripts/local-onboarding-smoke.sh`, which builds `@memories.sh/cli` and then runs `memories setup --minimal-local -y`, `memories doctor --local-only`, and an `add`/`search` round-trip in isolated temp `HOME`/data dirs, failing fast with step IDs, remediation hints, and captured logs.
> 
> Updates docs to link a workflow badge and notes the new smoke check in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f695fb7cefebd5011591469f5a00336f5b432d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->