### PR TITLE
feat(graph-ui): persist Graph Explorer filters in URL state

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -27,6 +27,7 @@ description: Product and documentation updates.
 - Stabilized Graph Explorer wheel zoom behavior so rapid scroll events compose against the latest viewport state without dropping zoom steps.
 - Clamped Graph Explorer mini-map viewport geometry at low zoom to keep viewport bounds inside the graph canvas extent.
 - Added Graph Explorer interaction logic tests (filtering, selected-edge fallback, zoom/minimap math, and node-stat summaries).
+- Persisted Graph Explorer filters in URL state (edge/node type selections, thresholds, evidence-only) for shareable deep links.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/src/components/dashboard/MemoryGraphSection.tsx
+++ b/packages/web/src/components/dashboard/MemoryGraphSection.tsx
@@ -118,6 +118,15 @@ export function MemoryGraphSection({ status }: MemoryGraphSectionProps): React.J
     }
 
     setIsFocusMode(urlState.isFocusMode)
+    if (urlState.filters.edgeTypes) {
+      setEdgeTypeFilter(urlState.filters.edgeTypes)
+    }
+    if (urlState.filters.nodeTypes) {
+      setNodeTypeFilter(urlState.filters.nodeTypes)
+    }
+    setMinWeight(urlState.filters.minWeight)
+    setMinConfidence(urlState.filters.minConfidence)
+    setOnlyEvidenceEdges(urlState.filters.onlyEvidenceEdges)
 
     setUrlHydrated(true)
   }, [])
@@ -308,6 +317,32 @@ export function MemoryGraphSection({ status }: MemoryGraphSectionProps): React.J
   const selectedEdge = useMemo(() => {
     return resolveSelectedGraphEdge(filteredGraph, selectedEdgeId)
   }, [filteredGraph, selectedEdgeId])
