### PR TITLE
feat(graph): phase 3 llm semantic edge extraction

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -17,6 +17,7 @@ description: Product and documentation updates.
 - Added graph LLM controls: `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN`, `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX`, `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD`, `GRAPH_LLM_RELATIONSHIP_MODEL_ID`.
 - Added relationship-aware graph ranking weights by edge type (`caused_by`, `contradicts`, `supersedes`, `similar_to`, etc.) with confidence + hop decay in retrieval scoring.
 - Added `conflicts` to `get_context` responses when returned memories are linked by `contradicts` edges, including confidence and clarification suggestions.
+- Added semantic LLM relationship extraction on writes for `caused_by`, `prefers_over`, `depends_on`, `specializes`, and `conditional_on` edges (with reusable `condition` graph nodes).
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 
 ## February 20, 2026

--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -92,6 +92,9 @@ When `GRAPH_LLM_EXTRACTION_ENABLED=true`, ambiguous similarity matches can be cl
 
 - `contradicts`: bidirectional conflict relationship.
 - `supersedes`: directional "newer memory refines older memory" relationship.
+- semantic extraction edges: `caused_by`, `prefers_over`, `depends_on`, `specializes`, `conditional_on`.
+
+`conditional_on` edges link memories to shared `condition` nodes (for example `time:morning`), which are auto-created and reused during graph upsert.
 
 Environment controls:
 

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -316,6 +316,19 @@ export function getGraphLlmRelationshipModelId(): string {
   return envValue("GRAPH_LLM_RELATIONSHIP_MODEL_ID") ?? "anthropic/claude-3-5-haiku-latest"
 }
 
