### PR TITLE
feat(graph): phase 0 memory-as-node graph mapping

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -8,6 +8,10 @@ description: Product and documentation updates.
 - Added cron reminder support in CLI via `memories reminders` (`add`, `list`, `run`, `enable`, `disable`, `delete`).
 - Added local CLI MCP reminder tools: `add_reminder`, `list_reminders`, `run_due_reminders`, `enable_reminder`, `disable_reminder`, `delete_reminder`.
 - Published reminder docs in CLI reference and MCP references, including local-only reminder tooling guidance.
+- Added first-class `memory` graph nodes (`node_type = memory`, `node_key = memory_id`) with `self` links so each memory is directly addressable in graph traversal.
+- Updated graph mapping cleanup to remove edges attached to deleted memory nodes, not only edges where the memory is listed as evidence.
+- Extended `vacuum_memories` cleanup to prune graph mappings for purged soft-deleted memories.
+- Updated memory graph architecture docs to document memory nodes and self-link behavior.
 
 ## February 20, 2026
 

--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -18,9 +18,11 @@ Examples:
 
 Graph storage is maintained in the workspace Turso database:
 
-- `graph_nodes`: canonical entities (`repo`, `topic`, `category`, `memory_type`, etc.)
+- `graph_nodes`: canonical entities (`memory`, `repo`, `topic`, `category`, `memory_type`, etc.)
 - `graph_edges`: typed, weighted directional relationships between nodes
 - `memory_node_links`: mapping between each memory and its extracted nodes
+
+Every memory is also represented as a first-class `memory` node (`node_key = memory_id`) and linked back with role `self`. This enables direct memory-to-memory edges in later graph phases without schema changes.
 
 Primary code paths:
 
@@ -31,8 +33,8 @@ Primary code paths:
 ## Write Path
 
 1. A memory write/update enters memory mutation handlers.
-2. Graph extraction produces node and edge candidates from memory content and metadata.
-3. `upsert.ts` ensures schema, upserts nodes, writes memory-node links, writes evidence-backed edges, and prunes stale links for edited/forgotten memories.
+2. Graph extraction produces node and edge candidates from memory content and metadata, including the memory's own `memory` node.
+3. `upsert.ts` ensures schema, upserts nodes, writes memory-node links (`self`, `type`, `tag`, etc.), writes evidence-backed edges, and prunes stale links for edited/forgotten memories.
 4. Cleanup removes orphan graph nodes with no links or edges.
 
 Behavior is best-effort: memory writes stay available even if graph indexing fails.

