### PR TITLE
feat(context): phase 5 contradiction conflict surfacing

### DIFF
--- a/packages/core/src/client-schemas.ts
+++ b/packages/core/src/client-schemas.ts
@@ -39,10 +39,20 @@ export const structuredMemorySchema = z.object({
       linkedViaNode: z.string(),
       edgeType: z.string(),
       hopCount: z.number().int().nonnegative(),
+      confidence: z.number().nonnegative().optional(),
       seedMemoryId: z.string(),
     })
     .nullable()
     .optional(),
+})
+
+export const contextConflictSchema = z.object({
+  memoryAId: z.string(),
+  memoryBId: z.string(),
+  edgeType: z.literal("contradicts"),
+  confidence: z.number().nonnegative(),
+  explanation: z.string(),
+  suggestion: z.string(),
 })
 
 export const structuredSkillFileSchema = z.object({
@@ -59,6 +69,7 @@ export const structuredSkillFileSchema = z.object({
 export const contextStructuredSchema = z.object({
   rules: z.array(structuredMemorySchema).optional().default([]),
   memories: z.array(structuredMemorySchema).optional().default([]),
+  conflicts: z.array(contextConflictSchema).optional().default([]),
   skillFiles: z.array(structuredSkillFileSchema).optional().default([]),
   workingMemories: z.array(structuredMemorySchema).optional().default([]),
   longTermMemories: z.array(structuredMemorySchema).optional().default([]),
@@ -102,6 +113,7 @@ export const contextStructuredSchema = z.object({
       baselineCandidates: z.number().int().nonnegative(),
       graphCandidates: z.number().int().nonnegative(),
       graphExpandedCount: z.number().int().nonnegative(),
+      conflictCount: z.number().int().nonnegative().optional(),
       fallbackTriggered: z.boolean().optional(),
       fallbackReason: z.string().nullable().optional(),
       totalCandidates: z.number().int().nonnegative(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,14 +49,25 @@ export interface MemoryRecord {
     linkedViaNode: string
     edgeType: string
     hopCount: number
+    confidence?: number
     seedMemoryId: string
   } | null
   raw?: string
 }
 
+export interface ConflictPair {
+  memoryAId: string
+  memoryBId: string
+  edgeType: "contradicts"
+  confidence: number
+  explanation: string
+  suggestion: string
+}
+
 export interface ContextResult {
   rules: MemoryRecord[]
   memories: MemoryRecord[]
+  conflicts?: ConflictPair[]
   skillFiles?: SkillFileRecord[]
   trace?: {
     requestedStrategy?: ContextStrategy
@@ -79,6 +90,7 @@ export interface ContextResult {
     baselineCandidates: number
     graphCandidates: number
     graphExpandedCount: number
+    conflictCount?: number
     fallbackTriggered?: boolean
     fallbackReason?: string | null
     totalCandidates: number

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -16,6 +16,7 @@ description: Product and documentation updates.
 - Added optional LLM relationship extraction for ambiguous similarity matches to create `contradicts` and `supersedes` memory edges.
 - Added graph LLM controls: `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN`, `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX`, `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD`, `GRAPH_LLM_RELATIONSHIP_MODEL_ID`.
 - Added relationship-aware graph ranking weights by edge type (`caused_by`, `contradicts`, `supersedes`, `similar_to`, etc.) with confidence + hop decay in retrieval scoring.
+- Added `conflicts` to `get_context` responses when returned memories are linked by `contradicts` edges, including confidence and clarification suggestions.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 
 ## February 20, 2026

--- a/packages/web/content/docs/mcp-server/tools-reference.mdx
+++ b/packages/web/content/docs/mcp-server/tools-reference.mdx
@@ -40,6 +40,8 @@ The primary tool for AI agents. Returns all active rules (with path and category
 
 Returns all rules first (including path scope and category when set), followed by relevant search results. Uses FTS5 with BM25 ranking for the search query, falling back to LIKE matching for databases without FTS support. When hybrid graph retrieval is enabled, semantically similar memories may be added via graph `similar_to` edges, and conflict/refinement links may be traversed via `contradicts` / `supersedes` edges when LLM extraction is enabled.
 
+If returned memories include contradiction links, the response also includes a `conflicts[]` array with pair IDs, confidence, explanation text, and a suggestion for clarification.
+
 ## add_memory
 
 Store a new memory with optional metadata, path scoping, and categorization.

--- a/packages/web/src/app/api/sdk/v1/context/get/route.ts
+++ b/packages/web/src/app/api/sdk/v1/context/get/route.ts
@@ -137,6 +137,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       query: parsedRequest.query ?? "",
       rules,
       memories,
+      conflicts: payload.data.conflicts,
       skillFiles: skillFilesPayload.data.skillFiles,
       workingMemories: payload.data.workingMemories,
       longTermMemories: payload.data.longTermMemories,

--- a/packages/web/src/lib/memory-service/types.ts
+++ b/packages/web/src/lib/memory-service/types.ts
@@ -89,6 +89,15 @@ export interface GraphExplainability {
   seedMemoryId: string
 }
 
+export interface ContextConflict {
+  memoryAId: string
+  memoryBId: string
+  edgeType: "contradicts"
+  confidence: number
+  explanation: string
+  suggestion: string
+}
+
 export interface ContextTrace {
   requestedStrategy: ContextRetrievalStrategy
   strategy: ContextRetrievalStrategy
@@ -113,6 +122,7 @@ export interface ContextTrace {
   baselineCandidates: number
   graphCandidates: number
   graphExpandedCount: number
+  conflictCount?: number
   fallbackTriggered: boolean
   fallbackReason: string | null
   totalCandidates: number


### PR DESCRIPTION
## Summary
- add contradiction conflict extraction for returned `get_context` memories (only when both memory ids are present in the response set)
- include `conflicts[]` in context payloads with pair ids, confidence, explanation, and clarification suggestion
- add `conflictCount` to context trace for observability
- thread `conflicts` through SDK context route response
- update web/core context types and core response schemas to recognize graph confidence + conflict payloads
- add graph query tests covering conflict surfacing, empty conflicts when gate conditions fail, and trace count behavior
- document conflict payload behavior in MCP tools reference and changelog

## Validation
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/graph/retrieval.test.ts src/lib/memory-service/queries.graph.test.ts src/app/api/sdk/v1/context/get/__tests__/parity.test.ts`
- `pnpm --filter @memories.sh/web exec vitest run src/lib/memory-service/graph/extract.test.ts src/lib/memory-service/graph/retrieval.test.ts src/lib/memory-service/graph/llm-extract.test.ts src/lib/memory-service/graph/similarity.test.ts src/lib/memory-service/graph/upsert.test.ts src/lib/memory-service/graph/status.test.ts src/lib/memory-service/mutations.graph.test.ts src/lib/memory-service/queries.graph.test.ts src/lib/sdk-embeddings/jobs.test.ts src/app/api/sdk/v1/context/get/__tests__/parity.test.ts`
- `pnpm --filter @memories.sh/core exec vitest run src/__tests__/client.test.ts`
- `pnpm --filter @memories.sh/web build && pnpm --filter @memories.sh/web typecheck`

Closes #231
Part of #225
Docs: #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new response fields and executes an extra graph query during context retrieval, which could impact compatibility and performance if clients or DBs assume the old shape or query cost.
> 
> **Overview**
> Surfaces **contradiction conflicts** in `get_context` results by scanning returned memory IDs for `contradicts` graph edges and returning a new `conflicts[]` payload (pair IDs, confidence, explanation, suggestion), plus a `conflictCount` trace field for observability.
> 
> Threads this new data through the SDK `context/get` route response, updates core/web types and Zod client schemas (including optional graph `confidence`), expands integration tests to cover conflict presence/absence across rollout modes, and documents the new response behavior in the changelog and MCP tools reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d5568ed6294355ddddd057879b68410d30c5933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->