### PR TITLE
docs: align graph hardening + retry observability guidance

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -18,6 +18,9 @@ description: Product and documentation updates.
 - Added relationship-aware graph ranking weights by edge type (`caused_by`, `contradicts`, `supersedes`, `similar_to`, etc.) with confidence + hop decay in retrieval scoring.
 - Added `conflicts` to `get_context` responses when returned memories are linked by `contradicts` edges, including confidence and clarification suggestions.
 - Added semantic LLM relationship extraction on writes for `caused_by`, `prefers_over`, `depends_on`, `specializes`, and `conditional_on` edges (with reusable `condition` graph nodes).
+- Made relationship edge replacement atomic via savepoint rollback in graph upsert (`replaceMemoryRelationshipEdges`) to prevent partial edge loss on write failures.
+- Added structured LLM extraction degradation reporting in embedding worker metrics (`GRAPH_RELATIONSHIP_PARTIAL_DEGRADE`) with issue-level codes (`GRAPH_LLM_CLASSIFICATION_FAILED`, `GRAPH_LLM_SEMANTIC_EXTRACTION_FAILED`).
+- Optimized graph-only retry path after `GRAPH_RELATIONSHIP_SYNC_FAILED` to reuse stored embeddings and avoid redundant embeddings API calls.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/content/docs/sdk/embedding-operations-runbook.mdx
+++ b/packages/web/content/docs/sdk/embedding-operations-runbook.mdx
@@ -46,6 +46,19 @@ Current SLO thresholds emitted in observability payload:
 4. If retrieval alarms fire, inspect fallback reason trends and graph rollout mode.
 5. Confirm cost impact by comparing `cost.customerCostUsd` with usage trends.
 
+### Worker graph-relationship signals
+
+For relationship-edge extraction incidents, focus on:
+
+- `GRAPH_RELATIONSHIP_SYNC_FAILED` in `worker.topErrorCodes`:
+  - indicates edge write/sync failures that trigger retry/dead-letter behavior
+- `GRAPH_RELATIONSHIP_PARTIAL_DEGRADE` in successful worker metrics:
+  - indicates writes succeeded but LLM classification/semantic extraction degraded (`GRAPH_LLM_CLASSIFICATION_FAILED`, `GRAPH_LLM_SEMANTIC_EXTRACTION_FAILED`)
+
+Operational note:
+
+- when retries are caused by graph sync failures after embedding upsert, workers reuse stored vectors and avoid extra embeddings API calls when possible
+
 ## Rollback + Feature Flags
 
 ### 1) Retrieval rollback (high fallback/latency)

--- a/packages/web/content/docs/sdk/graph-architecture.mdx
+++ b/packages/web/content/docs/sdk/graph-architecture.mdx
@@ -161,7 +161,9 @@ Enabling `GRAPH_LLM_EXTRACTION_ENABLED` adds model calls per memory write (pairw
 Operationally:
 
 - memory writes still succeed if extraction fails
-- extraction failures are logged and skipped
+- extraction failures are logged as best-effort degradation and surfaced in embedding job metrics as `GRAPH_RELATIONSHIP_PARTIAL_DEGRADE`
+- issue-level extraction codes are recorded (`GRAPH_LLM_CLASSIFICATION_FAILED`, `GRAPH_LLM_SEMANTIC_EXTRACTION_FAILED`) to make rollout regressions visible
+- retries after `GRAPH_RELATIONSHIP_SYNC_FAILED` reuse stored embeddings when available to avoid repeated embedding API calls for graph-only failures
 - monitor AI Gateway usage when enabling this in high-write tenants
 - embedding usage endpoints currently report embedding spend, not a separate semantic-extraction meter
 

--- a/skills/memories-dev/references/architecture.md
+++ b/skills/memories-dev/references/architecture.md
@@ -48,6 +48,22 @@ memories sync → turso.ts
   → Push/pull changes
 ```
 
+### Hosted SDK Embedding Worker Path (web)
+```
+memory write (SDK) → enqueue embedding job
+  → jobs.ts worker claims queued job
+  → generate or reuse embedding (on graph-only retry)
+  → upsert memory_embeddings
+  → sync relationship edges (similar_to + optional LLM-derived edges)
+  → write job metric outcome/error codes
+```
+
+Notes:
+- Relationship edge replacement is savepoint-wrapped to avoid partial delete/insert states on failure.
+- LLM extraction failures are best-effort and can surface on successful jobs as `GRAPH_RELATIONSHIP_PARTIAL_DEGRADE`.
+- Issue-level degradation codes include `GRAPH_LLM_CLASSIFICATION_FAILED` and `GRAPH_LLM_SEMANTIC_EXTRACTION_FAILED`.
+- Retries after `GRAPH_RELATIONSHIP_SYNC_FAILED` attempt to reuse stored vectors to avoid repeated embeddings API calls.
+
 ---
 
 ## Database Layer


### PR DESCRIPTION
## Summary
- updated changelog with relationship hardening/reliability entries from the latest graph fixes
- updated graph architecture docs to reflect structured LLM degradation codes and retry embedding reuse behavior
- updated embedding operations runbook with graph relationship error/degrade triage guidance
- updated memories-dev architecture reference with hosted SDK embedding worker path and error-code notes

## Validation
- `pnpm -C /Users/tradecraft/dev/memories/packages/web build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no production code, auth, or data-path modifications.
> 
> **Overview**
> Documents recent graph relationship-edge reliability improvements, including **atomic edge replacement** via savepoints, **structured best-effort degradation reporting** (`GRAPH_RELATIONSHIP_PARTIAL_DEGRADE` with issue codes), and **graph-only retry optimization** that reuses stored embeddings after `GRAPH_RELATIONSHIP_SYNC_FAILED`.
> 
> Expands operational guidance: the embeddings runbook now calls out graph-relationship triage signals/error codes, and the architecture references add the hosted embedding worker flow plus notes on retries and degradation observability. The changelog is updated to list these hardening/observability items alongside the broader Feb 21 graph updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e601389d55764b3e54371d433f684660dbb1b6a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->