### PR TITLE
fix: harden memory-graph sync/error paths from review

### DIFF
--- a/packages/web/src/lib/sdk-embeddings/jobs.ts
+++ b/packages/web/src/lib/sdk-embeddings/jobs.ts
@@ -494,15 +494,15 @@ async function processSingleJob(turso: TursoClient, job: EmbeddingJobRow, nowIso
 
     const graphMappingEnabled = parseBooleanFlag(process.env.GRAPH_MAPPING_ENABLED, false)
     if (graphMappingEnabled && memoryRow) {
-      try {
-        const llmExtractionEnabled = parseBooleanFlag(process.env.GRAPH_LLM_EXTRACTION_ENABLED, false)
-        const memoryType = typeof memoryRow.type === "string" ? memoryRow.type : "note"
-        const memoryLayerRaw = typeof memoryRow.memory_layer === "string" ? memoryRow.memory_layer : null
-        const memoryLayer =
-          memoryLayerRaw === "rule" || memoryLayerRaw === "working" || memoryLayerRaw === "long_term"
-            ? memoryLayerRaw
-            : defaultLayerForType(memoryType)
+      const llmExtractionEnabled = parseBooleanFlag(process.env.GRAPH_LLM_EXTRACTION_ENABLED, false)
+      const memoryType = typeof memoryRow.type === "string" ? memoryRow.type : "note"
+      const memoryLayerRaw = typeof memoryRow.memory_layer === "string" ? memoryRow.memory_layer : null
+      const memoryLayer =
+        memoryLayerRaw === "rule" || memoryLayerRaw === "working" || memoryLayerRaw === "long_term"
+          ? memoryLayerRaw
+          : defaultLayerForType(memoryType)
 
+      try {
         await syncRelationshipEdgesForMemory({
           turso,
           memoryId: job.memoryId,
@@ -519,7 +519,11 @@ async function processSingleJob(turso: TursoClient, job: EmbeddingJobRow, nowIso
           nowIso,
         })
       } catch (error) {
-        console.error("Relationship edge sync failed:", error)
+        throw new EmbeddingJobError("Relationship edge sync failed", {
+          code: "GRAPH_RELATIONSHIP_SYNC_FAILED",
+          retryable: true,
+          cause: error,
+        })
       }
     }
 


### PR DESCRIPTION
## Summary
- align `supersedes` edge direction to classifier contract (`incoming -> existing`) instead of timestamp heuristics
- make graph mapping sync atomic with savepoint rollback so partial failures do not drop existing mappings
- gracefully fallback from semantic retrieval when `memory_embeddings` table is unavailable
- treat post-embedding relationship sync failure as retryable job failure instead of silently succeeding

## Tests
- added regression for supersedes direction with inverted timestamps
- added rollback regression for failed graph remap writes
- added semantic fallback regression when `memory_embeddings` table is missing
- added embedding jobs regression to ensure relationship-sync failures are retried
- `pnpm -C /Users/tradecraft/dev/memories --filter @memories.sh/web test -- src/lib/memory-service/graph/similarity.test.ts src/lib/memory-service/graph/upsert.test.ts src/lib/memory-service/queries.semantic.test.ts src/lib/sdk-embeddings/jobs.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence flows (graph mapping writes), retrieval behavior, and embedding job retry semantics; failures could impact graph consistency or search results, but changes are localized and covered by new regression tests.
> 
> **Overview**
> Aligns `supersedes` edge direction with the relationship classifier contract (new/incoming memory supersedes the existing candidate) by removing timestamp-based direction heuristics, with a regression test for inverted timestamps.
> 
> Makes `syncMemoryGraphMapping` atomic by wrapping the remove+reinsert sequence in a SQLite savepoint and rolling back on failure, preventing partial writes from deleting existing mappings; adds a test that forces a mid-write failure.
> 
> Hardens semantic retrieval by treating a missing `memory_embeddings` table as “no semantic candidates” (triggering lexical fallback) and adds coverage for that scenario.
> 
> Updates the embedding job worker to treat relationship-edge sync failures as a retryable `EmbeddingJobError` (instead of logging and continuing), with a test asserting the job re-queues while the embedding upsert remains persisted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6edce0dc0aef85aba2c33686e8b0f8efbbabb3bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->