### PR TITLE
perf(web): isolate not-found from shared app client bundles

### DIFF
--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -1,16 +1,5 @@
-"use client";
-import React from "react"
-
-import { motion } from "framer-motion";
 import Link from "next/link";
 import Image from "next/image";
-import dynamic from "next/dynamic";
-import { ScrambleText } from "@/components/animations/ScrambleText";
-
-const ShaderBackground = dynamic(
-  () => import("@/components/ShaderBackground").then((mod) => mod.ShaderBackground),
-  { ssr: false }
-);
 
 const GeometricPattern = ({ className = "" }: { className?: string }) => (
   <svg
@@ -28,98 +17,47 @@ const GeometricPattern = ({ className = "" }: { className?: string }) => (
   </svg>
 );
 
-export default function NotFound(): React.JSX.Element {
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-        delayChildren: 0.1,
-      },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { y: 20, opacity: 0, filter: "blur(8px)" },
-    visible: {
-      y: 0,
-      opacity: 1,
-      filter: "blur(0px)",
-      transition: {
-        duration: 1,
-        ease: [0.16, 1, 0.3, 1] as [number, number, number, number],
-      },
-    },
-  };
-
+export default function NotFound() {
   return (
-    <main className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      <ShaderBackground
-        className="opacity-40 z-0"
-        color="#b855f7"
-        backgroundColor="#0a0a0f"
-      />
-      {/* Gradient overlay */}
-      <div className="absolute inset-0 pointer-events-none z-[1] bg-gradient-to-tr from-background from-50% to-transparent" />
-
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 1.5, ease: [0.16, 1, 0.3, 1] }}
-      >
-        <GeometricPattern className="opacity-10 text-primary/40" />
-      </motion.div>
-
+    <main className="relative min-h-screen flex items-center justify-center overflow-hidden bg-background">
+      <div className="absolute inset-0 pointer-events-none z-0 bg-[radial-gradient(ellipse_at_top,_rgba(184,85,247,0.2),transparent_60%)]" />
+      <GeometricPattern className="opacity-10 text-primary/40 z-0" />
       <div className="relative z-10 w-full px-6 flex flex-col items-center text-center">
-        <motion.div
-          variants={containerVariants}
-          initial="hidden"
-          animate="visible"
-          className="flex flex-col items-center max-w-2xl"
-        >
+        <div className="flex flex-col items-center max-w-2xl">
           {/* Logo */}
-          <motion.div variants={itemVariants}>
-            <Link href="/" className="flex items-center gap-3 mb-12 group">
-              <Image
-                src="/memories.svg"
-                alt="memories.sh logo"
-                width={32}
-                height={32}
-                className="w-8 h-8 dark:invert group-hover:scale-110 transition-transform duration-500"
-              />
-              <span className="font-mono text-sm font-bold tracking-tighter uppercase text-foreground">
-                memories.sh
-              </span>
-            </Link>
-          </motion.div>
+          <Link href="/" className="flex items-center gap-3 mb-12 group">
+            <Image
+              src="/memories.svg"
+              alt="memories.sh logo"
+              width={32}
+              height={32}
+              className="w-8 h-8 dark:invert group-hover:scale-110 transition-transform duration-500"
+            />
+            <span className="font-mono text-sm font-bold tracking-tighter uppercase text-foreground">
+              memories.sh
+            </span>
+          </Link>
 
           {/* 404 Badge */}
-          <motion.div variants={itemVariants} className="inline-flex items-center gap-2 mb-6">
+          <div className="inline-flex items-center gap-2 mb-6">
             <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
             <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">
               Memory Not Found
             </span>
-          </motion.div>
+          </div>
 
           {/* Main heading */}
-          <motion.h1
-            variants={itemVariants}
-            className="font-mono font-normal text-3xl sm:text-4xl lg:text-5xl xl:text-6xl mb-6 leading-[0.95] text-foreground"
-          >
-            <ScrambleText text="404" delayMs={300} duration={0.8} />
-          </motion.h1>
+          <h1 className="font-mono font-normal text-3xl sm:text-4xl lg:text-5xl xl:text-6xl mb-6 leading-[0.95] text-foreground">
+            404
+          </h1>
 
           {/* Description */}
-          <motion.p
-            variants={itemVariants}
-            className="text-lg md:text-xl text-muted-foreground mb-10 max-w-md leading-relaxed font-light"
-          >
+          <p className="text-lg md:text-xl text-muted-foreground mb-10 max-w-md leading-relaxed font-light">
             This page doesn&apos;t exist in our memory store. It may have been moved, deleted, or never existed.
-          </motion.p>
+          </p>
 
           {/* Actions */}
-          <motion.div variants={itemVariants} className="flex flex-col sm:flex-row items-center gap-4">
+          <div className="flex flex-col sm:flex-row items-center gap-4">
             <Link
               href="/"
               className="px-6 py-3 bg-foreground text-background font-bold text-xs uppercase tracking-[0.15em] rounded-md hover:bg-primary hover:text-primary-foreground transition-all duration-300"
@@ -132,17 +70,14 @@ export default function NotFound(): React.JSX.Element {
             >
               View Documentation
             </Link>
-          </motion.div>
+          </div>
 
           {/* Terminal-style hint */}
-          <motion.div
-            variants={itemVariants}
-            className="mt-16 flex items-center gap-3 px-4 py-3 bg-foreground/5 border border-border rounded-md font-mono text-sm"
-          >
+          <div className="mt-16 flex items-center gap-3 px-4 py-3 bg-foreground/5 border border-border rounded-md font-mono text-sm">
             <span className="text-muted-foreground select-none">$</span>
             <code className="text-foreground/70">memories search &quot;what you were looking for&quot;</code>
-          </motion.div>
-        </motion.div>
+          </div>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- convert root `not-found` route to a server component
- remove framer-motion, GSAP/scramble, and dynamic shader imports from the global 404 path
- keep equivalent 404 UX with static styling

## Validation
- `pnpm --filter @memories.sh/web build`

Closes #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the 404 route and primarily removes client-side effects; risk is limited to potential visual/regression differences on the not-found page.
> 
> **Overview**
> Refactors the root `not-found` page from a client component to a server-rendered, static implementation.
> 
> Removes `framer-motion` animations, `ScrambleText`, and the dynamically imported `ShaderBackground`, replacing the visual treatment with a lightweight CSS radial gradient + static `GeometricPattern` so the 404 route no longer pulls these dependencies into shared client bundles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d935bfb1bf343dc900167c5c1efc098dbeea005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->