### PR TITLE
feat(api-keys): support multiple active API keys

### DIFF
--- a/packages/core/src/client-schemas.ts
+++ b/packages/core/src/client-schemas.ts
@@ -152,14 +152,26 @@ export const vacuumResultSchema = z.object({
 
 export const managementKeyStatusSchema = z.object({
   hasKey: z.boolean(),
+  keyCount: z.number().int().nonnegative().optional(),
+  activeKeyCount: z.number().int().nonnegative().optional(),
   keyPreview: z.string().optional(),
   createdAt: z.string().nullable().optional(),
   expiresAt: z.string().nullable().optional(),
   isExpired: z.boolean().optional(),
+  keys: z.array(
+    z.object({
+      id: z.string(),
+      keyPreview: z.string().nullable().optional(),
+      createdAt: z.string().nullable().optional(),
+      expiresAt: z.string().nullable().optional(),
+      isExpired: z.boolean().optional(),
+    })
+  ).optional(),
 })
 
 export const managementKeyCreateSchema = z.object({
   apiKey: z.string(),
+  keyId: z.string().optional(),
   keyPreview: z.string().optional(),
   createdAt: z.string().optional(),
   expiresAt: z.string().optional(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -222,10 +222,19 @@ export interface VacuumResult {
 
 export interface ManagementKeyStatus {
   hasKey: boolean
+  keyCount?: number
+  activeKeyCount?: number
   keyPreview?: string
   createdAt?: string | null
   expiresAt?: string | null
   isExpired?: boolean
+  keys?: Array<{
+    id: string
+    keyPreview?: string | null
+    createdAt?: string | null
+    expiresAt?: string | null
+    isExpired?: boolean
+  }>
 }
 
 export interface ManagementKeyCreateInput {
@@ -234,6 +243,7 @@ export interface ManagementKeyCreateInput {
 
 export interface ManagementKeyCreateResult {
   apiKey: string
+  keyId?: string
   keyPreview?: string
   createdAt?: string
   expiresAt?: string

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -28,6 +28,7 @@ description: Product and documentation updates.
 - Clamped Graph Explorer mini-map viewport geometry at low zoom to keep viewport bounds inside the graph canvas extent.
 - Added Graph Explorer interaction logic tests (filtering, selected-edge fallback, zoom/minimap math, and node-stat summaries).
 - Persisted Graph Explorer filters in URL state (edge/node type selections, thresholds, evidence-only) for shareable deep links.
+- Added multi-key API key management: users can create multiple active `mem_` keys, list key metadata, and revoke individual keys without rotating all keys.
 - Updated memory graph architecture docs to document memory nodes and self-link behavior.
 - Expanded graph + MCP docs with edge weight tables, contradiction/semantic extraction pipeline guidance, conflict payload schemas/examples, and skills guidance for conflict-aware agent handling.
 

--- a/packages/web/content/docs/sdk/endpoint-contract.mdx
+++ b/packages/web/content/docs/sdk/endpoint-contract.mdx
@@ -656,9 +656,9 @@ Response `data`:
 
 ### `GET|POST|DELETE /api/sdk/v1/management/keys`
 
-- `GET`: current key status (`hasKey`, `keyPreview`, `createdAt`, `expiresAt`, `isExpired`)
-- `POST`: rotate key with `expiresAt` body
-- `DELETE`: revoke key
+- `GET`: current key status plus key inventory (`hasKey`, `keyCount`, `activeKeyCount`, primary preview timestamps, and `keys[]`)
+- `POST`: create an additional key with `expiresAt` body (returns new `apiKey` once)
+- `DELETE`: revoke all keys, or revoke one key when `keyId` query param is provided
 
 `POST` request:
 
@@ -666,6 +666,13 @@ Response `data`:
 {
   "expiresAt": "2027-01-01T00:00:00.000Z"
 }
+```
+
+`DELETE` examples:
+
+```http
+DELETE /api/sdk/v1/management/keys
+DELETE /api/sdk/v1/management/keys?keyId=3c02d4fd-6f3d-4f7f-a190-9dc7527dd0b3
 ```
 
 ### `GET|POST|DELETE /api/sdk/v1/management/tenant-overrides`

--- a/packages/web/src/app/api/db/credentials/__tests__/route.test.ts
+++ b/packages/web/src/app/api/db/credentials/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { hashMcpApiKey } from "@/lib/mcp-api-key"
 
 const {
   mockAuthenticateRequest,
@@ -72,7 +71,6 @@ describe("/api/db/credentials", () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(mockEq).toHaveBeenCalledWith("mcp_api_key_hash", hashMcpApiKey(VALID_API_KEY))
     expect(mockResolveActiveMemoryContext).toHaveBeenCalledWith(expect.anything(), "user-mcp-1")
     expect(body).toMatchObject({
       url: "libsql://demo.turso.io",

--- a/packages/web/src/app/api/sdk/v1/management/__tests__/routes.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/__tests__/routes.test.ts
@@ -124,7 +124,7 @@ describe("/api/sdk/v1/management/keys", () => {
   it("forwards delete status", async () => {
     mockKeyDelete.mockResolvedValue(jsonResponse({ ok: true }, 200))
 
-    const response = await keysDelete()
+    const response = await keysDelete(new Request("https://example.com", { method: "DELETE" }))
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body.ok).toBe(true)

--- a/packages/web/src/app/api/sdk/v1/management/keys/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/keys/route.ts
@@ -40,8 +40,8 @@ export async function POST(request: Request): Promise<Response> {
   return wrapLegacyResponse(requestId, response)
 }
 
-export async function DELETE(): Promise<Response> {
+export async function DELETE(request: Request): Promise<Response> {
   const requestId = crypto.randomUUID()
-  const response = await legacyDelete()
+  const response = await legacyDelete(request)
   return wrapLegacyResponse(requestId, response)
 }

--- a/packages/web/src/components/dashboard/ApiKeySection.tsx
+++ b/packages/web/src/components/dashboard/ApiKeySection.tsx
@@ -41,10 +41,28 @@ function formatDateTime(value: string | null): string {
 
 interface KeyMetadataResponse {
   hasKey?: boolean
+  keyCount?: number
+  activeKeyCount?: number
+  keyId?: string
   keyPreview?: string | null
   createdAt?: string | null
   expiresAt?: string | null
   isExpired?: boolean
+  keys?: Array<{
+    id?: string
+    keyPreview?: string | null
+    createdAt?: string | null
+    expiresAt?: string | null
+    isExpired?: boolean
+  }>
+}
+
+interface ApiKeySummary {
+  id: string
+  keyPreview: string | null
+  createdAt: string | null
+  expiresAt: string | null
+  isExpired: boolean
 }
 
 interface ApiKeySectionProps {
@@ -54,13 +72,16 @@ interface ApiKeySectionProps {
 export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.Element {
   const [apiKey, setApiKey] = useState<string | null>(null)
   const [hasKey, setHasKey] = useState(false)
+  const [keys, setKeys] = useState<ApiKeySummary[]>([])
   const [keyPreview, setKeyPreview] = useState<string | null>(null)
   const [createdAt, setCreatedAt] = useState<string | null>(null)
   const [expiresAt, setExpiresAt] = useState<string | null>(null)
   const [isExpired, setIsExpired] = useState(false)
+  const [activeKeyCount, setActiveKeyCount] = useState(0)
   const [expiryInput, setExpiryInput] = useState(defaultExpiryInputValue())
   const [loading, setLoading] = useState(true)
   const [showKey, setShowKey] = useState(false)
+  const [generatedKeyId, setGeneratedKeyId] = useState<string | null>(null)
   const [copiedKey, setCopiedKey] = useState(false)
   const [copiedEndpoint, setCopiedEndpoint] = useState(false)
   const [copiedHeader, setCopiedHeader] = useState(false)
@@ -76,14 +97,44 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
       }
 
       const data = (payload ?? {}) as KeyMetadataResponse
-      setHasKey(Boolean(data.hasKey))
-      setKeyPreview(data.keyPreview || null)
-      setCreatedAt(data.createdAt || null)
-      setExpiresAt(data.expiresAt || null)
-      setIsExpired(Boolean(data.isExpired))
+      const parsedKeys: ApiKeySummary[] = Array.isArray(data.keys)
+        ? data.keys
+            .map((item) => ({
+              id: item.id || "",
+              keyPreview: item.keyPreview || null,
+              createdAt: item.createdAt || null,
+              expiresAt: item.expiresAt || null,
+              isExpired: Boolean(item.isExpired),
+            }))
+            .filter((item) => item.id.length > 0)
+        : []
+
+      const primaryKey =
+        parsedKeys.find((item) => !item.isExpired) ??
+        parsedKeys[0] ??
+        null
+
+      const computedHasKey = parsedKeys.length > 0 || Boolean(data.hasKey)
+      const computedActiveCount =
+        parsedKeys.length > 0
+          ? parsedKeys.filter((item) => !item.isExpired).length
+          : (data.activeKeyCount ?? (data.hasKey && !data.isExpired ? 1 : 0))
+
+      setHasKey(computedHasKey)
+      setKeys(parsedKeys)
+      setActiveKeyCount(computedActiveCount)
+      setKeyPreview(data.keyPreview || primaryKey?.keyPreview || null)
+      setCreatedAt(data.createdAt || primaryKey?.createdAt || null)
+      setExpiresAt(data.expiresAt || primaryKey?.expiresAt || null)
+      setIsExpired(
+        primaryKey
+          ? primaryKey.isExpired
+          : Boolean(data.isExpired)
+      )
       setApiKey(null)
       setShowKey(false)
-      setExpiryInput(isoToLocalInputValue(data.expiresAt || null))
+      setGeneratedKeyId(null)
+      setExpiryInput(isoToLocalInputValue((data.expiresAt || primaryKey?.expiresAt) ?? null))
     } catch (err) {
       console.error("Failed to fetch API key:", err)
       setError("Failed to fetch API key metadata")
@@ -134,6 +185,7 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
         payload && typeof payload === "object"
           ? (payload as {
               apiKey?: string
+              keyId?: string
               keyPreview?: string | null
               createdAt?: string | null
               expiresAt?: string | null
@@ -141,12 +193,26 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
           : {}
 
       if (data.apiKey) {
+        const nextCreatedAt = data.createdAt || new Date().toISOString()
+        const nextExpiresAt = data.expiresAt || parsedExpiry.toISOString()
+        const nextKeyId = data.keyId || `generated-${Date.now()}`
+        const nextSummary: ApiKeySummary = {
+          id: nextKeyId,
+          keyPreview: data.keyPreview || null,
+          createdAt: nextCreatedAt,
+          expiresAt: nextExpiresAt,
+          isExpired: false,
+        }
+        const nextKeys = [nextSummary, ...keys.filter((item) => item.id !== nextSummary.id)]
         setApiKey(data.apiKey)
         setShowKey(true)
+        setGeneratedKeyId(nextKeyId)
         setHasKey(true)
-        setKeyPreview(data.keyPreview || null)
-        setCreatedAt(data.createdAt || new Date().toISOString())
-        setExpiresAt(data.expiresAt || parsedExpiry.toISOString())
+        setKeys(nextKeys)
+        setActiveKeyCount(nextKeys.filter((item) => !item.isExpired).length)
+        setKeyPreview(nextSummary.keyPreview)
+        setCreatedAt(nextCreatedAt)
+        setExpiresAt(nextExpiresAt)
         setIsExpired(false)
       }
       recordClientWorkflowEvent({
@@ -169,8 +235,11 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
     }
   }
 
-  async function revokeKey() {
-    if (!confirm("Are you sure? Any tools using this key will stop working.")) {
+  async function revokeKey(keyId?: string) {
+    const isSingleKeyRevoke = typeof keyId === "string" && keyId.length > 0
+    if (!confirm(isSingleKeyRevoke
+      ? "Revoke this API key? Any client using it will stop working."
+      : "Revoke all API keys? Any tools using them will stop working.")) {
       return
     }
     setLoading(true)
@@ -181,18 +250,43 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
     })
     try {
       setError(null)
-      const res = await fetch("/api/mcp/key", { method: "DELETE" })
+      const endpoint = isSingleKeyRevoke
+        ? `/api/mcp/key?keyId=${encodeURIComponent(keyId)}`
+        : "/api/mcp/key"
+      const res = await fetch(endpoint, { method: "DELETE" })
       if (!res.ok) {
         const payload = await res.json().catch(() => null)
         throw new Error(extractErrorMessage(payload, `Failed to revoke API key (HTTP ${res.status})`))
       }
-      setApiKey(null)
-      setHasKey(false)
-      setKeyPreview(null)
-      setCreatedAt(null)
-      setExpiresAt(null)
-      setIsExpired(false)
-      setShowKey(false)
+
+      if (isSingleKeyRevoke) {
+        const nextKeys = keys.filter((item) => item.id !== keyId)
+        const nextPrimary = nextKeys.find((item) => !item.isExpired) ?? nextKeys[0] ?? null
+        if (generatedKeyId === keyId) {
+          setApiKey(null)
+          setShowKey(false)
+          setGeneratedKeyId(null)
+        }
+        setKeys(nextKeys)
+        setActiveKeyCount(nextKeys.filter((item) => !item.isExpired).length)
+        setHasKey(nextKeys.length > 0)
+        setKeyPreview(nextPrimary?.keyPreview ?? null)
+        setCreatedAt(nextPrimary?.createdAt ?? null)
+        setExpiresAt(nextPrimary?.expiresAt ?? null)
+        setIsExpired(nextPrimary?.isExpired ?? false)
+      } else {
+        setApiKey(null)
+        setGeneratedKeyId(null)
+        setHasKey(false)
+        setKeys([])
+        setActiveKeyCount(0)
+        setKeyPreview(null)
+        setCreatedAt(null)
+        setExpiresAt(null)
+        setIsExpired(false)
+        setShowKey(false)
+      }
+
       setExpiryInput(defaultExpiryInputValue())
       recordClientWorkflowEvent({
         workflow: "api_key_revoke",
@@ -251,6 +345,7 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
 
   const maskedKey = apiKey ? `${apiKey.slice(0, 12)}${"*".repeat(40)}${apiKey.slice(-4)}` : ""
   const displayedKey = apiKey ? (showKey ? apiKey : maskedKey) : (keyPreview || "")
+  const hasActiveKey = activeKeyCount > 0
   const minExpiryValue = toDateTimeLocalValue(new Date(Date.now() + MIN_EXPIRY_OFFSET_MS))
 
   if (loading && !hasKey && !apiKey) {
@@ -338,6 +433,40 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
                 </div>
               </div>
 
+              {keys.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs text-muted-foreground uppercase tracking-wider">
+                    Keys ({keys.length}) · Active {activeKeyCount}
+                  </p>
+                  <div className="space-y-2">
+                    {keys.map((item) => (
+                      <div
+                        key={item.id}
+                        className="flex flex-col gap-2 rounded border border-border/60 bg-muted/20 p-2 text-xs sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="space-y-1">
+                          <code className="font-mono">{item.keyPreview || item.id}</code>
+                          <p className="text-muted-foreground">
+                            Created {formatDateTime(item.createdAt)} · Expires{" "}
+                            <span className={item.isExpired ? "text-red-400" : ""}>
+                              {formatDateTime(item.expiresAt)}
+                            </span>
+                          </p>
+                        </div>
+                        <button
+                          onClick={() => void revokeKey(item.id)}
+                          disabled={loading}
+                          className="inline-flex items-center gap-1.5 self-start rounded px-2 py-1 text-xs text-red-400 hover:bg-red-500/10 disabled:opacity-50"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                          Revoke
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               <div className="space-y-2">
                 <label className="text-xs text-muted-foreground">MCP Endpoint URL (for MCP clients)</label>
                 <div className="flex items-center gap-2">
@@ -388,10 +517,10 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
                   className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-muted/30 hover:bg-muted/50 rounded transition-colors disabled:opacity-50"
                 >
                   <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
-                  Regenerate
+                  Create Another
                 </button>
                 <button
-                  onClick={revokeKey}
+                  onClick={() => void revokeKey()}
                   disabled={loading}
                   className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-red-400 hover:bg-red-500/10 rounded transition-colors disabled:opacity-50"
                 >
@@ -425,8 +554,8 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
       </div>
 
       <TenantDatabaseMappingsSection
-        hasApiKey={hasKey}
-        apiKeyExpired={isExpired}
+        hasApiKey={hasActiveKey}
+        apiKeyExpired={hasKey && !hasActiveKey}
         workspacePlan={workspacePlan}
       />
     </div>

--- a/packages/web/src/lib/mcp-api-key-store.ts
+++ b/packages/web/src/lib/mcp-api-key-store.ts
@@ -1,0 +1,363 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import {
+  formatMcpApiKeyPreview,
+  generateMcpApiKey,
+  getMcpApiKeyLast4,
+  getMcpApiKeyPrefix,
+  hashMcpApiKey,
+} from "@/lib/mcp-api-key"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+interface LegacyUserKeyRow {
+  id: string
+  email: string | null
+  mcp_api_key_hash: string | null
+  mcp_api_key_prefix: string | null
+  mcp_api_key_last4: string | null
+  mcp_api_key_created_at: string | null
+  mcp_api_key_expires_at: string | null
+}
+
+interface ApiKeyRow {
+  id: string
+  user_id: string
+  api_key_hash: string
+  api_key_prefix: string
+  api_key_last4: string
+  created_at: string
+  expires_at: string
+  revoked_at: string | null
+}
+
+export interface UserApiKeyRecord {
+  id: string
+  keyPreview: string | null
+  createdAt: string
+  expiresAt: string
+  isExpired: boolean
+}
+
+export interface ApiKeyOwnerRecord {
+  userId: string
+  email: string | null
+  expiresAt: string | null
+}
+
+export interface CreatedUserApiKey {
+  keyId: string
+  apiKey: string
+  keyPreview: string | null
+  createdAt: string
+  expiresAt: string
+}
+
+function isMissingApiKeysTableError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const code = "code" in error ? String((error as { code?: unknown }).code ?? "") : ""
+  if (code === "42P01") return true
+
+  const message = "message" in error ? String((error as { message?: unknown }).message ?? "") : ""
+  return message.includes("mcp_api_keys") || message.includes("Unexpected table: mcp_api_keys")
+}
+
+function toApiKeyRecord(row: Pick<ApiKeyRow, "id" | "api_key_prefix" | "api_key_last4" | "created_at" | "expires_at">): UserApiKeyRecord {
+  return {
+    id: row.id,
+    keyPreview: formatMcpApiKeyPreview(row.api_key_prefix, row.api_key_last4),
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    isExpired: new Date(row.expires_at).getTime() <= Date.now(),
+  }
+}
+
+async function getLegacyUserKey(admin: AdminClient, userId: string): Promise<LegacyUserKeyRow | null> {
+  const { data, error } = await admin
+    .from("users")
+    .select(
+      "id, email, mcp_api_key_hash, mcp_api_key_prefix, mcp_api_key_last4, mcp_api_key_created_at, mcp_api_key_expires_at"
+    )
+    .eq("id", userId)
+    .single()
+
+  if (error) {
+    throw new Error(`Failed to load API key metadata: ${error.message}`)
+  }
+
+  return (data as LegacyUserKeyRow | null) ?? null
+}
+
+async function clearLegacyUserKey(admin: AdminClient, userId: string): Promise<void> {
+  const { error } = await admin
+    .from("users")
+    .update({
+      mcp_api_key: null,
+      mcp_api_key_hash: null,
+      mcp_api_key_prefix: null,
+      mcp_api_key_last4: null,
+      mcp_api_key_created_at: null,
+      mcp_api_key_expires_at: null,
+    })
+    .eq("id", userId)
+
+  if (error) {
+    throw new Error(`Failed to clear legacy API key metadata: ${error.message}`)
+  }
+}
+
+async function upsertLegacyUserKey(
+  admin: AdminClient,
+  params: {
+    userId: string
+    apiKeyHash: string
+    apiKeyPrefix: string
+    apiKeyLast4: string
+    createdAt: string
+    expiresAt: string
+  }
+): Promise<void> {
+  const { error } = await admin
+    .from("users")
+    .update({
+      mcp_api_key: null,
+      mcp_api_key_hash: params.apiKeyHash,
+      mcp_api_key_prefix: params.apiKeyPrefix,
+      mcp_api_key_last4: params.apiKeyLast4,
+      mcp_api_key_created_at: params.createdAt,
+      mcp_api_key_expires_at: params.expiresAt,
+    })
+    .eq("id", params.userId)
+
+  if (error) {
+    throw new Error(`Failed to sync legacy API key metadata: ${error.message}`)
+  }
+}
+
+export async function listUserApiKeys(admin: AdminClient, userId: string): Promise<UserApiKeyRecord[]> {
+  const { data, error } = await admin
+    .from("mcp_api_keys")
+    .select("id, api_key_prefix, api_key_last4, created_at, expires_at, revoked_at")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    if (!isMissingApiKeysTableError(error)) {
+      throw new Error(`Failed to list API keys: ${error.message}`)
+    }
+
+    const legacy = await getLegacyUserKey(admin, userId)
+    if (!legacy?.mcp_api_key_hash || !legacy.mcp_api_key_created_at || !legacy.mcp_api_key_expires_at) {
+      return []
+    }
+
+    return [
+      {
+        id: `legacy:${legacy.mcp_api_key_hash}`,
+        keyPreview: formatMcpApiKeyPreview(legacy.mcp_api_key_prefix, legacy.mcp_api_key_last4),
+        createdAt: legacy.mcp_api_key_created_at,
+        expiresAt: legacy.mcp_api_key_expires_at,
+        isExpired: new Date(legacy.mcp_api_key_expires_at).getTime() <= Date.now(),
+      },
+    ]
+  }
+
+  return ((data as ApiKeyRow[] | null) ?? [])
+    .filter((row) => !row.revoked_at)
+    .map((row) => toApiKeyRecord(row))
+}
+
+async function syncLegacyPrimaryApiKey(admin: AdminClient, userId: string): Promise<void> {
+  const nowIso = new Date().toISOString()
+  const { data, error } = await admin
+    .from("mcp_api_keys")
+    .select("api_key_hash, api_key_prefix, api_key_last4, created_at, expires_at")
+    .eq("user_id", userId)
+    .is("revoked_at", null)
+    .gt("expires_at", nowIso)
+    .order("expires_at", { ascending: false })
+    .order("created_at", { ascending: false })
+    .limit(1)
+
+  if (error) {
+    if (isMissingApiKeysTableError(error)) {
+      return
+    }
+    throw new Error(`Failed to sync primary API key metadata: ${error.message}`)
+  }
+
+  const primary = (data as Array<{
+    api_key_hash: string
+    api_key_prefix: string
+    api_key_last4: string
+    created_at: string
+    expires_at: string
+  }> | null)?.[0]
+
+  if (!primary) {
+    await clearLegacyUserKey(admin, userId)
+    return
+  }
+
+  await upsertLegacyUserKey(admin, {
+    userId,
+    apiKeyHash: primary.api_key_hash,
+    apiKeyPrefix: primary.api_key_prefix,
+    apiKeyLast4: primary.api_key_last4,
+    createdAt: primary.created_at,
+    expiresAt: primary.expires_at,
+  })
+}
+
+export async function createUserApiKey(
+  admin: AdminClient,
+  params: { userId: string; expiresAt: string }
+): Promise<CreatedUserApiKey> {
+  const apiKey = generateMcpApiKey()
+  const apiKeyHash = hashMcpApiKey(apiKey)
+  const apiKeyPrefix = getMcpApiKeyPrefix(apiKey)
+  const apiKeyLast4 = getMcpApiKeyLast4(apiKey)
+  const createdAt = new Date().toISOString()
+
+  const { data, error } = await admin
+    .from("mcp_api_keys")
+    .insert({
+      user_id: params.userId,
+      api_key_hash: apiKeyHash,
+      api_key_prefix: apiKeyPrefix,
+      api_key_last4: apiKeyLast4,
+      created_at: createdAt,
+      expires_at: params.expiresAt,
+      created_via: "dashboard",
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    if (!isMissingApiKeysTableError(error)) {
+      throw new Error(`Failed to create API key: ${error.message}`)
+    }
+
+    await upsertLegacyUserKey(admin, {
+      userId: params.userId,
+      apiKeyHash,
+      apiKeyPrefix,
+      apiKeyLast4,
+      createdAt,
+      expiresAt: params.expiresAt,
+    })
+
+    return {
+      keyId: `legacy:${apiKeyHash}`,
+      apiKey,
+      keyPreview: formatMcpApiKeyPreview(apiKeyPrefix, apiKeyLast4),
+      createdAt,
+      expiresAt: params.expiresAt,
+    }
+  }
+
+  await syncLegacyPrimaryApiKey(admin, params.userId)
+
+  return {
+    keyId: String((data as { id?: string } | null)?.id ?? ""),
+    apiKey,
+    keyPreview: formatMcpApiKeyPreview(apiKeyPrefix, apiKeyLast4),
+    createdAt,
+    expiresAt: params.expiresAt,
+  }
+}
+
+export async function revokeUserApiKeys(
+  admin: AdminClient,
+  params: { userId: string; keyId?: string }
+): Promise<{ revokedCount: number }> {
+  const nowIso = new Date().toISOString()
+
+  if (params.keyId) {
+    if (params.keyId.startsWith("legacy:")) {
+      await clearLegacyUserKey(admin, params.userId)
+      return { revokedCount: 1 }
+    }
+
+    const { data, error } = await admin
+      .from("mcp_api_keys")
+      .update({ revoked_at: nowIso })
+      .eq("user_id", params.userId)
+      .eq("id", params.keyId)
+      .is("revoked_at", null)
+      .select("id")
+
+    if (error) {
+      if (!isMissingApiKeysTableError(error)) {
+        throw new Error(`Failed to revoke API key: ${error.message}`)
+      }
+      return { revokedCount: 0 }
+    }
+
+    await syncLegacyPrimaryApiKey(admin, params.userId)
+    return { revokedCount: Array.isArray(data) ? data.length : 0 }
+  }
+
+  const { data, error } = await admin
+    .from("mcp_api_keys")
+    .update({ revoked_at: nowIso })
+    .eq("user_id", params.userId)
+    .is("revoked_at", null)
+    .select("id")
+
+  if (error) {
+    if (!isMissingApiKeysTableError(error)) {
+      throw new Error(`Failed to revoke API keys: ${error.message}`)
+    }
+    await clearLegacyUserKey(admin, params.userId)
+    return { revokedCount: 1 }
+  }
+
+  await syncLegacyPrimaryApiKey(admin, params.userId)
+  return { revokedCount: Array.isArray(data) ? data.length : 0 }
+}
+
+export async function resolveApiKeyOwnerByHash(
+  admin: AdminClient,
+  apiKeyHash: string
+): Promise<ApiKeyOwnerRecord | null> {
+  const { data: legacyUser, error: legacyError } = await admin
+    .from("users")
+    .select("id, email, mcp_api_key_expires_at")
+    .eq("mcp_api_key_hash", apiKeyHash)
+    .single()
+
+  if (!legacyError && legacyUser?.id) {
+    return {
+      userId: String(legacyUser.id),
+      email: (legacyUser as { email?: string | null }).email ?? null,
+      expiresAt: (legacyUser as { mcp_api_key_expires_at?: string | null }).mcp_api_key_expires_at ?? null,
+    }
+  }
+
+  const { data: keyRow, error: keyLookupError } = await admin
+    .from("mcp_api_keys")
+    .select("user_id, expires_at, revoked_at")
+    .eq("api_key_hash", apiKeyHash)
+    .single()
+
+  if (keyLookupError || !keyRow || (keyRow as { revoked_at?: string | null }).revoked_at) {
+    return null
+  }
+
+  const userId = String((keyRow as { user_id: string }).user_id)
+  const { data: user, error: userError } = await admin
+    .from("users")
+    .select("id, email")
+    .eq("id", userId)
+    .single()
+
+  if (userError || !user?.id) {
+    return null
+  }
+
+  return {
+    userId,
+    email: (user as { email?: string | null }).email ?? null,
+    expiresAt: String((keyRow as { expires_at: string }).expires_at),
+  }
+}

--- a/packages/web/src/lib/memory-service/scope.ts
+++ b/packages/web/src/lib/memory-service/scope.ts
@@ -14,6 +14,7 @@ import {
   resolveSdkProjectBillingContext,
   type SdkProjectBillingContext,
 } from "@/lib/sdk-project-billing"
+import { resolveApiKeyOwnerByHash } from "@/lib/mcp-api-key-store"
 import {
   apiError,
   type TursoClient,
@@ -270,12 +271,8 @@ async function resolveTenantOwnerScope(params: {
   let ownerUserId = params.ownerUserId ?? null
 
   if (!ownerUserId) {
-    const { data: keyOwnerData } = await params.admin
-      .from("users")
-      .select("id")
-      .eq("mcp_api_key_hash", params.apiKeyHash)
-      .maybeSingle()
-    ownerUserId = (keyOwnerData?.id as string | undefined) ?? null
+    const owner = await resolveApiKeyOwnerByHash(params.admin, params.apiKeyHash)
+    ownerUserId = owner?.userId ?? null
   }
 
   let billingContext: SdkProjectBillingContext | null = null

--- a/supabase/migrations/20260221191000_add_mcp_api_keys_table.sql
+++ b/supabase/migrations/20260221191000_add_mcp_api_keys_table.sql
@@ -1,0 +1,50 @@
+-- Support multiple active API keys per user for MCP + SDK access.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.mcp_api_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  api_key_hash TEXT NOT NULL,
+  api_key_prefix TEXT NOT NULL,
+  api_key_last4 TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  last_used_at TIMESTAMPTZ,
+  created_via TEXT NOT NULL DEFAULT 'dashboard',
+  CONSTRAINT mcp_api_keys_hash_non_empty CHECK (char_length(trim(api_key_hash)) > 0),
+  CONSTRAINT mcp_api_keys_prefix_non_empty CHECK (char_length(trim(api_key_prefix)) > 0),
+  CONSTRAINT mcp_api_keys_last4_non_empty CHECK (char_length(trim(api_key_last4)) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_api_keys_hash_unique
+  ON public.mcp_api_keys (api_key_hash);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_api_keys_user_id_active
+  ON public.mcp_api_keys (user_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mcp_api_keys_expires_at
+  ON public.mcp_api_keys (expires_at);
+
+-- Backfill any existing primary user key metadata so old keys continue to work.
+INSERT INTO public.mcp_api_keys (
+  user_id,
+  api_key_hash,
+  api_key_prefix,
+  api_key_last4,
+  created_at,
+  expires_at,
+  created_via
+)
+SELECT
+  u.id,
+  u.mcp_api_key_hash,
+  COALESCE(u.mcp_api_key_prefix, left('mem_legacy', 12)),
+  COALESCE(u.mcp_api_key_last4, right(u.mcp_api_key_hash, 4)),
+  COALESCE(u.mcp_api_key_created_at, now()),
+  COALESCE(u.mcp_api_key_expires_at, now() + INTERVAL '365 days'),
+  'legacy-backfill'
+FROM public.users AS u
+WHERE u.mcp_api_key_hash IS NOT NULL
+ON CONFLICT (api_key_hash) DO NOTHING;


### PR DESCRIPTION
## Summary
- add mcp_api_keys persistence with migration/backfill so users can keep multiple active mem_ keys
- add shared key-store helpers for list/create/revoke and non-primary key ownership lookup
- extend /api/mcp/key to return key inventory, create additional keys, and revoke individual keys (?keyId=) or all keys
- update dashboard API Keys UI to show key inventory, active/expired state, create additional keys, and per-key revoke actions
- keep compatibility by syncing one active legacy key onto users metadata for existing flows
- route API-key auth through owner lookup that supports both legacy and multi-key records
- document updated management key contract and changelog

## Validation
- pnpm -C packages/web exec vitest run src/app/api/mcp/key/__tests__/route.test.ts src/app/api/db/credentials/__tests__/route.test.ts src/app/api/sdk/v1/management/__tests__/routes.test.ts
- pnpm -C packages/web exec vitest run src/app/api/mcp/__tests__/route.test.ts src/app/api/sdk/v1/context/get/__tests__/route.test.ts
- pnpm -C packages/web typecheck
- pnpm -C packages/web lint
- pnpm -C packages/web build
- pnpm -C packages/core typecheck
- pnpm -C packages/core test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and key lifecycle logic across multiple entry points (MCP, SDK runtime, credentials) and adds a new persistence layer/migration, so regressions could break API key validation or revocation behavior despite compatibility fallbacks.
> 
> **Overview**
> Enables **multiple active `mem_` API keys per user** by introducing a new `mcp_api_keys` table (with backfill from legacy `users` key fields) and a shared key-store module to list/create/revoke keys while keeping the legacy single-key metadata in sync.
> 
> Updates the legacy `/api/mcp/key` (and its SDK wrapper `/api/sdk/v1/management/keys`) to return key inventory (`keyCount`, `activeKeyCount`, `keys[]`), create additional keys (returns `keyId`), and revoke either all keys or a single key via `?keyId=`; dashboard UI now displays the key list and supports per-key revocation and “Create Another”.
> 
> Routes API-key authentication/ownership resolution for MCP, SDK runtime, and DB credentials through `resolveApiKeyOwnerByHash` so requests can be authorized via either legacy user key fields or the new multi-key records, and updates core client schemas/types plus docs/changelog to match the expanded responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f652d54150b75a254a72697405df1970d47d0cc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->