### PR TITLE
fix(graph-ui): stabilize wheel zoom updates

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -24,6 +24,7 @@ description: Product and documentation updates.
 - Added live Graph Explorer status refresh (manual + background polling) so rollout health, alarms, and quality gate data stay current without page reloads.
 - Added keyboard-accessible graph canvas interactions in Graph Explorer (focusable node/edge controls with Enter/Space activation and ARIA labels).
 - Updated Graph Explorer node switching to cancel stale `/api/graph/explore` requests using `AbortController`, reducing redundant in-flight fetches during rapid navigation.
+- Stabilized Graph Explorer wheel zoom behavior so rapid scroll events compose against the latest viewport state without dropping zoom steps.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/src/components/dashboard/memory-graph-helpers.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.ts
@@ -81,6 +81,24 @@ export const DEFAULT_GRAPH_VIEWPORT: GraphViewport = {
   y: 0,
 }
 
+export function scaleViewportAtPoint(
+  viewport: GraphViewport,
+  scaleMultiplier: number,
+  anchor: { x: number; y: number }
+): GraphViewport {
+  const clampedScale = clamp(viewport.scale * scaleMultiplier, GRAPH_ZOOM_MIN, GRAPH_ZOOM_MAX)
+  if (clampedScale === viewport.scale) {
+    return viewport
+  }
+
+  const ratio = clampedScale / viewport.scale
+  return {
+    scale: clampedScale,
+    x: anchor.x - (anchor.x - viewport.x) * ratio,
+    y: anchor.y - (anchor.y - viewport.y) * ratio,
+  }
+}
+
 export const NODE_TYPE_STYLES: Record<string, { fill: string; stroke: string; text: string }> = {
   repo: { fill: "rgba(56, 189, 248, 0.16)", stroke: "#38bdf8", text: "#d8f3ff" },
   topic: { fill: "rgba(16, 185, 129, 0.16)", stroke: "#10b981", text: "#dcfce7" },


### PR DESCRIPTION
## Summary
- add `scaleViewportAtPoint()` helper to compute zoom transforms from the latest viewport state
- update wheel zoom handling to compose scale updates via functional state, avoiding stale closure scale reads
- add helper tests for repeated zoom composition + min/max clamping, and update changelog

## Testing
- `pnpm -C packages/web exec vitest run src/components/dashboard/memory-graph-helpers.test.ts src/components/dashboard/memory-graph-status-client.test.ts`
- `pnpm -C packages/web typecheck`
- `pnpm -C packages/web lint`
- `pnpm -C packages/web build`

Closes #247.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI behavior change plus helper refactor and new tests; risk is limited to zoom/viewport interactions in the dashboard graph explorer.
> 
> **Overview**
> Graph Explorer wheel zoom now updates the viewport using a shared `scaleViewportAtPoint` helper and functional `setGraphViewport` updates, preventing rapid scroll events from applying against stale `scale` state and dropping zoom steps.
> 
> Adds unit tests covering repeated zoom composition and min/max clamping, and updates the changelog to note the stabilized wheel zoom behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb571028b82140545d026151d2aaeee704b7f9b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->