+export function getGraphLlmSemanticContextLimit(): number {
+  return parsePositiveInt(process.env.GRAPH_LLM_SEMANTIC_CONTEXT_LIMIT, 20)
+}
+
+export function getGraphLlmSemanticConfidenceThreshold(): number {
+  const value = parseNonNegativeFloat(process.env.GRAPH_LLM_SEMANTIC_CONFIDENCE_THRESHOLD, 0.6)
+  return Math.max(0, Math.min(1, value))
+}
+
+export function getGraphLlmSemanticMinChars(): number {
+  return parsePositiveInt(process.env.GRAPH_LLM_SEMANTIC_MIN_CHARS, 20)
+}
+
 // ── Other ────────────────────────────────────────────────────────────
 
 export function getAppUrl(): string {

--- a/packages/web/src/lib/memory-service/graph/similarity.ts
+++ b/packages/web/src/lib/memory-service/graph/similarity.ts
@@ -2,6 +2,9 @@ import {
   getGraphLlmAmbiguousSimilarityMax,
   getGraphLlmAmbiguousSimilarityMin,
   getGraphLlmRelationshipConfidenceThreshold,
+  getGraphLlmSemanticConfidenceThreshold,
+  getGraphLlmSemanticContextLimit,
+  getGraphLlmSemanticMinChars,
   getSimilarityEdgeMaxK,
   getSimilarityEdgeMaxPerMemory,
   getSimilarityEdgeThreshold,
@@ -69,11 +72,50 @@ export type RelationshipClassifier = (
   input: RelationshipClassifierInput
 ) => Promise<RelationshipClassifierResult>
 
+export type SemanticRelationshipEdgeType =
+  | "caused_by"
+  | "prefers_over"
+  | "depends_on"
+  | "specializes"
+  | "conditional_on"
+
+export interface SemanticRelationshipContextMemory {
+  id: string
+  content: string
+  createdAt: string | null
+}
+
+export interface SemanticRelationshipExtractedEdge {
+  type: SemanticRelationshipEdgeType
+  targetMemoryId?: string | null
+  conditionKey?: string | null
+  direction: "from_new" | "to_new"
+  confidence: number
+  evidence: string
+}
+
+export interface SemanticRelationshipExtractionResult {
+  edges: SemanticRelationshipExtractedEdge[]
+}
+
+export type SemanticRelationshipExtractor = (input: {
+  newMemory: {
+    id: string
+    content: string
+    createdAt: string | null
+  }
+  recentMemories: SemanticRelationshipContextMemory[]
+}) => Promise<SemanticRelationshipExtractionResult>
+
 export interface ComputeRelationshipEdgesInput extends ComputeSimilarityEdgesInput {
   ambiguousMinScore?: number
   ambiguousMaxScore?: number
   llmConfidenceThreshold?: number
   classifier?: RelationshipClassifier | null
+  semanticExtractor?: SemanticRelationshipExtractor | null
+  semanticContextLimit?: number
+  semanticConfidenceThreshold?: number
+  semanticMinChars?: number
 }
 
 function decodeEmbeddingBlob(value: unknown): Float32Array | null {
@@ -216,6 +258,47 @@ async function selectSimilarityCandidates(input: ComputeSimilarityEdgesInput): P
     })
     .filter((entry): entry is SimilarityMatch => Boolean(entry))
     .sort((a, b) => b.score - a.score || String(b.updatedAt).localeCompare(String(a.updatedAt)))
+}
+
+async function selectRecentMemoryContext(
+  input: ComputeRelationshipEdgesInput
+): Promise<SemanticRelationshipContextMemory[]> {
+  const nowIso = input.nowIso ?? new Date().toISOString()
+  const limit = Math.max(1, input.semanticContextLimit ?? getGraphLlmSemanticContextLimit())
+  const userFilter = buildUserScopeFilter(input.userId, "m.")
+  const activeFilter = buildNotExpiredFilter(nowIso, "m.")
+  const projectFilter = input.projectId
+    ? "AND (m.scope = 'global' OR (m.scope = 'project' AND m.project_id = ?))"
+    : "AND m.scope = 'global'"
+
+  const args: (string | number)[] = [input.memoryId]
+  if (input.projectId) {
+    args.push(input.projectId)
+  }
+  args.push(...userFilter.args)
+  args.push(...activeFilter.args)
+  args.push(limit)
+
+  const result = await input.turso.execute({
+    sql: `SELECT m.id, m.content, m.created_at
+          FROM memories m
+          WHERE m.id != ?
+            AND m.deleted_at IS NULL
+            ${projectFilter}
+            AND ${userFilter.clause}
+            AND ${activeFilter.clause}
+          ORDER BY m.updated_at DESC
+          LIMIT ?`,
+    args,
+  })
+
+  return (result.rows as Array<Record<string, unknown>>)
+    .map((row) => ({
+      id: String(row.id ?? "").trim(),
+      content: String(row.content ?? "").trim(),
+      createdAt: typeof row.created_at === "string" ? row.created_at : null,
+    }))
+    .filter((row) => row.id.length > 0 && row.content.length > 0)
 }
 
 function buildBidirectionalMemoryEdges(params: {
@@ -376,6 +459,89 @@ async function buildLlmRelationshipEdges(
   return edges
 }
 
+function normalizeConditionKey(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "_")
+}
+
+async function buildSemanticRelationshipEdges(
+  input: ComputeRelationshipEdgesInput,
+  expiresAt: string | null
+): Promise<GraphEdgeWrite[]> {
+  if (!input.semanticExtractor) return []
+
+  const sourceContent = input.memoryContent?.trim()
+  if (!sourceContent) return []
+  const minChars = Math.max(1, input.semanticMinChars ?? getGraphLlmSemanticMinChars())
+  if (sourceContent.length < minChars) return []
+
+  const semanticContext = await selectRecentMemoryContext(input)
+  if (semanticContext.length === 0) return []
+
+  const confidenceThreshold = normalizeScore(
+    input.semanticConfidenceThreshold ?? getGraphLlmSemanticConfidenceThreshold()
+  )
+
+  try {
+    const extraction = await input.semanticExtractor({
+      newMemory: {
+        id: input.memoryId,
+        content: sourceContent,
+        createdAt: input.memoryCreatedAt ?? null,
+      },
+      recentMemories: semanticContext,
+    })
+
+    const edges: GraphEdgeWrite[] = []
+    for (const extractedEdge of extraction.edges) {
+      const confidence = normalizeScore(extractedEdge.confidence)
+      if (confidence < confidenceThreshold) continue
+
+      if (extractedEdge.type === "conditional_on") {
+        const conditionKey = typeof extractedEdge.conditionKey === "string"
+          ? normalizeConditionKey(extractedEdge.conditionKey)
+          : ""
+        if (!conditionKey) continue
+
+        const conditionRef = {
+          nodeType: "condition",
+          nodeKey: conditionKey,
+        } satisfies GraphNodeRef
+
+        edges.push({
+          from: extractedEdge.direction === "to_new" ? conditionRef : memoryNodeRef(input.memoryId),
+          to: extractedEdge.direction === "to_new" ? memoryNodeRef(input.memoryId) : conditionRef,
+          edgeType: extractedEdge.type,
+          weight: 1,
+          confidence,
+          evidenceMemoryId: input.memoryId,
+          expiresAt,
+        })
+        continue
+      }
+
+      const targetMemoryId = extractedEdge.targetMemoryId?.trim()
+      if (!targetMemoryId || targetMemoryId === input.memoryId) continue
+      const hasTarget = semanticContext.some((entry) => entry.id === targetMemoryId)
+      if (!hasTarget) continue
+
+      edges.push({
+        from: extractedEdge.direction === "to_new" ? memoryNodeRef(targetMemoryId) : memoryNodeRef(input.memoryId),
+        to: extractedEdge.direction === "to_new" ? memoryNodeRef(input.memoryId) : memoryNodeRef(targetMemoryId),
+        edgeType: extractedEdge.type,
+        weight: 1,
+        confidence,
+        evidenceMemoryId: input.memoryId,
+        expiresAt,
+      })
+    }
+
+    return edges
+  } catch (error) {
+    console.error("Semantic relationship extraction failed:", error)
+    return []
+  }
+}
+
 export async function computeSimilarityEdges(input: ComputeSimilarityEdgesInput): Promise<GraphEdgeWrite[]> {
   if (input.embedding.length === 0) return []
 
@@ -411,8 +577,9 @@ export async function computeRelationshipEdges(input: ComputeRelationshipEdgesIn
     expiresAt,
   })
   const llmEdges = await buildLlmRelationshipEdges(input, matches, expiresAt)
+  const semanticEdges = await buildSemanticRelationshipEdges(input, expiresAt)
 
-  return dedupeEdges([...similarEdges, ...llmEdges])
+  return dedupeEdges([...similarEdges, ...llmEdges, ...semanticEdges])
 }
 
 export async function syncSimilarityEdgesForMemory(input: ComputeSimilarityEdgesInput): Promise<void> {
@@ -424,6 +591,15 @@ export async function syncRelationshipEdgesForMemory(input: ComputeRelationshipE
   const edges = await computeRelationshipEdges(input)
   await replaceMemoryRelationshipEdges(input.turso, input.memoryId, edges, {
     nowIso: input.nowIso,
-    edgeTypes: ["similar_to", "contradicts", "supersedes"],
+    edgeTypes: [
+      "similar_to",
+      "contradicts",
+      "supersedes",
+      "caused_by",
+      "prefers_over",
+      "depends_on",
+      "specializes",
+      "conditional_on",
+    ],
   })
 }

--- a/packages/web/src/lib/sdk-embeddings/jobs.ts
+++ b/packages/web/src/lib/sdk-embeddings/jobs.ts
@@ -8,7 +8,7 @@ import {
   getSdkEmbeddingJobRetryMaxMs,
   getSdkEmbeddingJobWorkerBatchSize,
 } from "@/lib/env"
-import { classifyMemoryRelationship } from "@/lib/memory-service/graph/llm-extract"
+import { classifyMemoryRelationship, extractSemanticRelationships } from "@/lib/memory-service/graph/llm-extract"
 import { syncRelationshipEdgesForMemory } from "@/lib/memory-service/graph/similarity"
 import {
   defaultLayerForType,
@@ -515,6 +515,7 @@ async function processSingleJob(turso: TursoClient, job: EmbeddingJobRow, nowIso
           memoryContent: job.content,
           memoryCreatedAt: typeof memoryRow.created_at === "string" ? memoryRow.created_at : null,
           classifier: llmExtractionEnabled ? classifyMemoryRelationship : null,
+          semanticExtractor: llmExtractionEnabled ? extractSemanticRelationships : null,
           nowIso,
         })
       } catch (error) {


### PR DESCRIPTION
## Summary
- implement Phase 3 semantic relationship extraction for graph writes
- add LLM edge extraction support for `caused_by`, `prefers_over`, `depends_on`, `specializes`, and `conditional_on`
- map `conditional_on` to reusable `condition` nodes and upsert extracted edges alongside existing relationships
- wire extraction into embedding jobs behind feature flags and document the new behavior

## Testing
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm --filter @memories.sh/web test -- src/lib/memory-service/graph/llm-extract.test.ts src/lib/memory-service/graph/similarity.test.ts src/lib/sdk-embeddings/jobs.test.ts`
- `pnpm --filter @memories.sh/web test`

Refs #229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new LLM-driven write-path behavior and new graph node/edge upsert logic (including non-memory node creation), which can affect graph integrity and job-time API calls, though it is feature-flag gated and best-effort.
> 
> **Overview**
> Enables Phase 3 semantic relationship extraction on graph write/sync by calling an LLM to emit new edge types (`caused_by`, `prefers_over`, `depends_on`, `specializes`, `conditional_on`) and persisting them with confidence gating.
> 
> `computeRelationshipEdges` now fetches a limited recent-memory context, filters by min content length and confidence threshold, and adds `conditional_on` edges that point to reusable `condition` graph nodes (auto-upserted during edge upsert). Embedding job processing wires this extraction behind `GRAPH_LLM_EXTRACTION_ENABLED`, expands the edge-type replacement set, and updates docs/changelog plus tests to cover the new extraction and condition-node reuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d0370e60a90ae32eef248019d0ad1d560bfdd2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->