### PR TITLE
feat(graph): phase 4 relationship-aware retrieval scoring

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -15,6 +15,7 @@ description: Product and documentation updates.
 - Added similarity edge controls: `SIMILARITY_EDGE_THRESHOLD`, `SIMILARITY_EDGE_MAX_K`, `SIMILARITY_EDGE_MAX_PER_MEMORY`.
 - Added optional LLM relationship extraction for ambiguous similarity matches to create `contradicts` and `supersedes` memory edges.
 - Added graph LLM controls: `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN`, `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX`, `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD`, `GRAPH_LLM_RELATIONSHIP_MODEL_ID`.
+- Added relationship-aware graph ranking weights by edge type (`caused_by`, `contradicts`, `supersedes`, `similar_to`, etc.) with confidence + hop decay in retrieval scoring.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 
 ## February 20, 2026

--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -51,6 +51,8 @@ Hybrid retrieval runs in layered recall logic:
 
 Graph expansion can include semantically related memories via `similar_to` edges, even without shared tags/categories.
 
+Graph candidate ranking is edge-type aware and confidence-weighted. For equal hop counts, higher-priority relationships (for example `caused_by`, `contradicts`, `supersedes`) outrank generic relational links.
+
 Fallback reasons include:
 
 - `feature_flag_disabled`

--- a/packages/web/src/lib/memory-service/queries.ts
+++ b/packages/web/src/lib/memory-service/queries.ts
@@ -21,7 +21,7 @@ import {
   buildUserScopeFilter,
   parseMemoryLayer,
 } from "./scope"
-import { expandMemoryGraph } from "./graph/retrieval"
+import { expandMemoryGraph, graphReasonRank } from "./graph/retrieval"
 import {
   evaluateGraphRolloutQuality,
   getGraphRolloutConfig,
@@ -92,12 +92,6 @@ function normalizeGraphDepth(value: number | undefined): 0 | 1 | 2 {
 function normalizeGraphLimit(value: number | undefined): number {
   if (!Number.isFinite(value)) return 8
   return Math.max(1, Math.min(Math.floor(value ?? 8), 50))
-}
-
-function graphReasonRank(reason: GraphExplainability | undefined): number {
-  if (!reason) return 0
-  const sharedNodeBoost = reason.edgeType === "shared_node" ? 0.25 : 0
-  return sharedNodeBoost + 1 / Math.max(1, reason.hopCount)
 }
 
 function decodeEmbeddingBlob(value: unknown): Float32Array | null {

--- a/packages/web/src/lib/memory-service/types.ts
+++ b/packages/web/src/lib/memory-service/types.ts
@@ -85,6 +85,7 @@ export interface GraphExplainability {
   linkedViaNode: string
   edgeType: string
   hopCount: number
+  confidence: number
   seedMemoryId: string
 }
 


### PR DESCRIPTION
## Summary
- add edge-type weighting map for graph expansion ranking (`caused_by`, `contradicts`, `supersedes`, `similar_to`, etc.)
- propagate edge confidence through graph traversal explainability and candidate scoring
- replace flat graph ranking in `queries.ts` with shared `graphReasonRank` from retrieval module
- preserve `shared_node` behavior while keeping it lower-weight than direct semantic relationships
- add retrieval tests for causal > relational ordering, confidence weighting, and hop decay
- update graph architecture docs and changelog with relationship-aware scoring behavior

## Validation
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/graph/retrieval.test.ts src/lib/memory-service/queries.graph.test.ts src/lib/memory-service/graph/similarity.test.ts src/lib/sdk-embeddings/jobs.test.ts`
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/graph/extract.test.ts src/lib/memory-service/graph/retrieval.test.ts src/lib/memory-service/graph/llm-extract.test.ts src/lib/memory-service/graph/similarity.test.ts src/lib/memory-service/graph/upsert.test.ts src/lib/memory-service/graph/status.test.ts src/lib/memory-service/mutations.graph.test.ts src/lib/memory-service/queries.graph.test.ts src/lib/sdk-embeddings/jobs.test.ts`
- `pnpm --filter @memories.sh/web build && pnpm --filter @memories.sh/web typecheck`

Closes #230
Part of #225
Docs: #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ordering logic used to select and sort graph-expanded memories, which can materially affect retrieval results; behavior is covered by targeted unit tests and is explainability-only/data-shape additive (`confidence`).
> 
> **Overview**
> Graph retrieval scoring is updated to rank expansion candidates by **edge type priority** (e.g. `caused_by`/`contradicts`/`supersedes` above `similar_to`), multiplied by **edge confidence** and decayed by **hop count**.
> 
> This propagates `confidence` through `expandMemoryGraph` explainability (`GraphExplainability`) and centralizes ranking via a shared `graphReasonRank` helper (removing the previous flat ranking in `queries.ts`), while keeping `shared_node` behavior but weighting it below direct relationship edges. Tests and docs/changelog are updated to cover the new ordering/weighting semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a4b82c04a9fb9a44cbebeb470734f130db3b807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->