### PR TITLE
fix(graph): guard semantic context selection inside LLM extraction try block

### DIFF
--- a/packages/web/src/lib/memory-service/graph/similarity.ts
+++ b/packages/web/src/lib/memory-service/graph/similarity.ts
@@ -431,14 +431,14 @@ async function buildSemanticRelationshipEdges(
   const minChars = Math.max(1, input.semanticMinChars ?? getGraphLlmSemanticMinChars())
   if (sourceContent.length < minChars) return []
 
-  const semanticContext = await selectRecentMemoryContext(input)
-  if (semanticContext.length === 0) return []
-
   const confidenceThreshold = normalizeScore(
     input.semanticConfidenceThreshold ?? getGraphLlmSemanticConfidenceThreshold()
   )
 
   try {
+    const semanticContext = await selectRecentMemoryContext(input)
+    if (semanticContext.length === 0) return []
+
     const extraction = await input.semanticExtractor({
       newMemory: {
         id: input.memoryId,


### PR DESCRIPTION
## Summary
- move semantic context selection into the existing semantic extraction try/catch
- ensure transient DB/query failures during context loading are handled gracefully and do not abort memory writes

## Why
A post-merge Bugbot autofix produced this change on the feature branch after #241 merged. This PR carries the fix cleanly into `main`.

## Validation
- `pnpm --filter @memories.sh/web test -- src/lib/memory-service/graph/similarity.test.ts src/lib/memory-service/queries.semantic.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change scoped to semantic edge generation; main risk is silently skipping semantic edges on context-load errors, but other edge types remain unaffected.
> 
> **Overview**
> Moves `selectRecentMemoryContext()` into the `try/catch` in `buildSemanticRelationshipEdges`, so failures while loading semantic context are caught and logged as part of semantic extraction.
> 
> Behaviorally, semantic relationship edge generation now returns `[]` (rather than throwing) when context selection errors occur, allowing the rest of the memory write/edge sync flow to proceed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c9fc0c22e5186016477cd01f156f7ca67a2db05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->