### PR TITLE
test(graph-ui): add interaction projection coverage

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -26,6 +26,7 @@ description: Product and documentation updates.
 - Updated Graph Explorer node switching to cancel stale `/api/graph/explore` requests using `AbortController`, reducing redundant in-flight fetches during rapid navigation.
 - Stabilized Graph Explorer wheel zoom behavior so rapid scroll events compose against the latest viewport state without dropping zoom steps.
 - Clamped Graph Explorer mini-map viewport geometry at low zoom to keep viewport bounds inside the graph canvas extent.
+- Added Graph Explorer interaction logic tests (filtering, selected-edge fallback, zoom/minimap math, and node-stat summaries).
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 


### PR DESCRIPTION
## Summary
- extract Graph Explorer interaction projection logic into memory-graph-helpers
- cover filter projection, selected-edge fallback, and node-stat summarization with focused helper tests
- document Graph Explorer interaction test coverage in changelog

## Validation
- pnpm -C packages/web exec vitest run src/components/dashboard/memory-graph-helpers.test.ts src/components/dashboard/memory-graph-status-client.test.ts
- pnpm -C packages/web lint
- pnpm -C packages/web build
- pnpm -C packages/web typecheck

Closes #251.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor with added unit tests and documentation; behavior should remain equivalent aside from any subtle edge-case differences in filtering/selection logic.
> 
> **Overview**
> Graph Explorer’s *interaction projection* logic is extracted from `MemoryGraphSection` into new reusable helpers in `memory-graph-helpers` (`filterGraphCanvasModel`, `resolveSelectedGraphEdge`, `summarizeGraphNodeStats`), replacing inline filtering/selection/stats computations.
> 
> Adds targeted `vitest` coverage for these projections (filtering behavior, selected-edge fallback, and stats summarization) and updates the changelog to note the new interaction-logic tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d9316c9296645569e0e518bfe24f8884542b867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->