### PR TITLE
feat(graph): phase 2 contradicts/supersedes edge extraction

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -13,6 +13,8 @@ description: Product and documentation updates.
 - Extended `vacuum_memories` cleanup to prune graph mappings for purged soft-deleted memories.
 - Added embedding-driven `similar_to` graph edges between memory nodes (bidirectional) using cosine thresholding and per-memory caps.
 - Added similarity edge controls: `SIMILARITY_EDGE_THRESHOLD`, `SIMILARITY_EDGE_MAX_K`, `SIMILARITY_EDGE_MAX_PER_MEMORY`.
+- Added optional LLM relationship extraction for ambiguous similarity matches to create `contradicts` and `supersedes` memory edges.
+- Added graph LLM controls: `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN`, `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX`, `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD`, `GRAPH_LLM_RELATIONSHIP_MODEL_ID`.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 
 ## February 20, 2026

--- a/packages/web/content/docs/mcp-server/tools-reference.mdx
+++ b/packages/web/content/docs/mcp-server/tools-reference.mdx
@@ -38,7 +38,7 @@ The primary tool for AI agents. Returns all active rules (with path and category
 }
 ```
 
-Returns all rules first (including path scope and category when set), followed by relevant search results. Uses FTS5 with BM25 ranking for the search query, falling back to LIKE matching for databases without FTS support. When hybrid graph retrieval is enabled, semantically similar memories may be added via graph `similar_to` edges even if tags do not overlap.
+Returns all rules first (including path scope and category when set), followed by relevant search results. Uses FTS5 with BM25 ranking for the search query, falling back to LIKE matching for databases without FTS support. When hybrid graph retrieval is enabled, semantically similar memories may be added via graph `similar_to` edges, and conflict/refinement links may be traversed via `contradicts` / `supersedes` edges when LLM extraction is enabled.
 
 ## add_memory
 

--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -35,7 +35,7 @@ Primary code paths:
 1. A memory write/update enters memory mutation handlers.
 2. Graph extraction produces node and edge candidates from memory content and metadata, including the memory's own `memory` node.
 3. `upsert.ts` ensures schema, upserts nodes, writes memory-node links (`self`, `type`, `tag`, etc.), writes evidence-backed edges, and prunes stale links for edited/forgotten memories.
-4. When embeddings are available, similarity sync writes bidirectional `similar_to` edges between memory nodes for high-cosine neighbors.
+4. When embeddings are available, similarity sync writes bidirectional `similar_to` edges between memory nodes for high-cosine neighbors. If LLM extraction is enabled, ambiguous-neighbor pairs are additionally classified into `contradicts` or `supersedes`.
 5. Cleanup removes orphan graph nodes with no links or edges.
 
 Behavior is best-effort: memory writes stay available even if graph indexing fails.
@@ -83,6 +83,20 @@ Similarity edge extraction is controlled by environment variables:
 - `SIMILARITY_EDGE_THRESHOLD` (default `0.85`): cosine score cutoff for `similar_to` edge creation.
 - `SIMILARITY_EDGE_MAX_K` (default `20`): max candidate embeddings scanned per write.
 - `SIMILARITY_EDGE_MAX_PER_MEMORY` (default `5`): max neighbors retained per memory after ranking.
+
+## LLM Relationship Extraction Configuration
+
+When `GRAPH_LLM_EXTRACTION_ENABLED=true`, ambiguous similarity matches can be classified into additional relationship edges:
+
+- `contradicts`: bidirectional conflict relationship.
+- `supersedes`: directional "newer memory refines older memory" relationship.
+
+Environment controls:
+
+- `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN` (default `0.70`)
+- `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX` (default `0.90`)
+- `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD` (default `0.70`)
+- `GRAPH_LLM_RELATIONSHIP_MODEL_ID` (default `anthropic/claude-3-5-haiku-latest`)
 
 ## Scope And Workspace Routing
 

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -297,6 +297,25 @@ export function getSimilarityEdgeMaxPerMemory(): number {
   return parsePositiveInt(process.env.SIMILARITY_EDGE_MAX_PER_MEMORY, 5)
 }
 
+export function getGraphLlmAmbiguousSimilarityMin(): number {
+  const value = parseNonNegativeFloat(process.env.GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN, 0.7)
+  return Math.max(0, Math.min(1, value))
+}
+
+export function getGraphLlmAmbiguousSimilarityMax(): number {
+  const value = parseNonNegativeFloat(process.env.GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX, 0.9)
+  return Math.max(0, Math.min(1, value))
+}
+
+export function getGraphLlmRelationshipConfidenceThreshold(): number {
+  const value = parseNonNegativeFloat(process.env.GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD, 0.7)
+  return Math.max(0, Math.min(1, value))
+}
+
+export function getGraphLlmRelationshipModelId(): string {
+  return envValue("GRAPH_LLM_RELATIONSHIP_MODEL_ID") ?? "anthropic/claude-3-5-haiku-latest"
+}
+
 // ── Other ────────────────────────────────────────────────────────────
 
 export function getAppUrl(): string {

--- a/packages/web/src/lib/memory-service/graph/llm-extract.test.ts
+++ b/packages/web/src/lib/memory-service/graph/llm-extract.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { classifyMemoryRelationship } from "./llm-extract"
+
+const originalAiGatewayApiKey = process.env.AI_GATEWAY_API_KEY
+const originalAiGatewayBaseUrl = process.env.AI_GATEWAY_BASE_URL
+const originalModelId = process.env.GRAPH_LLM_RELATIONSHIP_MODEL_ID
+
+beforeEach(() => {
+  process.env.AI_GATEWAY_API_KEY = "test_gateway_key"
+  process.env.AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh"
+  process.env.GRAPH_LLM_RELATIONSHIP_MODEL_ID = "anthropic/claude-3-5-haiku-latest"
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  if (originalAiGatewayApiKey === undefined) {
+    delete process.env.AI_GATEWAY_API_KEY
+  } else {
+    process.env.AI_GATEWAY_API_KEY = originalAiGatewayApiKey
+  }
+  if (originalAiGatewayBaseUrl === undefined) {
+    delete process.env.AI_GATEWAY_BASE_URL
+  } else {
+    process.env.AI_GATEWAY_BASE_URL = originalAiGatewayBaseUrl
+  }
+  if (originalModelId === undefined) {
+    delete process.env.GRAPH_LLM_RELATIONSHIP_MODEL_ID
+  } else {
+    process.env.GRAPH_LLM_RELATIONSHIP_MODEL_ID = originalModelId
+  }
+})
+
+describe("classifyMemoryRelationship", () => {
+  it("parses JSON content responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    relationship: "contradicts",
+                    confidence: 0.86,
+                    explanation: "Both memories discuss the same preference with opposite polarity.",
+                  }),
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      )
+    )
+
+    const result = await classifyMemoryRelationship({
+      memoryA: { id: "mem-a", content: "I love spicy food.", createdAt: "2026-02-20T00:00:00.000Z" },
+      memoryB: { id: "mem-b", content: "I dislike spicy food.", createdAt: "2026-02-21T00:00:00.000Z" },
+    })
+
+    expect(result).toEqual({
+      relationship: "contradicts",
+      confidence: 0.86,
+      explanation: "Both memories discuss the same preference with opposite polarity.",
+    })
+  })
+
+  it("parses array-based content payloads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: [
+                    {
+                      type: "output_text",
+                      text: JSON.stringify({
+                        relationship: "refines",
+                        confidence: 0.91,
+                        explanation: "Memory B narrows scope with more recent detail.",
+                      }),
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      )
+    )
+
+    const result = await classifyMemoryRelationship({
+      memoryA: { id: "mem-a", content: "I like coffee.", createdAt: "2026-02-19T00:00:00.000Z" },
+      memoryB: { id: "mem-b", content: "I only drink coffee in the morning.", createdAt: "2026-02-21T00:00:00.000Z" },
+    })
+
+    expect(result.relationship).toBe("refines")
+    expect(result.confidence).toBe(0.91)
+  })
+
+  it("throws when response payload is invalid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    relationship: "something_else",
+                    confidence: 0.5,
+                    explanation: "Not a supported relationship.",
+                  }),
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      )
+    )
+
+    await expect(
+      classifyMemoryRelationship({
+        memoryA: { id: "mem-a", content: "A", createdAt: null },
+        memoryB: { id: "mem-b", content: "B", createdAt: null },
+      })
+    ).rejects.toThrow("Invalid relationship classification")
+  })
+})

--- a/packages/web/src/lib/memory-service/graph/llm-extract.ts
+++ b/packages/web/src/lib/memory-service/graph/llm-extract.ts
@@ -1,0 +1,186 @@
+import { getAiGatewayApiKey, getAiGatewayBaseUrl, getGraphLlmRelationshipModelId } from "@/lib/env"
+
+export type MemoryRelationshipClassification = "agrees" | "contradicts" | "refines" | "unrelated"
+
+export interface MemoryRelationshipClassificationResult {
+  relationship: MemoryRelationshipClassification
+  confidence: number
+  explanation: string
+}
+
+export interface MemoryRelationshipInput {
+  id: string
+  content: string
+  createdAt: string | null
+}
+
+export interface ClassifyMemoryRelationshipInput {
+  memoryA: MemoryRelationshipInput
+  memoryB: MemoryRelationshipInput
+  modelId?: string
+}
+
+interface GatewayChatResponse {
+  choices?: Array<{
+    message?: {
+      content?: unknown
+    } | null
+  }>
+}
+
+const VALID_RELATIONSHIPS = new Set<MemoryRelationshipClassification>([
+  "agrees",
+  "contradicts",
+  "refines",
+  "unrelated",
+])
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(1, value))
+}
+
+function truncateText(value: string, max = 600): string {
+  if (value.length <= max) return value
+  if (max <= 3) return value.slice(0, max)
+  return `${value.slice(0, max - 3)}...`
+}
+
+function normalizeContent(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value.trim()
+  }
+
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const textParts: string[] = []
+  for (const part of value) {
+    if (!part || typeof part !== "object") continue
+    const text = (part as { text?: unknown }).text
+    if (typeof text === "string" && text.trim().length > 0) {
+      textParts.push(text.trim())
+    }
+  }
+
+  if (textParts.length === 0) return null
+  return textParts.join("\n")
+}
+
+function parseClassificationPayload(payloadText: string): MemoryRelationshipClassificationResult {
+  const parsed = JSON.parse(payloadText) as {
+    relationship?: unknown
+    confidence?: unknown
+    explanation?: unknown
+  }
+
+  const relationship = typeof parsed.relationship === "string" ? parsed.relationship.trim() : ""
+  if (!VALID_RELATIONSHIPS.has(relationship as MemoryRelationshipClassification)) {
+    throw new Error(`Invalid relationship classification: ${relationship || "<empty>"}`)
+  }
+
+  return {
+    relationship: relationship as MemoryRelationshipClassification,
+    confidence: clamp01(Number(parsed.confidence)),
+    explanation: typeof parsed.explanation === "string" ? parsed.explanation.trim() : "",
+  }
+}
+
+function buildPrompt(input: ClassifyMemoryRelationshipInput): string {
+  const dateA = input.memoryA.createdAt ?? "unknown"
+  const dateB = input.memoryB.createdAt ?? "unknown"
+
+  return [
+    "Given two memories from the same user, classify their relationship.",
+    "",
+    `Memory A (id: ${input.memoryA.id}, created ${dateA}): "${input.memoryA.content}"`,
+    `Memory B (id: ${input.memoryB.id}, created ${dateB}): "${input.memoryB.content}"`,
+    "",
+    "Classify as one of:",
+    "- agrees: Both express compatible information",
+    "- contradicts: They conflict or express opposing views on the same topic",
+    "- refines: Memory B updates/narrows/corrects Memory A",
+    "- unrelated: Despite surface similarity, they're about different things",
+    "",
+    "Return strict JSON: {\"relationship\":\"...\",\"confidence\":0.0-1.0,\"explanation\":\"...\"}",
+  ].join("\n")
+}
+
+export async function classifyMemoryRelationship(
+  input: ClassifyMemoryRelationshipInput
+): Promise<MemoryRelationshipClassificationResult> {
+  const apiKey = getAiGatewayApiKey()
+  const baseUrl = getAiGatewayBaseUrl().replace(/\/$/, "")
+  const modelId = input.modelId?.trim() || getGraphLlmRelationshipModelId()
+
+  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: modelId,
+      temperature: 0,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You classify pairwise memory relationships. Return only valid JSON matching the provided schema.",
+        },
+        {
+          role: "user",
+          content: buildPrompt(input),
+        },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "memory_relationship_classification",
+          strict: true,
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              relationship: {
+                type: "string",
+                enum: ["agrees", "contradicts", "refines", "unrelated"],
+              },
+              confidence: {
+                type: "number",
+                minimum: 0,
+                maximum: 1,
+              },
+              explanation: {
+                type: "string",
+              },
+            },
+            required: ["relationship", "confidence", "explanation"],
+          },
+        },
+      },
+    }),
+    cache: "no-store",
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(
+      `Memory relationship classification failed with status ${response.status}${body ? `: ${truncateText(body, 300)}` : ""}`
+    )
+  }
+
+  const payload = (await response.json().catch(() => null)) as GatewayChatResponse | null
+  if (!payload || !Array.isArray(payload.choices) || payload.choices.length === 0) {
+    throw new Error("Memory relationship classification response did not include choices")
+  }
+
+  const rawContent = payload.choices[0]?.message?.content
+  const content = normalizeContent(rawContent)
+  if (!content) {
+    throw new Error("Memory relationship classification response did not include parsable content")
+  }
+
+  return parseClassificationPayload(content)
+}

--- a/packages/web/src/lib/memory-service/graph/similarity.ts
+++ b/packages/web/src/lib/memory-service/graph/similarity.ts
@@ -1,4 +1,7 @@
 import {
+  getGraphLlmAmbiguousSimilarityMax,
+  getGraphLlmAmbiguousSimilarityMin,
+  getGraphLlmRelationshipConfidenceThreshold,
   getSimilarityEdgeMaxK,
   getSimilarityEdgeMaxPerMemory,
   getSimilarityEdgeThreshold,
@@ -6,12 +9,22 @@ import {
 import { buildNotExpiredFilter, buildUserScopeFilter } from "../scope"
 import type { MemoryLayer, TursoClient } from "../types"
 import type { GraphNodeRef } from "./extract"
-import { replaceMemorySimilarityEdges, type GraphEdgeWrite } from "./upsert"
+import { replaceMemoryRelationshipEdges, replaceMemorySimilarityEdges, type GraphEdgeWrite } from "./upsert"
 
 interface SimilarityCandidateRow {
   memory_id: string
   embedding: unknown
   updated_at: string
+  created_at: string | null
+  content: string | null
+}
+
+interface SimilarityMatch {
+  memoryId: string
+  score: number
+  updatedAt: string
+  createdAt: string | null
+  content: string | null
 }
 
 export interface ComputeSimilarityEdgesInput {
@@ -27,6 +40,40 @@ export interface ComputeSimilarityEdgesInput {
   threshold?: number
   maxCandidates?: number
   maxEdges?: number
+  memoryContent?: string | null
+  memoryCreatedAt?: string | null
+}
+
+export type MemoryRelationship = "agrees" | "contradicts" | "refines" | "unrelated"
+
+export interface RelationshipClassifierInput {
+  memoryA: {
+    id: string
+    content: string
+    createdAt: string | null
+  }
+  memoryB: {
+    id: string
+    content: string
+    createdAt: string | null
+  }
+}
+
+export interface RelationshipClassifierResult {
+  relationship: MemoryRelationship
+  confidence: number
+  explanation: string
+}
+
+export type RelationshipClassifier = (
+  input: RelationshipClassifierInput
+) => Promise<RelationshipClassifierResult>
+
+export interface ComputeRelationshipEdgesInput extends ComputeSimilarityEdgesInput {
+  ambiguousMinScore?: number
+  ambiguousMaxScore?: number
+  llmConfidenceThreshold?: number
+  classifier?: RelationshipClassifier | null
 }
 
 function decodeEmbeddingBlob(value: unknown): Float32Array | null {
@@ -85,13 +132,32 @@ function isMissingEmbeddingsTableError(error: unknown): boolean {
   return message.includes("no such table") && message.includes("memory_embeddings")
 }
 
-export async function computeSimilarityEdges(input: ComputeSimilarityEdgesInput): Promise<GraphEdgeWrite[]> {
-  if (input.embedding.length === 0) return []
+function normalizeScore(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(1, value))
+}
 
+function normalizeRange(minValue: number, maxValue: number): [number, number] {
+  const minScore = normalizeScore(minValue)
+  const maxScore = normalizeScore(maxValue)
+  return minScore <= maxScore ? [minScore, maxScore] : [maxScore, minScore]
+}
+
+function dedupeEdges(edges: GraphEdgeWrite[]): GraphEdgeWrite[] {
+  const seen = new Set<string>()
+  const deduped: GraphEdgeWrite[] = []
+  for (const edge of edges) {
+    const key = `${edge.edgeType}:${edge.from.nodeType}:${edge.from.nodeKey}:${edge.to.nodeType}:${edge.to.nodeKey}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(edge)
+  }
+  return deduped
+}
+
+async function selectSimilarityCandidates(input: ComputeSimilarityEdgesInput): Promise<SimilarityMatch[]> {
   const nowIso = input.nowIso ?? new Date().toISOString()
-  const threshold = Math.max(0, Math.min(1, input.threshold ?? getSimilarityEdgeThreshold()))
   const maxCandidates = Math.max(1, input.maxCandidates ?? getSimilarityEdgeMaxK())
-  const maxEdges = Math.max(1, input.maxEdges ?? getSimilarityEdgeMaxPerMemory())
   const userFilter = buildUserScopeFilter(input.userId, "m.")
   const activeFilter = buildNotExpiredFilter(nowIso, "m.")
   const projectFilter = input.projectId
@@ -109,7 +175,11 @@ export async function computeSimilarityEdges(input: ComputeSimilarityEdgesInput)
   let resultRows: SimilarityCandidateRow[] = []
   try {
     const result = await input.turso.execute({
-      sql: `SELECT m.id AS memory_id, e.embedding, m.updated_at
+      sql: `SELECT m.id AS memory_id,
+                   e.embedding,
+                   m.updated_at,
+                   m.created_at,
+                   m.content
             FROM memory_embeddings e
             JOIN memories m ON m.id = e.memory_id
             WHERE e.model = ?
@@ -130,50 +200,230 @@ export async function computeSimilarityEdges(input: ComputeSimilarityEdgesInput)
     throw error
   }
 
-  const ranked = resultRows
+  return resultRows
     .map((row) => {
       const decoded = decodeEmbeddingBlob(row.embedding)
       if (!decoded) return null
       const score = cosineSimilarity(input.embedding, decoded)
-      if (!Number.isFinite(score) || score < threshold) return null
+      if (!Number.isFinite(score)) return null
       return {
         memoryId: row.memory_id,
         score,
         updatedAt: row.updated_at,
+        createdAt: row.created_at ?? null,
+        content: row.content ?? null,
       }
     })
-    .filter((entry): entry is { memoryId: string; score: number; updatedAt: string } => Boolean(entry))
+    .filter((entry): entry is SimilarityMatch => Boolean(entry))
     .sort((a, b) => b.score - a.score || String(b.updatedAt).localeCompare(String(a.updatedAt)))
-    .slice(0, maxEdges)
+}
 
-  const expiresAt = input.layer === "working" ? input.expiresAt : null
+function buildBidirectionalMemoryEdges(params: {
+  fromMemoryId: string
+  toMemoryId: string
+  edgeType: string
+  weight: number
+  confidence: number
+  evidenceMemoryId: string
+  expiresAt: string | null
+}): GraphEdgeWrite[] {
+  return [
+    {
+      from: memoryNodeRef(params.fromMemoryId),
+      to: memoryNodeRef(params.toMemoryId),
+      edgeType: params.edgeType,
+      weight: params.weight,
+      confidence: params.confidence,
+      evidenceMemoryId: params.evidenceMemoryId,
+      expiresAt: params.expiresAt,
+    },
+    {
+      from: memoryNodeRef(params.toMemoryId),
+      to: memoryNodeRef(params.fromMemoryId),
+      edgeType: params.edgeType,
+      weight: params.weight,
+      confidence: params.confidence,
+      evidenceMemoryId: params.evidenceMemoryId,
+      expiresAt: params.expiresAt,
+    },
+  ]
+}
+
+function resolveSupersedesDirection(params: {
+  sourceMemoryId: string
+  sourceCreatedAt: string | null
+  candidateMemoryId: string
+  candidateCreatedAt: string | null
+}): { fromMemoryId: string; toMemoryId: string } {
+  const sourceTs = params.sourceCreatedAt ? Date.parse(params.sourceCreatedAt) : Number.NaN
+  const candidateTs = params.candidateCreatedAt ? Date.parse(params.candidateCreatedAt) : Number.NaN
+  if (Number.isFinite(sourceTs) && Number.isFinite(candidateTs)) {
+    if (sourceTs > candidateTs) {
+      return { fromMemoryId: params.sourceMemoryId, toMemoryId: params.candidateMemoryId }
+    }
+    if (candidateTs > sourceTs) {
+      return { fromMemoryId: params.candidateMemoryId, toMemoryId: params.sourceMemoryId }
+    }
+  }
+  return { fromMemoryId: params.sourceMemoryId, toMemoryId: params.candidateMemoryId }
+}
+
+function buildSimilarEdges(params: {
+  matches: SimilarityMatch[]
+  threshold: number
+  maxEdges: number
+  memoryId: string
+  evidenceMemoryId: string
+  expiresAt: string | null
+}): GraphEdgeWrite[] {
   const edges: GraphEdgeWrite[] = []
+  for (const match of params.matches) {
+    if (match.score < params.threshold) continue
+    if (match.memoryId === params.memoryId) continue
+    edges.push(
+      ...buildBidirectionalMemoryEdges({
+        fromMemoryId: params.memoryId,
+        toMemoryId: match.memoryId,
+        edgeType: "similar_to",
+        weight: match.score,
+        confidence: 1,
+        evidenceMemoryId: params.evidenceMemoryId,
+        expiresAt: params.expiresAt,
+      })
+    )
+    if (edges.length >= params.maxEdges * 2) {
+      break
+    }
+  }
+  return edges
+}
 
-  for (const match of ranked) {
-    edges.push({
-      from: memoryNodeRef(input.memoryId),
-      to: memoryNodeRef(match.memoryId),
-      edgeType: "similar_to",
-      weight: match.score,
-      confidence: 1,
-      evidenceMemoryId: input.memoryId,
-      expiresAt,
-    })
-    edges.push({
-      from: memoryNodeRef(match.memoryId),
-      to: memoryNodeRef(input.memoryId),
-      edgeType: "similar_to",
-      weight: match.score,
-      confidence: 1,
-      evidenceMemoryId: input.memoryId,
-      expiresAt,
-    })
+async function buildLlmRelationshipEdges(
+  input: ComputeRelationshipEdgesInput,
+  matches: SimilarityMatch[],
+  expiresAt: string | null
+): Promise<GraphEdgeWrite[]> {
+  if (!input.classifier) return []
+
+  const sourceContent = input.memoryContent?.trim()
+  if (!sourceContent) return []
+
+  const [ambiguousMin, ambiguousMax] = normalizeRange(
+    input.ambiguousMinScore ?? getGraphLlmAmbiguousSimilarityMin(),
+    input.ambiguousMaxScore ?? getGraphLlmAmbiguousSimilarityMax()
+  )
+  const confidenceThreshold = normalizeScore(
+    input.llmConfidenceThreshold ?? getGraphLlmRelationshipConfidenceThreshold()
+  )
+
+  const edges: GraphEdgeWrite[] = []
+  for (const match of matches) {
+    if (match.memoryId === input.memoryId) continue
+    if (match.score < ambiguousMin || match.score > ambiguousMax) continue
+    const candidateContent = match.content?.trim()
+    if (!candidateContent) continue
+
+    try {
+      const classification = await input.classifier({
+        memoryA: {
+          id: match.memoryId,
+          content: candidateContent,
+          createdAt: match.createdAt,
+        },
+        memoryB: {
+          id: input.memoryId,
+          content: sourceContent,
+          createdAt: input.memoryCreatedAt ?? null,
+        },
+      })
+      const confidence = normalizeScore(classification.confidence)
+      if (confidence < confidenceThreshold) continue
+
+      if (classification.relationship === "contradicts") {
+        edges.push(
+          ...buildBidirectionalMemoryEdges({
+            fromMemoryId: input.memoryId,
+            toMemoryId: match.memoryId,
+            edgeType: "contradicts",
+            weight: 1,
+            confidence,
+            evidenceMemoryId: input.memoryId,
+            expiresAt,
+          })
+        )
+      } else if (classification.relationship === "refines") {
+        const direction = resolveSupersedesDirection({
+          sourceMemoryId: input.memoryId,
+          sourceCreatedAt: input.memoryCreatedAt ?? null,
+          candidateMemoryId: match.memoryId,
+          candidateCreatedAt: match.createdAt,
+        })
+        edges.push({
+          from: memoryNodeRef(direction.fromMemoryId),
+          to: memoryNodeRef(direction.toMemoryId),
+          edgeType: "supersedes",
+          weight: 1,
+          confidence,
+          evidenceMemoryId: input.memoryId,
+          expiresAt,
+        })
+      }
+    } catch (error) {
+      console.error("Memory relationship classification failed:", error)
+    }
   }
 
   return edges
 }
 
+export async function computeSimilarityEdges(input: ComputeSimilarityEdgesInput): Promise<GraphEdgeWrite[]> {
+  if (input.embedding.length === 0) return []
+
+  const threshold = normalizeScore(input.threshold ?? getSimilarityEdgeThreshold())
+  const maxEdges = Math.max(1, input.maxEdges ?? getSimilarityEdgeMaxPerMemory())
+  const expiresAt = input.layer === "working" ? input.expiresAt : null
+  const matches = await selectSimilarityCandidates(input)
+
+  return buildSimilarEdges({
+    matches,
+    threshold,
+    maxEdges,
+    memoryId: input.memoryId,
+    evidenceMemoryId: input.memoryId,
+    expiresAt,
+  })
+}
+
+export async function computeRelationshipEdges(input: ComputeRelationshipEdgesInput): Promise<GraphEdgeWrite[]> {
+  if (input.embedding.length === 0) return []
+
+  const threshold = normalizeScore(input.threshold ?? getSimilarityEdgeThreshold())
+  const maxEdges = Math.max(1, input.maxEdges ?? getSimilarityEdgeMaxPerMemory())
+  const expiresAt = input.layer === "working" ? input.expiresAt : null
+  const matches = await selectSimilarityCandidates(input)
+
+  const similarEdges = buildSimilarEdges({
+    matches,
+    threshold,
+    maxEdges,
+    memoryId: input.memoryId,
+    evidenceMemoryId: input.memoryId,
+    expiresAt,
+  })
+  const llmEdges = await buildLlmRelationshipEdges(input, matches, expiresAt)
+
+  return dedupeEdges([...similarEdges, ...llmEdges])
+}
+
 export async function syncSimilarityEdgesForMemory(input: ComputeSimilarityEdgesInput): Promise<void> {
   const edges = await computeSimilarityEdges(input)
   await replaceMemorySimilarityEdges(input.turso, input.memoryId, edges, { nowIso: input.nowIso })
+}
+
+export async function syncRelationshipEdgesForMemory(input: ComputeRelationshipEdgesInput): Promise<void> {
+  const edges = await computeRelationshipEdges(input)
+  await replaceMemoryRelationshipEdges(input.turso, input.memoryId, edges, {
+    nowIso: input.nowIso,
+    edgeTypes: ["similar_to", "contradicts", "supersedes"],
+  })
 }

--- a/packages/web/src/lib/sdk-embeddings/jobs.test.ts
+++ b/packages/web/src/lib/sdk-embeddings/jobs.test.ts
@@ -16,6 +16,7 @@ const originalAiGatewayBaseUrl = process.env.AI_GATEWAY_BASE_URL
 const originalRetryBaseMs = process.env.SDK_EMBEDDING_JOB_RETRY_BASE_MS
 const originalRetryMaxMs = process.env.SDK_EMBEDDING_JOB_RETRY_MAX_MS
 const originalGraphMappingEnabled = process.env.GRAPH_MAPPING_ENABLED
+const originalGraphLlmExtractionEnabled = process.env.GRAPH_LLM_EXTRACTION_ENABLED
 
 async function setupDb(prefix: string): Promise<DbClient> {
   const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
@@ -114,6 +115,11 @@ afterEach(() => {
     delete process.env.GRAPH_MAPPING_ENABLED
   } else {
     process.env.GRAPH_MAPPING_ENABLED = originalGraphMappingEnabled
+  }
+  if (originalGraphLlmExtractionEnabled === undefined) {
+    delete process.env.GRAPH_LLM_EXTRACTION_ENABLED
+  } else {
+    process.env.GRAPH_LLM_EXTRACTION_ENABLED = originalGraphLlmExtractionEnabled
   }
 })
 
@@ -361,5 +367,134 @@ describe("sdk embedding jobs", () => {
 
     const pairs = edgeResult.rows.map((row) => `${row.from_key}->${row.to_key}`)
     expect(pairs).toEqual(["mem_neighbor->mem_seed", "mem_seed->mem_neighbor"])
+  })
+
+  it("creates contradicts edges in ambiguous zone when llm extraction is enabled", async () => {
+    process.env.GRAPH_MAPPING_ENABLED = "true"
+    process.env.GRAPH_LLM_EXTRACTION_ENABLED = "true"
+
+    const db = await setupDb("memories-embedding-jobs-llm-relationships")
+    const nowIso = "2026-02-20T03:00:00.000Z"
+    const modelId = "openai/text-embedding-3-small"
+
+    await insertMemory(db, {
+      id: "mem_seed",
+      content: "I like coffee",
+      nowIso,
+    })
+    await insertMemory(db, {
+      id: "mem_neighbor",
+      content: "I dislike coffee",
+      nowIso,
+    })
+
+    await syncMemoryGraphMapping(db, {
+      id: "mem_seed",
+      content: "I like coffee",
+      type: "note",
+      layer: "long_term",
+      expiresAt: null,
+      projectId: null,
+      userId: null,
+      tags: [],
+      category: null,
+    })
+    await syncMemoryGraphMapping(db, {
+      id: "mem_neighbor",
+      content: "I dislike coffee",
+      type: "note",
+      layer: "long_term",
+      expiresAt: null,
+      projectId: null,
+      userId: null,
+      tags: [],
+      category: null,
+    })
+
+    await db.execute({
+      sql: `INSERT INTO memory_embeddings (
+              memory_id, embedding, model, model_version, dimension, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        "mem_neighbor",
+        encodeEmbedding([0.8, 0.6]),
+        modelId,
+        modelId,
+        2,
+        nowIso,
+        nowIso,
+      ],
+    })
+
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input)
+      if (url.includes("/v1/embeddings")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ embedding: [1, 0] }],
+            model: modelId,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      }
+
+      if (url.includes("/v1/chat/completions")) {
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    relationship: "contradicts",
+                    confidence: 0.91,
+                    explanation: "Opposite preference on the same topic.",
+                  }),
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      }
+
+      return new Response("not found", { status: 404 })
+    })
+
+    vi.stubGlobal("fetch", fetchMock)
+
+    await enqueueEmbeddingJob({
+      turso: db,
+      memoryId: "mem_seed",
+      content: "I like coffee",
+      modelId,
+      operation: "add",
+      nowIso,
+    })
+
+    const summary = await processDueEmbeddingJobs({
+      turso: db,
+      maxJobs: 1,
+      nowIso,
+    })
+    expect(summary.success).toBe(1)
+
+    const relationshipEdges = await db.execute({
+      sql: `SELECT from_n.node_key AS from_key, to_n.node_key AS to_key
+            FROM graph_edges e
+            JOIN graph_nodes from_n ON from_n.id = e.from_node_id
+            JOIN graph_nodes to_n ON to_n.id = e.to_node_id
+            WHERE e.edge_type = 'contradicts'
+            ORDER BY from_key, to_key`,
+    })
+
+    const pairs = relationshipEdges.rows.map((row) => `${row.from_key}->${row.to_key}`)
+    expect(pairs).toEqual(["mem_neighbor->mem_seed", "mem_seed->mem_neighbor"])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary
- add `graph/llm-extract.ts` to classify ambiguous memory pairs as `agrees | contradicts | refines | unrelated` via AI Gateway
- extend graph similarity pipeline to classify ambiguous cosine matches (default `0.70-0.90`) and emit `contradicts` / `supersedes` edges with confidence
- add generic relationship-edge replacement in graph upsert to prune stale `similar_to`, `contradicts`, and `supersedes` links for recomputed memories
- wire embedding worker graph sync to optionally call LLM classification behind runtime `GRAPH_LLM_EXTRACTION_ENABLED`
- add env controls for ambiguous range, confidence threshold, and model id
- add tests for llm classifier parsing, contradictory/refinement edge creation, confidence filtering, and worker integration
- update graph architecture + MCP tools docs and changelog for phase 2 behavior

## Validation
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/graph/extract.test.ts src/lib/memory-service/graph/retrieval.test.ts src/lib/memory-service/graph/llm-extract.test.ts src/lib/memory-service/graph/similarity.test.ts src/lib/memory-service/graph/upsert.test.ts src/lib/memory-service/graph/status.test.ts src/lib/memory-service/mutations.graph.test.ts src/lib/memory-service/queries.graph.test.ts src/lib/sdk-embeddings/jobs.test.ts`
- `pnpm --filter @memories.sh/web build && pnpm --filter @memories.sh/web typecheck`

Closes #228
Part of #225
Docs: #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new external LLM calls in the embedding worker write-path and changes graph edge deletion/replacement behavior, which could affect indexing reliability and retrieval results if misconfigured or if the gateway is unstable.
> 
> **Overview**
> Adds an optional LLM-driven “phase 2” relationship extraction step to the memory similarity pipeline: for embedding neighbors in an ambiguous cosine band, the system can call AI Gateway chat completions to classify the pair and emit `contradicts` (bidirectional) or `supersedes` (directed by memory timestamps) edges alongside `similar_to`.
> 
> Updates graph edge maintenance to support typed edge replacement (pruning stale `similar_to`/`contradicts`/`supersedes` edges when recomputing), wires the embedding job worker to run relationship syncing when `GRAPH_MAPPING_ENABLED` is on (and LLM classification when `GRAPH_LLM_EXTRACTION_ENABLED` is on), and introduces new env knobs for ambiguous-score range, confidence threshold, and model selection. Adds unit/integration tests for classifier parsing, edge creation/confidence filtering, and worker behavior, and refreshes changelog + graph/MCP docs to describe the new traversal behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74c2464b421d0741e81f8233985b055350132ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->