### PR TITLE
docs(graph): complete memory-edge rollout documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ memories generate
 - **Skills** — define reusable agent workflows following the [Agent Skills](https://agentskills.io) standard
 - **`.agents/` canonical directory** — tool-agnostic intermediate format, checked into git
 - **Semantic search** — AI-powered embeddings find related memories, not just keyword matches
+- **Relationship-aware graph retrieval** — traverses `similar_to`, `contradicts`, `supersedes`, and semantic edges (`caused_by`, `prefers_over`, `depends_on`, `specializes`, `conditional_on`) with confidence-aware ranking
+- **Conflict surfacing** — `get_context` can return contradiction pairs so agents can ask clarification questions before acting
 - **MCP server** — fallback MCP server for agents that need real-time access beyond static configs
 - **Auto-setup** — `memories setup` (`init` alias) detects installed tools, configures MCP, and imports existing project skills automatically
 - **Global SKILLS.md bootstrap** — installs cross-tool memory usage guidance into detected global agent config directories

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -19,6 +19,7 @@ description: Product and documentation updates.
 - Added `conflicts` to `get_context` responses when returned memories are linked by `contradicts` edges, including confidence and clarification suggestions.
 - Added semantic LLM relationship extraction on writes for `caused_by`, `prefers_over`, `depends_on`, `specializes`, and `conditional_on` edges (with reusable `condition` graph nodes).
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
+- Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 
 ## February 20, 2026
 

--- a/packages/web/content/docs/mcp-server/tools-reference.mdx
+++ b/packages/web/content/docs/mcp-server/tools-reference.mdx
@@ -42,6 +42,33 @@ Returns all rules first (including path scope and category when set), followed b
 
 If returned memories include contradiction links, the response also includes a `conflicts[]` array with pair IDs, confidence, explanation text, and a suggestion for clarification.
 
+Example `structuredContent` conflict payload fragment:
+
+```json
+{
+  "data": {
+    "memories": [
+      { "id": "mem_a", "content": "I prefer tea in the afternoon." },
+      { "id": "mem_b", "content": "I avoid tea after lunch." }
+    ],
+    "conflicts": [
+      {
+        "memoryAId": "mem_a",
+        "memoryBId": "mem_b",
+        "edgeType": "contradicts",
+        "confidence": 0.88,
+        "explanation": "These memories are linked by a contradiction edge from relationship extraction.",
+        "suggestion": "These memories may conflict. Consider asking the user to clarify which preference is current."
+      }
+    ],
+    "trace": {
+      "strategy": "hybrid_graph",
+      "conflictCount": 1
+    }
+  }
+}
+```
+
 ## add_memory
 
 Store a new memory with optional metadata, path scoping, and categorization.

--- a/packages/web/content/docs/sdk/endpoint-contract.mdx
+++ b/packages/web/content/docs/sdk/endpoint-contract.mdx
@@ -223,10 +223,41 @@ Response `data`:
 - `mode`, `query`
 - `rules[]`
 - `memories[]`
+- `conflicts[]` (optional contradiction pairs when returned memories are linked by `contradicts` edges)
 - `skillFiles[]`
 - `workingMemories[]`
 - `longTermMemories[]`
 - `trace` (strategy, rollout mode, fallback details, candidate counts, retrieval policy diagnostics)
+
+`memories[].graph` explainability (present for graph-expanded memories):
+
+- `whyIncluded`: `graph_expansion`
+- `linkedViaNode`: graph node label that connected the memory
+- `edgeType`: relationship edge used for expansion
+- `hopCount`: traversal depth from seed memory
+- `confidence`: normalized edge confidence (`0..1`)
+- `seedMemoryId`: originating seed memory id
+
+`conflicts[]` item shape (`ConflictPair` in `@memories.sh/core`):
+
+```json
+{
+  "memoryAId": "mem_a",
+  "memoryBId": "mem_b",
+  "edgeType": "contradicts",
+  "confidence": 0.91,
+  "explanation": "These memories are linked by a contradiction edge from relationship extraction.",
+  "suggestion": "These memories may conflict. Consider asking the user to clarify which preference is current."
+}
+```
+
+`trace` includes rollout + retrieval diagnostics such as:
+
+- `retrievalPolicyDefaultStrategy`, `retrievalPolicyAppliedStrategy`, `retrievalPolicySelection`
+- `semanticStrategyRequested`, `semanticStrategyApplied`, `semanticFallbackTriggered`, `semanticFallbackReason`
+- `graphDepth`, `graphLimit`, `rolloutMode`, `shadowExecuted`
+- `baselineCandidates`, `graphCandidates`, `graphExpandedCount`, `conflictCount`, `totalCandidates`
+- `fallbackTriggered`, `fallbackReason`
 
 ### `POST /api/sdk/v1/memories/add`
 

--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -53,6 +53,30 @@ Graph expansion can include semantically related memories via `similar_to` edges
 
 Graph candidate ranking is edge-type aware and confidence-weighted. For equal hop counts, higher-priority relationships (for example `caused_by`, `contradicts`, `supersedes`) outrank generic relational links.
 
+### Edge Weight Table
+
+The retrieval ranker applies edge-type multipliers before hop decay:
+
+| Edge type | Weight | Why |
+| --- | --- | --- |
+| `caused_by` | `1.5` | Causal updates should dominate older generic preference facts |
+| `contradicts` | `1.3` | Surface conflicts quickly for clarification |
+| `supersedes` | `1.2` | Prefer newer refinement over stale variants |
+| `similar_to` | `1.0` | Semantic neighbor baseline |
+| `depends_on` | `0.9` | Preserve workflow ordering context |
+| `prefers_over` | `0.8` | Preference edges with lower certainty than causal updates |
+| `specializes` | `0.7` | Hierarchical narrowing |
+| `conditional_on` | `0.6` | Condition-gated relationships |
+| `shared_node` | `0.25` | Legacy/shared metadata traversal fallback |
+
+Ranking formula:
+
+```text
+score = (edge_type_weight * edge_weight * confidence) / max(1, hop_count)
+```
+
+At equal confidence and hop count, `caused_by` will outrank `prefers_over`, which is how causal facts can override older stated preferences.
+
 Fallback reasons include:
 
 - `feature_flag_disabled`
@@ -102,6 +126,44 @@ Environment controls:
 - `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MAX` (default `0.90`)
 - `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD` (default `0.70`)
 - `GRAPH_LLM_RELATIONSHIP_MODEL_ID` (default `anthropic/claude-3-5-haiku-latest`)
+- `GRAPH_LLM_SEMANTIC_CONTEXT_LIMIT` (default `20`)
+- `GRAPH_LLM_SEMANTIC_CONFIDENCE_THRESHOLD` (default `0.60`)
+- `GRAPH_LLM_SEMANTIC_MIN_CHARS` (default `20`)
+
+### Contradiction Detection Pipeline
+
+Contradiction/refinement extraction runs in the async embedding worker:
+
+1. Compute similarity neighbors from `memory_embeddings`.
+2. Filter to ambiguous matches using `GRAPH_LLM_AMBIGUOUS_SIMILARITY_MIN..MAX`.
+3. Classify each pair as `agrees`, `contradicts`, `refines`, or `unrelated`.
+4. Persist only edges meeting `GRAPH_LLM_RELATIONSHIP_CONFIDENCE_THRESHOLD`.
+
+Outputs:
+
+- `contradicts` (bidirectional memory-memory edge)
+- `supersedes` (directional memory-memory edge)
+
+### Semantic Relationship Extraction Pipeline
+
+Semantic extraction also runs asynchronously in the embedding worker and does not block memory writes:
+
+1. Select recent scoped memories (`GRAPH_LLM_SEMANTIC_CONTEXT_LIMIT`).
+2. Send new-memory + recent-memory context to the configured model with strict JSON schema output.
+3. Parse + validate typed edges (`caused_by`, `prefers_over`, `depends_on`, `specializes`, `conditional_on`).
+4. Drop low-confidence edges (< `GRAPH_LLM_SEMANTIC_CONFIDENCE_THRESHOLD`).
+5. Persist edges with evidence metadata; map `conditional_on` to shared `condition` nodes.
+
+### Cost And Operations Note
+
+Enabling `GRAPH_LLM_EXTRACTION_ENABLED` adds model calls per memory write (pairwise ambiguous classification + semantic extraction pass). These calls run in background embedding jobs and are best-effort.
+
+Operationally:
+
+- memory writes still succeed if extraction fails
+- extraction failures are logged and skipped
+- monitor AI Gateway usage when enabling this in high-write tenants
+- embedding usage endpoints currently report embedding spend, not a separate semantic-extraction meter
 
 ## Scope And Workspace Routing
 

--- a/skills/memories-mcp/SKILL.md
+++ b/skills/memories-mcp/SKILL.md
@@ -37,12 +37,15 @@ get_context({ query: "authentication flow" })
 
 Leave `query` empty to get just rules. Use `limit` to control memory count (default: 10).
 
+When relationship extraction is enabled server-side, `get_context` may also return `conflicts[]` for contradiction-linked memories. Treat these as clarification prompts before taking irreversible actions.
+
 ## Tool Selection Guide
 
 | Goal | Tool | When |
 |------|------|------|
 | Start a task | `get_context` | Beginning of any task — gets rules + relevant context |
 | Save knowledge | `add_memory` | After learning something worth persisting |
+| Resolve contradictory context | `get_context` | If `conflicts[]` is present, ask a disambiguating question and persist the answer |
 | Find specific info | `search_memories` | Full-text search with prefix matching |
 | Browse recent | `list_memories` | Explore what's stored, filter by type/tags |
 | Get coding standards | `get_rules` | When you only need rules, not memories |

--- a/skills/memories-mcp/references/tools.md
+++ b/skills/memories-mcp/references/tools.md
@@ -30,6 +30,8 @@ Complete reference for all memories.sh MCP tools.
 
 **Returns:** Markdown with `## Project Rules` and `## Global Rules` sections + `## Relevant Memories` section. Uses FTS5 with BM25 ranking (LIKE fallback for older databases).
 
+When contradiction edges are present in returned memories, `structuredContent.data.conflicts[]` is included with `memoryAId`, `memoryBId`, `edgeType`, `confidence`, `explanation`, and `suggestion`.
+
 **When to use:** At the start of any task. Call with no query to get just rules.
 
 ```
@@ -40,6 +42,24 @@ get_context({ query: "database migration" })
 → ## Relevant to: "database migration"
 → 💡 DECISION (P) abc123: Chose Drizzle ORM for type-safe migrations
 → 📋 FACT (P) def456: Production DB is PostgreSQL 15 on Supabase
+```
+
+Conflict example (structured payload fragment):
+
+```json
+{
+  "data": {
+    "conflicts": [
+      {
+        "memoryAId": "mem_a",
+        "memoryBId": "mem_b",
+        "edgeType": "contradicts",
+        "confidence": 0.9,
+        "suggestion": "These memories may conflict. Consider asking the user to clarify which preference is current."
+      }
+    ]
+  }
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary
- complete graph rollout docs across phases 0-5 in architecture + endpoint contracts
- document edge-type weight table, scoring formula, contradiction and semantic extraction pipelines, and LLM extraction operational cost notes
- add `get_context` conflict payload shape (`ConflictPair`) and trace field guidance in SDK endpoint contract + MCP tools reference
- update memories-mcp skill docs to guide conflict-aware handling when `conflicts[]` is present
- add README feature callouts for relationship-aware retrieval + conflict surfacing

## Validation
- `pnpm --filter @memories.sh/web build`

Refs #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; no runtime code paths or data-handling logic are modified.
> 
> **Overview**
> Documentation update that **completes the graph retrieval rollout story** by detailing relationship-aware traversal/ranking (including an edge-weight table and scoring formula) and describing contradiction + semantic relationship extraction pipelines and their operational/cost considerations.
> 
> Updates the SDK and MCP references to document new `get_context` response fields, including optional `conflicts[]` contradiction pairs and `memories[].graph` explainability metadata, with concrete JSON payload examples. Also updates the `memories-mcp` skill docs to guide agents to treat `conflicts[]` as a clarification prompt, and adds README feature bullets for relationship-aware retrieval and conflict surfacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6977f207adc02059980e4e2c28792a495a3b7f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->