### PR TITLE
fix(graph-ui): clamp minimap viewport at low zoom

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -25,6 +25,7 @@ description: Product and documentation updates.
 - Added keyboard-accessible graph canvas interactions in Graph Explorer (focusable node/edge controls with Enter/Space activation and ARIA labels).
 - Updated Graph Explorer node switching to cancel stale `/api/graph/explore` requests using `AbortController`, reducing redundant in-flight fetches during rapid navigation.
 - Stabilized Graph Explorer wheel zoom behavior so rapid scroll events compose against the latest viewport state without dropping zoom steps.
+- Clamped Graph Explorer mini-map viewport geometry at low zoom to keep viewport bounds inside the graph canvas extent.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/src/components/dashboard/MemoryGraphSection.tsx
+++ b/packages/web/src/components/dashboard/MemoryGraphSection.tsx
@@ -20,6 +20,7 @@ import {
   type GraphRolloutMode,
   type GraphViewport,
   buildGraphCanvasModel,
+  buildMiniMapViewport,
   clamp,
   DEFAULT_GRAPH_VIEWPORT,
   formatNodeLabel,
@@ -593,28 +594,8 @@ export function MemoryGraphSection({ status }: MemoryGraphSectionProps): React.J
 
   const miniMapViewport = useMemo(() => {
     if (!filteredGraph || filteredGraph.nodes.length === 0) return null
-
-    const width = 172
-    const height = 98
-    const viewportWidth = GRAPH_WIDTH / graphViewport.scale
-    const viewportHeight = GRAPH_HEIGHT / graphViewport.scale
-    const rawViewportX = (-graphViewport.x) / graphViewport.scale
-    const rawViewportY = (-graphViewport.y) / graphViewport.scale
-    const maxViewportX = Math.max(0, GRAPH_WIDTH - viewportWidth)
-    const maxViewportY = Math.max(0, GRAPH_HEIGHT - viewportHeight)
-
-    const viewportX = clamp(rawViewportX, 0, maxViewportX)
-    const viewportY = clamp(rawViewportY, 0, maxViewportY)
-
-    return {
-      width,
-      height,
-      viewportX,
-      viewportY,
-      viewportWidth,
-      viewportHeight,
-    }
-  }, [filteredGraph, graphViewport.scale, graphViewport.x, graphViewport.y])
+    return buildMiniMapViewport(graphViewport)
+  }, [filteredGraph, graphViewport])
 
   const updateRolloutMode = (mode: GraphRolloutMode) => {
     if (!activeStatus || activeStatus.rollout.mode === mode) {

--- a/packages/web/src/components/dashboard/memory-graph-helpers.test.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 import type { GraphCanvasEdge, GraphCanvasNode } from "./memory-graph-helpers"
 import {
+  buildMiniMapViewport,
+  GRAPH_HEIGHT,
+  GRAPH_WIDTH,
   GRAPH_ZOOM_MAX,
   GRAPH_ZOOM_MIN,
   GRAPH_ZOOM_STEP,
@@ -132,5 +135,35 @@ describe("memory-graph-helpers viewport scaling", () => {
 
     expect(maxed.scale).toBe(GRAPH_ZOOM_MAX)
     expect(mined.scale).toBe(GRAPH_ZOOM_MIN)
+  })
+})
+
+describe("memory-graph-helpers minimap viewport", () => {
+  it("clamps low-zoom viewport extents to graph bounds", () => {
+    const miniMap = buildMiniMapViewport({
+      scale: 0.5,
+      x: -400,
+      y: -260,
+    })
+
+    expect(miniMap.viewportWidth).toBe(GRAPH_WIDTH)
+    expect(miniMap.viewportHeight).toBe(GRAPH_HEIGHT)
+    expect(miniMap.viewportX).toBe(0)
+    expect(miniMap.viewportY).toBe(0)
+  })
+
+  it("keeps viewport origin within bounds at higher zoom levels", () => {
+    const miniMap = buildMiniMapViewport({
+      scale: 2,
+      x: -900,
+      y: -800,
+    })
+
+    expect(miniMap.viewportWidth).toBeCloseTo(GRAPH_WIDTH / 2, 6)
+    expect(miniMap.viewportHeight).toBeCloseTo(GRAPH_HEIGHT / 2, 6)
+    expect(miniMap.viewportX).toBeGreaterThanOrEqual(0)
+    expect(miniMap.viewportY).toBeGreaterThanOrEqual(0)
+    expect(miniMap.viewportX + miniMap.viewportWidth).toBeLessThanOrEqual(GRAPH_WIDTH)
+    expect(miniMap.viewportY + miniMap.viewportHeight).toBeLessThanOrEqual(GRAPH_HEIGHT)
   })
 })

--- a/packages/web/src/components/dashboard/memory-graph-helpers.ts
+++ b/packages/web/src/components/dashboard/memory-graph-helpers.ts
@@ -63,6 +63,15 @@ export interface GraphViewport {
   y: number
 }
 
+export interface MiniMapViewport {
+  width: number
+  height: number
+  viewportX: number
+  viewportY: number
+  viewportWidth: number
+  viewportHeight: number
+}
+
 export const ROLLOUT_MODES: Array<{ value: GraphRolloutMode; label: string; description: string }> = [
   { value: "off", label: "Off", description: "Always serve baseline retrieval." },
   { value: "shadow", label: "Shadow", description: "Run graph retrieval without applying it." },
@@ -96,6 +105,28 @@ export function scaleViewportAtPoint(
     scale: clampedScale,
     x: anchor.x - (anchor.x - viewport.x) * ratio,
     y: anchor.y - (anchor.y - viewport.y) * ratio,
+  }
+}
+
+export function buildMiniMapViewport(viewport: GraphViewport): MiniMapViewport {
+  const width = 172
+  const height = 98
+  const unclampedViewportWidth = GRAPH_WIDTH / viewport.scale
+  const unclampedViewportHeight = GRAPH_HEIGHT / viewport.scale
+  const viewportWidth = clamp(unclampedViewportWidth, 0, GRAPH_WIDTH)
+  const viewportHeight = clamp(unclampedViewportHeight, 0, GRAPH_HEIGHT)
+  const rawViewportX = (-viewport.x) / viewport.scale
+  const rawViewportY = (-viewport.y) / viewport.scale
+  const maxViewportX = Math.max(0, GRAPH_WIDTH - viewportWidth)
+  const maxViewportY = Math.max(0, GRAPH_HEIGHT - viewportHeight)
+
+  return {
+    width,
+    height,
+    viewportX: clamp(rawViewportX, 0, maxViewportX),
+    viewportY: clamp(rawViewportY, 0, maxViewportY),
+    viewportWidth,
+    viewportHeight,
   }
 }
 


### PR DESCRIPTION
## Summary
- extract mini-map viewport geometry into `buildMiniMapViewport()` helper
- clamp viewport width/height and origin so low-zoom states cannot overflow graph bounds
- add regression tests for low-zoom and high-zoom minimap behavior and update changelog

## Testing
- `pnpm -C packages/web exec vitest run src/components/dashboard/memory-graph-helpers.test.ts src/components/dashboard/memory-graph-status-client.test.ts`
- `pnpm -C packages/web typecheck`
- `pnpm -C packages/web lint`
- `pnpm -C packages/web build`

Closes #252.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only viewport math refactor with added tests; minimal risk aside from potential visual regressions in minimap positioning/sizing.
> 
> **Overview**
> Fixes Graph Explorer’s mini-map viewport rendering at low zoom by extracting the geometry calculation into `buildMiniMapViewport()` and clamping both viewport size and origin to stay within `GRAPH_WIDTH`/`GRAPH_HEIGHT`.
> 
> Updates `MemoryGraphSection` to use the new helper, adds regression tests for low-zoom and higher-zoom minimap behavior, and documents the change in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3a54c635438da9b828de4e4c46b413be03c7230. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->