+  const persistedEdgeTypeFilter = useMemo(() => {
+    if (edgeTypeFilter.length === 0) return null
+    const normalizedCurrent = [...new Set(edgeTypeFilter)].sort()
+    if (edgeTypeOptions.length === 0) {
+      return normalizedCurrent
+    }
+
+    const normalizedOptions = [...edgeTypeOptions].sort()
+    const isDefaultSelection =
+      normalizedCurrent.length === normalizedOptions.length &&
+      normalizedCurrent.every((value, index) => value === normalizedOptions[index])
+    return isDefaultSelection ? null : normalizedCurrent
+  }, [edgeTypeFilter, edgeTypeOptions])
+  const persistedNodeTypeFilter = useMemo(() => {
+    if (nodeTypeFilter.length === 0) return null
+    const normalizedCurrent = [...new Set(nodeTypeFilter)].sort()
+    if (nodeTypeOptions.length === 0) {
+      return normalizedCurrent
+    }
+
+    const normalizedOptions = [...nodeTypeOptions].sort()
+    const isDefaultSelection =
+      normalizedCurrent.length === normalizedOptions.length &&
+      normalizedCurrent.every((value, index) => value === normalizedOptions[index])
+    return isDefaultSelection ? null : normalizedCurrent
+  }, [nodeTypeFilter, nodeTypeOptions])
 
   useEffect(() => {
     if (!graphCanvas) {
@@ -350,6 +385,13 @@ export function MemoryGraphSection({ status }: MemoryGraphSectionProps): React.J
       selectedNode,
       selectedEdgeId,
       isFocusMode,
+      filters: {
+        edgeTypes: persistedEdgeTypeFilter,
+        nodeTypes: persistedNodeTypeFilter,
+        minWeight,
+        minConfidence,
+        onlyEvidenceEdges,
+      },
     })
 
     const nextPath = graphUrlToRelativePath(nextUrl)
@@ -358,7 +400,14 @@ export function MemoryGraphSection({ status }: MemoryGraphSectionProps): React.J
       window.history.replaceState({}, "", nextPath)
     }
   }, [
+    edgeTypeFilter,
     isFocusMode,
+    minConfidence,
+    minWeight,
+    nodeTypeFilter,
+    onlyEvidenceEdges,
+    persistedEdgeTypeFilter,
+    persistedNodeTypeFilter,
     selectedEdgeId,
     selectedNode,
     selectedNode?.label,

--- a/packages/web/src/lib/graph-url-state.test.ts
+++ b/packages/web/src/lib/graph-url-state.test.ts
@@ -4,7 +4,7 @@ import { applyGraphUrlState, graphUrlToRelativePath, parseGraphUrlState } from "
 describe("graph-url-state", () => {
   it("parses selected node, edge, and focus state from search params", () => {
     const state = parseGraphUrlState(
-      "?graph_node_type=skill&graph_node_key=lint&graph_node_label=Lint+Skill&graph_edge_id=edge-1&graph_focus=1",
+      "?graph_node_type=skill&graph_node_key=lint&graph_node_label=Lint+Skill&graph_edge_id=edge-1&graph_focus=1&graph_et=similar_to,contradicts&graph_nt=repo,topic&graph_mw=0.5&graph_mc=0.75&graph_ev=1",
     )
 
     expect(state).toEqual({
@@ -15,6 +15,13 @@ describe("graph-url-state", () => {
       },
       selectedEdgeId: "edge-1",
       isFocusMode: true,
+      filters: {
+        edgeTypes: ["similar_to", "contradicts"],
+        nodeTypes: ["repo", "topic"],
+        minWeight: 0.5,
+        minConfidence: 0.75,
+        onlyEvidenceEdges: true,
+      },
     })
   })
 
@@ -25,6 +32,24 @@ describe("graph-url-state", () => {
       nodeType: "repo",
       nodeKey: "memories",
       label: "repo:memories",
+    })
+    expect(state.filters).toEqual({
+      edgeTypes: null,
+      nodeTypes: null,
+      minWeight: 0,
+      minConfidence: 0,
+      onlyEvidenceEdges: false,
+    })
+  })
+
+  it("normalizes invalid ratio filters to defaults", () => {
+    const state = parseGraphUrlState("?graph_mw=-1&graph_mc=wat")
+    expect(state.filters).toEqual({
+      edgeTypes: null,
+      nodeTypes: null,
+      minWeight: 0,
+      minConfidence: 0,
+      onlyEvidenceEdges: false,
     })
   })
 
@@ -39,22 +64,36 @@ describe("graph-url-state", () => {
       },
       selectedEdgeId: "edge-7",
       isFocusMode: true,
+      filters: {
+        edgeTypes: ["similar_to", "contradicts"],
+        nodeTypes: ["repo", "topic"],
+        minWeight: 0.5,
+        minConfidence: 0.75,
+        onlyEvidenceEdges: true,
+      },
     })
 
     expect(graphUrlToRelativePath(url)).toBe(
-      "/app/graph-explorer?tab=overview&graph_node_type=repo&graph_node_key=github.com%2Fmemories&graph_node_label=Memories+Repo&graph_edge_id=edge-7&graph_focus=1#graph",
+      "/app/graph-explorer?tab=overview&graph_node_type=repo&graph_node_key=github.com%2Fmemories&graph_node_label=Memories+Repo&graph_edge_id=edge-7&graph_focus=1&graph_et=similar_to%2Ccontradicts&graph_nt=repo%2Ctopic&graph_mw=0.5&graph_mc=0.75&graph_ev=1#graph",
     )
   })
 
   it("clears graph params when state is reset", () => {
     const url = new URL(
-      "https://example.com/app/graph-explorer?graph_node_type=repo&graph_node_key=memories&graph_node_label=Memories&graph_edge_id=e1&graph_focus=1&tab=overview",
+      "https://example.com/app/graph-explorer?graph_node_type=repo&graph_node_key=memories&graph_node_label=Memories&graph_edge_id=e1&graph_focus=1&graph_et=similar_to&graph_nt=repo&graph_mw=0.4&graph_mc=0.3&graph_ev=1&tab=overview",
     )
 
     applyGraphUrlState(url, {
       selectedNode: null,
       selectedEdgeId: null,
       isFocusMode: false,
+      filters: {
+        edgeTypes: null,
+        nodeTypes: null,
+        minWeight: 0,
+        minConfidence: 0,
+        onlyEvidenceEdges: false,
+      },
     })
 
     expect(graphUrlToRelativePath(url)).toBe("/app/graph-explorer?tab=overview")

--- a/packages/web/src/lib/graph-url-state.ts
+++ b/packages/web/src/lib/graph-url-state.ts
@@ -4,10 +4,19 @@ interface GraphUrlNodeSelection {
   label: string
 }
 
+interface GraphUrlFilterState {
+  edgeTypes: string[] | null
+  nodeTypes: string[] | null
+  minWeight: number
+  minConfidence: number
+  onlyEvidenceEdges: boolean
+}
+
 interface GraphUrlState {
   selectedNode: GraphUrlNodeSelection | null
   selectedEdgeId: string | null
   isFocusMode: boolean
+  filters: GraphUrlFilterState
 }
 
 const NODE_TYPE_PARAM = "graph_node_type"
@@ -15,6 +24,29 @@ const NODE_KEY_PARAM = "graph_node_key"
 const NODE_LABEL_PARAM = "graph_node_label"
 const EDGE_ID_PARAM = "graph_edge_id"
 const FOCUS_PARAM = "graph_focus"
+const EDGE_TYPES_PARAM = "graph_et"
+const NODE_TYPES_PARAM = "graph_nt"
+const MIN_WEIGHT_PARAM = "graph_mw"
+const MIN_CONFIDENCE_PARAM = "graph_mc"
+const EVIDENCE_ONLY_PARAM = "graph_ev"
+
+function parseListParam(value: string | null): string[] | null {
+  if (!value) return null
+  const values = value.split(",").map((item) => item.trim()).filter(Boolean)
+  if (values.length === 0) return null
+  return [...new Set(values)]
+}
+
+function parseNormalizedRatio(value: string | null): number {
+  if (!value) return 0
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 0
+  return Math.max(0, Math.min(1, parsed))
+}
+
+function toCompactRatioString(value: number): string {
+  return Number(value.toFixed(2)).toString()
+}
 
 export function parseGraphUrlState(search: string): GraphUrlState {
   const params = new URLSearchParams(search)
@@ -35,6 +67,13 @@ export function parseGraphUrlState(search: string): GraphUrlState {
     selectedNode,
     selectedEdgeId: params.get(EDGE_ID_PARAM),
     isFocusMode: params.get(FOCUS_PARAM) === "1",
+    filters: {
+      edgeTypes: parseListParam(params.get(EDGE_TYPES_PARAM)),
+      nodeTypes: parseListParam(params.get(NODE_TYPES_PARAM)),
+      minWeight: parseNormalizedRatio(params.get(MIN_WEIGHT_PARAM)),
+      minConfidence: parseNormalizedRatio(params.get(MIN_CONFIDENCE_PARAM)),
+      onlyEvidenceEdges: params.get(EVIDENCE_ONLY_PARAM) === "1",
+    },
   }
 }
 
@@ -59,6 +98,36 @@ export function applyGraphUrlState(url: URL, state: GraphUrlState): void {
     url.searchParams.set(FOCUS_PARAM, "1")
   } else {
     url.searchParams.delete(FOCUS_PARAM)
+  }
+
+  if (state.filters.edgeTypes && state.filters.edgeTypes.length > 0) {
+    url.searchParams.set(EDGE_TYPES_PARAM, state.filters.edgeTypes.join(","))
+  } else {
+    url.searchParams.delete(EDGE_TYPES_PARAM)
+  }
+
+  if (state.filters.nodeTypes && state.filters.nodeTypes.length > 0) {
+    url.searchParams.set(NODE_TYPES_PARAM, state.filters.nodeTypes.join(","))
+  } else {
+    url.searchParams.delete(NODE_TYPES_PARAM)
+  }
+
+  if (state.filters.minWeight > 0) {
+    url.searchParams.set(MIN_WEIGHT_PARAM, toCompactRatioString(state.filters.minWeight))
+  } else {
+    url.searchParams.delete(MIN_WEIGHT_PARAM)
+  }
+
+  if (state.filters.minConfidence > 0) {
+    url.searchParams.set(MIN_CONFIDENCE_PARAM, toCompactRatioString(state.filters.minConfidence))
+  } else {
+    url.searchParams.delete(MIN_CONFIDENCE_PARAM)
+  }
+
+  if (state.filters.onlyEvidenceEdges) {
+    url.searchParams.set(EVIDENCE_ONLY_PARAM, "1")
+  } else {
+    url.searchParams.delete(EVIDENCE_ONLY_PARAM)
   }
 }
 


### PR DESCRIPTION
## Summary
- extend graph URL state parser/serializer with compact filter params for edge types, node types, thresholds, and evidence-only mode
- hydrate Graph Explorer filter controls from URL on initial load
- persist non-default filter state into shareable deep links while preserving backwards compatibility for existing graph URLs
- add parser/serializer tests for the new URL filter fields

## Validation
- pnpm -C packages/web exec vitest run src/lib/graph-url-state.test.ts src/components/dashboard/memory-graph-helpers.test.ts src/components/dashboard/memory-graph-status-client.test.ts
- pnpm -C packages/web lint
- pnpm -C packages/web build
- pnpm -C packages/web typecheck

Closes #250.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only state serialization changes with straightforward parsing/normalization; main risk is minor URL/back-compat or deep-link hydration edge cases.
> 
> **Overview**
> Graph Explorer URLs now persist filter state (edge/node type selections, min weight/confidence thresholds, and evidence-only mode) via new compact query params added to `parseGraphUrlState`/`applyGraphUrlState`.
> 
> `MemoryGraphSection` hydrates filter controls from the URL on initial load and updates the URL as filters change while omitting default/all-selected values to keep links tidy. Tests were expanded to cover parsing, normalization of invalid ratio values, serialization, and clearing of the new filter params, and the changelog documents the new deep-linking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd9a8255d7558e9145e4031309bb88de12db6b16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->