### PR TITLE
fix(graph-ui): cancel stale graph explore requests

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -23,6 +23,7 @@ description: Product and documentation updates.
 - Optimized graph-only retry path after `GRAPH_RELATIONSHIP_SYNC_FAILED` to reuse stored embeddings and avoid redundant embeddings API calls.
 - Added live Graph Explorer status refresh (manual + background polling) so rollout health, alarms, and quality gate data stay current without page reloads.
 - Added keyboard-accessible graph canvas interactions in Graph Explorer (focusable node/edge controls with Enter/Space activation and ARIA labels).
+- Updated Graph Explorer node switching to cancel stale `/api/graph/explore` requests using `AbortController`, reducing redundant in-flight fetches during rapid navigation.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/src/components/dashboard/memory-graph-helpers.test.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   graphEdgeAriaLabel,
   graphNodeAriaLabel,
   handleGraphActivationKey,
+  isAbortLikeError,
   isGraphActivationKey,
 } from "./memory-graph-helpers"
 
@@ -98,5 +99,14 @@ describe("memory-graph-helpers aria labels", () => {
     expect(label).toContain("to topic:graph")
     expect(label).toContain("Weight 0.84")
     expect(label).toContain("Confidence 0.91")
+  })
+})
+
+describe("memory-graph-helpers abort detection", () => {
+  it("detects AbortError by name", () => {
+    expect(isAbortLikeError({ name: "AbortError" })).toBe(true)
+    expect(isAbortLikeError(new Error("network"))).toBe(false)
+    expect(isAbortLikeError({ name: "TypeError" })).toBe(false)
+    expect(isAbortLikeError(null)).toBe(false)
   })
 })

--- a/packages/web/src/components/dashboard/memory-graph-helpers.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.ts
@@ -133,6 +133,15 @@ export function handleGraphActivationKey(
   return true
 }
 
+export function isAbortLikeError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false
+  }
+
+  const name = "name" in error ? (error as { name?: unknown }).name : undefined
+  return typeof name === "string" && name === "AbortError"
+}
+
 export function graphNodeAriaLabel(node: GraphCanvasNode): string {
   return `Graph node ${node.label}. Type ${node.nodeType}. Degree ${node.degree}.`
 }


### PR DESCRIPTION
## Summary
- switch Graph Explorer node-neighborhood loading to `AbortController`-driven fetch cancellation
- avoid surfacing aborted requests as user-visible network errors during rapid node switching
- add `isAbortLikeError` helper + tests and update changelog notes

## Testing
- `pnpm -C packages/web exec vitest run src/components/dashboard/memory-graph-helpers.test.ts src/components/dashboard/memory-graph-status-client.test.ts`
- `pnpm -C packages/web typecheck`
- `pnpm -C packages/web lint`
- `pnpm -C packages/web build`

Closes #246.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-side request-cancellation change scoped to Graph Explorer fetches; low risk beyond potential edge cases in abort detection or loading-state updates.
> 
> **Overview**
> Graph Explorer node-neighborhood loading now uses `AbortController` to cancel stale `/api/graph/explore` fetches during rapid node switching, instead of relying on a manual `cancelled` flag.
> 
> Adds a shared `isAbortLikeError` helper (with tests) and updates status refresh + explorer error handling/loading state to ignore aborted requests rather than surfacing them as network errors. Changelog entry is updated to reflect the new cancellation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02048d16a05f36aeb29443045746905a3c4f3fe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->