--- a/packages/web/src/app/api/memories/migrate/route.ts
+++ b/packages/web/src/app/api/memories/migrate/route.ts
@@ -218,6 +218,7 @@ export async function POST(request: Request): Promise<Response> {
       try {
         await syncMemoryGraphMapping(destDb, {
           id: row.id,
+          content: row.content,
           type,
           layer: parseLayer(type, row.memory_layer),
           expiresAt: row.expires_at ?? null,

--- a/packages/web/src/lib/memory-insight-actions.ts
+++ b/packages/web/src/lib/memory-insight-actions.ts
@@ -189,6 +189,7 @@ async function updateMemoryTags(
     try {
       await syncMemoryGraphMapping(turso, {
         id: row.id,
+        content: row.content,
         type: row.type,
         layer: effectiveLayer(row),
         expiresAt: row.expires_at,

--- a/packages/web/src/lib/memory-service/graph/extract.test.ts
+++ b/packages/web/src/lib/memory-service/graph/extract.test.ts
@@ -5,6 +5,7 @@ describe("extractDeterministicGraph", () => {
   it("extracts deterministic nodes, links, and edges", () => {
     const graph = extractDeterministicGraph({
       id: "mem-1",
+      content: "I prefer semantic retrieval over pure lexical when quality gates stay green.",
       type: "decision",
       layer: "long_term",
       expiresAt: null,
@@ -18,6 +19,7 @@ describe("extractDeterministicGraph", () => {
     expect(nodeKeys).toEqual(
       [
         "category:architecture",
+        "memory:mem-1",
         "memory_type:decision",
         "repo:github.com/webrenew/memories",
         "topic:auth",
@@ -29,6 +31,7 @@ describe("extractDeterministicGraph", () => {
     const roles = graph.links.map((link) => link.role)
     expect(roles).toContain("scope")
     expect(roles).toContain("subject")
+    expect(roles).toContain("self")
     expect(roles).toContain("type")
     expect(roles).toContain("category")
     expect(roles.filter((role) => role === "tag").length).toBe(2)
@@ -56,5 +59,26 @@ describe("extractDeterministicGraph", () => {
     for (const edge of graph.edges) {
       expect(edge.expiresAt).toBe(expiresAt)
     }
+  })
+
+  it("creates a memory self-node with a truncated label", () => {
+    const graph = extractDeterministicGraph({
+      id: "mem-label",
+      content: "x".repeat(220),
+      type: "note",
+      layer: "long_term",
+      expiresAt: null,
+      projectId: null,
+      userId: null,
+      tags: [],
+      category: null,
+    })
+
+    const memoryNode = graph.nodes.find((node) => node.nodeType === "memory" && node.nodeKey === "mem-label")
+    expect(memoryNode).toBeDefined()
+    expect(memoryNode?.label.length).toBeLessThanOrEqual(120)
+
+    const selfLink = graph.links.find((link) => link.node.nodeType === "memory" && link.node.nodeKey === "mem-label")
+    expect(selfLink?.role).toBe("self")
   })
 })

--- a/packages/web/src/lib/memory-service/graph/extract.ts
+++ b/packages/web/src/lib/memory-service/graph/extract.ts
@@ -2,6 +2,7 @@ import type { MemoryLayer } from "../types"
 
 export interface GraphMemorySnapshot {
   id: string
+  content?: string | null
   type: string
   layer: MemoryLayer
   expiresAt: string | null
@@ -45,6 +46,13 @@ interface DeterministicGraphExtract {
 
 function normalizeText(value: string): string {
   return value.trim()
+}
+
+function truncateLabel(value: string, maxLength = 120): string {
+  const normalized = normalizeText(value)
+  if (!normalized) return ""
+  if (normalized.length <= maxLength) return normalized
+  return `${normalized.slice(0, Math.max(1, maxLength - 3)).trim()}...`
 }
 
 function normalizeTag(tag: string): string {
@@ -119,6 +127,16 @@ export function extractDeterministicGraph(snapshot: GraphMemorySnapshot): Determ
       })
     }
   }
+
+  const memoryNode = addNode("memory", snapshot.id, truncateLabel(snapshot.content ?? "") || snapshot.id, {
+    memoryId: snapshot.id,
+    type: snapshot.type,
+    layer: snapshot.layer,
+    scope: snapshot.projectId ? "project" : "global",
+    projectId: snapshot.projectId,
+    userId: snapshot.userId,
+  })
+  addLink(memoryNode, "self")
 
   const typeNode = addNode("memory_type", snapshot.type, snapshot.type, null)
   addLink(typeNode, "type")

--- a/packages/web/src/lib/memory-service/graph/retrieval.test.ts
+++ b/packages/web/src/lib/memory-service/graph/retrieval.test.ts
@@ -1,0 +1,134 @@
+import { createClient } from "@libsql/client"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { expandMemoryGraph } from "./retrieval"
+import { ensureGraphTables } from "./upsert"
+
+type DbClient = ReturnType<typeof createClient>
+
+const databases: DbClient[] = []
+
+async function setupDb(prefix: string): Promise<DbClient> {
+  const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const db = createClient({ url: `file:${join(dbDir, "graph-retrieval.db")}` })
+  databases.push(db)
+  await ensureGraphTables(db)
+  return db
+}
+
+afterEach(() => {
+  for (const db of databases.splice(0, databases.length)) {
+    db.close()
+  }
+})
+
+describe("expandMemoryGraph", () => {
+  it("traverses memory self-nodes without retrieval changes", async () => {
+    const db = await setupDb("memories-graph-retrieval-memory-nodes")
+    const nowIso = "2026-02-21T23:00:00.000Z"
+
+    await db.batch([
+      {
+        sql: `INSERT INTO graph_nodes (id, node_type, node_key, label, metadata, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          "graph-node:memory:mem-a",
+          "memory",
+          "mem-a",
+          "seed memory",
+          null,
+          nowIso,
+          nowIso,
+          "graph-node:memory:mem-b",
+          "memory",
+          "mem-b",
+          "linked memory",
+          null,
+          nowIso,
+          nowIso,
+        ],
+      },
+      {
+        sql: `INSERT INTO memory_node_links (memory_id, node_id, role, created_at)
+              VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
+        args: [
+          "mem-a",
+          "graph-node:memory:mem-a",
+          "self",
+          nowIso,
+          "mem-b",
+          "graph-node:memory:mem-b",
+          "self",
+          nowIso,
+        ],
+      },
+      {
+        sql: `INSERT INTO graph_edges (
+                id, from_node_id, to_node_id, edge_type, weight, confidence, evidence_memory_id, expires_at, created_at, updated_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          "edge:mem-a:mem-b",
+          "graph-node:memory:mem-a",
+          "graph-node:memory:mem-b",
+          "similar_to",
+          1,
+          1,
+          "mem-a",
+          null,
+          nowIso,
+          nowIso,
+        ],
+      },
+    ])
+
+    const expanded = await expandMemoryGraph({
+      turso: db,
+      seedMemoryIds: ["mem-a"],
+      nowIso,
+      depth: 1,
+      limit: 10,
+    })
+
+    expect(expanded.memoryIds).toEqual(["mem-b"])
+    expect(expanded.reasons.get("mem-b")).toEqual(
+      expect.objectContaining({
+        whyIncluded: "graph_expansion",
+        edgeType: "similar_to",
+        hopCount: 1,
+        seedMemoryId: "mem-a",
+        linkedViaNode: "memory:mem-b",
+      })
+    )
+  })
+
+  it("does not return the seed memory when only self-links exist", async () => {
+    const db = await setupDb("memories-graph-retrieval-seed-self-only")
+    const nowIso = "2026-02-21T23:10:00.000Z"
+
+    await db.batch([
+      {
+        sql: `INSERT INTO graph_nodes (id, node_type, node_key, label, metadata, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        args: ["graph-node:memory:mem-seed", "memory", "mem-seed", "seed only", null, nowIso, nowIso],
+      },
+      {
+        sql: `INSERT INTO memory_node_links (memory_id, node_id, role, created_at)
+              VALUES (?, ?, ?, ?)`,
+        args: ["mem-seed", "graph-node:memory:mem-seed", "self", nowIso],
+      },
+    ])
+
+    const expanded = await expandMemoryGraph({
+      turso: db,
+      seedMemoryIds: ["mem-seed"],
+      nowIso,
+      depth: 2,
+      limit: 10,
+    })
+
+    expect(expanded.memoryIds).toEqual([])
+    expect(expanded.totalCandidates).toBe(0)
+  })
+})

--- a/packages/web/src/lib/memory-service/graph/status.ts
+++ b/packages/web/src/lib/memory-service/graph/status.ts
@@ -30,6 +30,7 @@ interface GraphTopNodeRow {
 
 interface GraphSyncMemoryRow {
   id: string
+  content?: string | null
   type: string
   memory_layer: string | null
   expires_at: string | null
@@ -255,6 +256,7 @@ async function opportunisticGraphSync(
     try {
       await syncMemoryGraphMapping(turso, {
         id: row.id,
+        content: row.content,
         type: row.type,
         layer: parseLayer(row.type, row.memory_layer),
         expiresAt: row.expires_at,


### PR DESCRIPTION
## Summary
- add first-class `memory` nodes + `self` links in deterministic graph extraction
- thread memory content through graph sync callsites so memory nodes get stable labels
- harden graph cleanup to remove edges attached to deleted memory nodes
- extend `vacuum_memories` to clean graph mappings for purged soft-deleted memories
- add retrieval + mapping tests for memory node traversal and delete/vacuum cleanup
- document Phase 0 architecture/changelog updates

## Validation
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/graph/extract.test.ts src/lib/memory-service/graph/retrieval.test.ts src/lib/memory-service/graph/upsert.test.ts src/lib/memory-service/mutations.graph.test.ts src/lib/memory-service/graph/status.test.ts`
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/queries.graph.test.ts`
- `pnpm --filter @memories.sh/web build`
- `pnpm --filter @memories.sh/web typecheck`

Closes #226
Part of #225
Docs: #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes graph indexing and cleanup behavior around deletes/vacuum, which can impact graph consistency and potentially remove additional edges if the new memory-node resolution is wrong. Scope is contained to graph mapping paths and is covered by new integration/unit tests.
> 
> **Overview**
> Introduces first-class `memory` nodes (`node_type='memory'`, `node_key=memory_id`) into deterministic graph extraction, including a `self` link and a truncated content-based label, so memories are directly addressable for traversal.
> 
> Threads `content` through all graph sync callsites (add/edit/migrate/status/insights) to populate those labels, and hardens graph cleanup: `removeMemoryGraphMapping`/bulk removal now also deletes edges attached to a deleted memory node (not just edges where it was `evidence_memory_id`), and `vacuum_memories` precomputes purged IDs to prune graph mappings after hard deletes. Adds focused tests for memory-node traversal and for forget/vacuum cleanup, and updates changelog + graph architecture docs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 085da076ea0169f9925383868e0dfd00df85bb52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->