### PR TITLE
fix(graph-ui): live status refresh for Graph Explorer

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -21,6 +21,7 @@ description: Product and documentation updates.
 - Made relationship edge replacement atomic via savepoint rollback in graph upsert (`replaceMemoryRelationshipEdges`) to prevent partial edge loss on write failures.
 - Added structured LLM extraction degradation reporting in embedding worker metrics (`GRAPH_RELATIONSHIP_PARTIAL_DEGRADE`) with issue-level codes (`GRAPH_LLM_CLASSIFICATION_FAILED`, `GRAPH_LLM_SEMANTIC_EXTRACTION_FAILED`).
 - Optimized graph-only retry path after `GRAPH_RELATIONSHIP_SYNC_FAILED` to reuse stored embeddings and avoid redundant embeddings API calls.
+- Added live Graph Explorer status refresh (manual + background polling) so rollout health, alarms, and quality gate data stay current without page reloads.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/src/components/dashboard/memory-graph-status-client.test.ts
+++ b/packages/web/src/components/dashboard/memory-graph-status-client.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { GraphStatusPayload } from "@/lib/memory-service/graph/status"
+import { fetchGraphStatusPayload, parseGraphStatusResponse } from "./memory-graph-status-client"
+
+function buildStatusFixture(): GraphStatusPayload {
+  return {
+    sampledAt: "2026-02-21T00:00:00.000Z",
+  } as unknown as GraphStatusPayload
+}
+
+describe("memory-graph-status-client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns parsed status on successful payload", () => {
+    const status = buildStatusFixture()
+    expect(parseGraphStatusResponse(true, 200, { status })).toEqual({
+      status,
+      error: null,
+    })
+  })
+
+  it("returns fallback error when successful payload is missing status", () => {
+    expect(parseGraphStatusResponse(true, 200, {})).toEqual({
+      status: null,
+      error: "Graph status response was invalid.",
+    })
+  })
+
+  it("maps http failures to a user-facing message", () => {
+    expect(parseGraphStatusResponse(false, 503, { error: "Service unavailable" })).toEqual({
+      status: null,
+      error: "Service unavailable",
+    })
+  })
+
+  it("fetches and parses graph status payload", async () => {
+    const status = buildStatusFixture()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ status }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await fetchGraphStatusPayload()
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/graph/rollout", {
+      method: "GET",
+      cache: "no-store",
+      signal: undefined,
+    })
+    expect(result).toEqual({
+      status,
+      error: null,
+    })
+  })
+})

--- a/packages/web/src/components/dashboard/memory-graph-status-client.ts
+++ b/packages/web/src/components/dashboard/memory-graph-status-client.ts
@@ -1,0 +1,54 @@
+import { extractErrorMessage } from "@/lib/client-errors"
+import type { GraphStatusPayload } from "@/lib/memory-service/graph/status"
+
+interface GraphStatusApiResponse {
+  status?: GraphStatusPayload
+  error?: string
+}
+
+export interface GraphStatusRefreshResult {
+  status: GraphStatusPayload | null
+  error: string | null
+}
+
+export function parseGraphStatusResponse(
+  responseOk: boolean,
+  statusCode: number,
+  body: unknown
+): GraphStatusRefreshResult {
+  if (!responseOk) {
+    return {
+      status: null,
+      error: extractErrorMessage(body, `Failed to refresh graph status (HTTP ${statusCode})`),
+    }
+  }
+
+  const status =
+    body && typeof body === "object" && "status" in body
+      ? ((body as GraphStatusApiResponse).status ?? null)
+      : null
+
+  if (!status) {
+    return {
+      status: null,
+      error: "Graph status response was invalid.",
+    }
+  }
+
+  return {
+    status,
+    error: null,
+  }
+}
+
+export async function fetchGraphStatusPayload(
+  signal?: AbortSignal
+): Promise<GraphStatusRefreshResult> {
+  const response = await fetch("/api/graph/rollout", {
+    method: "GET",
+    cache: "no-store",
+    signal,
+  })
+  const body = await response.json().catch(() => null)
+  return parseGraphStatusResponse(response.ok, response.status, body)
+}


### PR DESCRIPTION
## Summary
- add client-side graph status refresh helper for `GET /api/graph/rollout` with robust payload/error parsing
- add manual refresh control and background visibility-aware polling in `MemoryGraphSection`
- add unit coverage for status refresh parsing/fetch helper and update changelog

## Testing
- `pnpm -C packages/web exec vitest run src/components/dashboard/memory-graph-status-client.test.ts`
- `pnpm -C packages/web typecheck`
- `pnpm -C packages/web lint`
- `pnpm -C packages/web build`

Closes #248.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that adds periodic status polling against an existing endpoint; main risk is minor extra network traffic or stale/error states from refresh logic.
> 
> **Overview**
> The dashboard `MemoryGraphSection` now refreshes graph rollout/health status client-side, with a manual **Refresh** button and background polling (every 30s) that pauses when the tab is hidden.
> 
> This introduces a small `memory-graph-status-client` fetch/parsing helper (with abort + user-facing error handling), wires it into the UI with in-flight protection, and adds Vitest coverage plus a changelog entry documenting the live refresh behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9be44588a49c34823c02ac6abed4278833e09c7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->