### PR TITLE
perf(web): move landing page toward server-first composition

### DIFF
--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,16 +1,56 @@
-import React from "react"
+import dynamic from "next/dynamic";
 import { TopNav } from "@/components/TopNav";
 import { Hero } from "@/components/Hero";
-import { HowItWorks } from "@/components/HowItWorks";
 import { FeaturesGrid } from "@/components/FeaturesGrid";
 import { SDKSection } from "@/components/SDKSection";
-import { ApiSection } from "@/components/ApiSection";
 import { Integrations } from "@/components/Integrations";
-import { Pricing } from "@/components/Pricing";
-import { FAQ } from "@/components/FAQ";
-import { Footer } from "@/components/Footer";
+import type { ReactNode } from "react";
 
-export default function Home(): React.JSX.Element {
+const HowItWorks = dynamic(
+  () => import("@/components/HowItWorks").then((mod) => mod.HowItWorks),
+  { loading: () => <SectionPlaceholder minHeightClassName="min-h-[640px]" /> },
+);
+const ApiSection = dynamic(
+  () => import("@/components/ApiSection").then((mod) => mod.ApiSection),
+  { loading: () => <SectionPlaceholder minHeightClassName="min-h-[620px]" /> },
+);
+const Pricing = dynamic(
+  () => import("@/components/Pricing").then((mod) => mod.Pricing),
+  { loading: () => <SectionPlaceholder minHeightClassName="min-h-[680px]" /> },
+);
+const FAQ = dynamic(
+  () => import("@/components/FAQ").then((mod) => mod.FAQ),
+  { loading: () => <SectionPlaceholder minHeightClassName="min-h-[540px]" /> },
+);
+const Footer = dynamic(
+  () => import("@/components/Footer").then((mod) => mod.Footer),
+  { loading: () => <FooterPlaceholder /> },
+);
+
+function SectionPlaceholder({ minHeightClassName }: { minHeightClassName: string }): ReactNode {
+  return (
+    <section
+      className={`w-full px-6 lg:px-16 xl:px-24 border-t border-border ${minHeightClassName}`}
+      aria-hidden="true"
+    >
+      <div className="mx-auto h-full max-w-6xl py-16">
+        <div className="h-7 w-48 rounded-md bg-foreground/10 animate-pulse" />
+        <div className="mt-6 h-4 w-full max-w-3xl rounded-md bg-foreground/10 animate-pulse" />
+        <div className="mt-3 h-4 w-full max-w-2xl rounded-md bg-foreground/10 animate-pulse" />
+      </div>
+    </section>
+  );
+}
+
+function FooterPlaceholder(): ReactNode {
+  return (
+    <footer className="border-t border-border px-6 lg:px-16 xl:px-24 py-12" aria-hidden="true">
+      <div className="mx-auto h-6 w-56 rounded-md bg-foreground/10 animate-pulse" />
+    </footer>
+  );
+}
+
+export default function Home() {
   return (
     <div className="min-h-screen bg-background text-foreground selection:bg-primary/30">
       


### PR DESCRIPTION
## Summary
- keep top-of-page interactive components eagerly rendered
- lazy-load heavier below-the-fold landing client sections with `next/dynamic`
- add server-rendered section placeholders while deferred chunks load

## Validation
- `pnpm --filter @memories.sh/web build`

Closes #263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to landing-page rendering/perf; main risk is layout/SEO regressions if dynamic loading or placeholder sizing behaves unexpectedly.
> 
> **Overview**
> Moves the landing page (`app/page.tsx`) toward server-first composition by replacing eager imports of heavier below-the-fold sections (`HowItWorks`, `ApiSection`, `Pricing`, `FAQ`, `Footer`) with `next/dynamic` imports.
> 
> Adds server-rendered `SectionPlaceholder`/`FooterPlaceholder` skeletons used as `loading` fallbacks so the above-the-fold content (`TopNav`, `Hero`, etc.) renders immediately while deferred chunks load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97cfd4506b5b6117f5c5dd267892157804237f1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->