### PR TITLE
fix(graph-ui): keyboard-accessible graph canvas interactions

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -22,6 +22,7 @@ description: Product and documentation updates.
 - Added structured LLM extraction degradation reporting in embedding worker metrics (`GRAPH_RELATIONSHIP_PARTIAL_DEGRADE`) with issue-level codes (`GRAPH_LLM_CLASSIFICATION_FAILED`, `GRAPH_LLM_SEMANTIC_EXTRACTION_FAILED`).
 - Optimized graph-only retry path after `GRAPH_RELATIONSHIP_SYNC_FAILED` to reuse stored embeddings and avoid redundant embeddings API calls.
 - Added live Graph Explorer status refresh (manual + background polling) so rollout health, alarms, and quality gate data stay current without page reloads.
+- Added keyboard-accessible graph canvas interactions in Graph Explorer (focusable node/edge controls with Enter/Space activation and ARIA labels).
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/src/components/dashboard/memory-graph-helpers.test.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest"
+import type { GraphCanvasEdge, GraphCanvasNode } from "./memory-graph-helpers"
+import {
+  graphEdgeAriaLabel,
+  graphNodeAriaLabel,
+  handleGraphActivationKey,
+  isGraphActivationKey,
+} from "./memory-graph-helpers"
+
+function buildNodeFixture(overrides: Partial<GraphCanvasNode> = {}): GraphCanvasNode {
+  return {
+    id: "repo:github.com/webrenew/memories",
+    nodeType: "repo",
+    nodeKey: "github.com/webrenew/memories",
+    label: "memories",
+    degree: 5,
+    x: 120,
+    y: 160,
+    isSelected: false,
+    ...overrides,
+  }
+}
+
+function buildEdgeFixture(overrides: Partial<GraphCanvasEdge> = {}): GraphCanvasEdge {
+  const from = buildNodeFixture()
+  const to = buildNodeFixture({
+    id: "topic:graph",
+    nodeType: "topic",
+    nodeKey: "graph",
+    label: "graph",
+  })
+
+  return {
+    id: "edge-1",
+    edgeType: "similar_to",
+    weight: 0.84,
+    confidence: 0.91,
+    expiresAt: null,
+    evidenceMemoryId: "mem_123",
+    direction: "outbound",
+    from,
+    to,
+    fromId: from.id,
+    toId: to.id,
+    path: "M0 0",
+    labelX: 10,
+    labelY: 15,
+    ...overrides,
+  }
+}
+
+describe("memory-graph-helpers keyboard activation", () => {
+  it("recognizes Enter and Space keys as activation keys", () => {
+    expect(isGraphActivationKey("Enter")).toBe(true)
+    expect(isGraphActivationKey(" ")).toBe(true)
+    expect(isGraphActivationKey("Spacebar")).toBe(true)
+    expect(isGraphActivationKey("Escape")).toBe(false)
+  })
+
+  it("activates selection handlers on Enter or Space keydown", () => {
+    const onActivate = vi.fn()
+    const preventDefault = vi.fn()
+
+    const enterActivated = handleGraphActivationKey({ key: "Enter", preventDefault }, onActivate)
+    const spaceActivated = handleGraphActivationKey({ key: " ", preventDefault }, onActivate)
+
+    expect(enterActivated).toBe(true)
+    expect(spaceActivated).toBe(true)
+    expect(onActivate).toHaveBeenCalledTimes(2)
+    expect(preventDefault).toHaveBeenCalledTimes(2)
+  })
+
+  it("ignores non-activation keys", () => {
+    const onActivate = vi.fn()
+    const preventDefault = vi.fn()
+
+    const activated = handleGraphActivationKey({ key: "Escape", preventDefault }, onActivate)
+
+    expect(activated).toBe(false)
+    expect(onActivate).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+})
+
+describe("memory-graph-helpers aria labels", () => {
+  it("formats node aria labels with key node details", () => {
+    const label = graphNodeAriaLabel(buildNodeFixture())
+    expect(label).toContain("Graph node memories")
+    expect(label).toContain("Type repo")
+    expect(label).toContain("Degree 5")
+  })
+
+  it("formats edge aria labels with direction and quality metadata", () => {
+    const label = graphEdgeAriaLabel(buildEdgeFixture())
+    expect(label).toContain("Graph edge similar_to")
+    expect(label).toContain("outbound")
+    expect(label).toContain("From repo:github.com/webrenew/memories")
+    expect(label).toContain("to topic:graph")
+    expect(label).toContain("Weight 0.84")
+    expect(label).toContain("Confidence 0.91")
+  })
+})

--- a/packages/web/src/components/dashboard/memory-graph-helpers.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.ts
@@ -116,6 +116,31 @@ export function truncateText(value: string, max = 180): string {
   return `${value.slice(0, max).trim()}...`
 }
 
+export function isGraphActivationKey(key: string): boolean {
+  return key === "Enter" || key === " " || key === "Spacebar"
+}
+
+export function handleGraphActivationKey(
+  event: Pick<KeyboardEvent, "key" | "preventDefault">,
+  onActivate: () => void
+): boolean {
+  if (!isGraphActivationKey(event.key)) {
+    return false
+  }
+
+  event.preventDefault()
+  onActivate()
+  return true
+}
+
+export function graphNodeAriaLabel(node: GraphCanvasNode): string {
+  return `Graph node ${node.label}. Type ${node.nodeType}. Degree ${node.degree}.`
+}
+
+export function graphEdgeAriaLabel(edge: GraphCanvasEdge): string {
+  return `Graph edge ${edge.edgeType}. ${edge.direction}. From ${edge.from.nodeType}:${edge.from.nodeKey} to ${edge.to.nodeType}:${edge.to.nodeKey}. Weight ${edge.weight.toFixed(2)}. Confidence ${edge.confidence.toFixed(2)}.`
+}
+
 export function nodeRefId(node: GraphNodeSelection): string {
   return `${node.nodeType}:${node.nodeKey}`
 }


### PR DESCRIPTION
## Summary
- make graph edges and nodes keyboard-focusable with `tabIndex`, ARIA labels, and Enter/Space activation parity
- add focus-state visual affordances for edge and node selection in the graph canvas
- add keyboard/a11y helper utilities with regression tests and update changelog

## Testing
- `pnpm -C packages/web exec vitest run src/components/dashboard/memory-graph-helpers.test.ts src/components/dashboard/memory-graph-status-client.test.ts`
- `pnpm -C packages/web typecheck`
- `pnpm -C packages/web lint`
- `pnpm -C packages/web build`

Closes #249.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only accessibility and interaction tweaks confined to the graph explorer, with lightweight helper functions and tests; minimal risk beyond potential minor interaction/regression in selection/focus handling.
> 
> **Overview**
> Graph Explorer’s SVG nodes and edges are now keyboard accessible: they are tabbable, expose ARIA labels, and support Enter/Space to activate the same selection behavior as clicks.
> 
> Adds focus tracking and visual affordances (highlighted strokes/labels and label visibility when focused) and resets focus state when the selected node changes. Introduces small a11y helper utilities in `memory-graph-helpers.ts` with new Vitest coverage, and records the change in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42fdf22dc3c3c118a7f2702590fe510ef6e99d19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->