### PR TITLE
perf(web): shift dashboard nav to interaction-based prefetch

### DIFF
--- a/packages/web/src/components/dashboard/DashboardShell.tsx
+++ b/packages/web/src/components/dashboard/DashboardShell.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import Image from "next/image"
-import { useCallback, useEffect, useMemo } from "react"
+import { useCallback } from "react"
 import { usePathname, useRouter } from "next/navigation"
 import type { User } from "@supabase/supabase-js"
 import { BookOpen, KeyRound, Network } from "lucide-react"
@@ -75,20 +75,12 @@ export function DashboardShell({
     plan === "past_due"
       ? "top-[6.25rem] h-[calc(100vh-6.25rem)]"
       : "top-16 h-[calc(100vh-4rem)]"
-  const internalNavItems = useMemo(() => navItems.filter((item) => !item.external), [])
-
   const prefetchRoute = useCallback(
     (href: string) => {
       router.prefetch(href)
     },
     [router],
   )
-
-  useEffect(() => {
-    for (const item of internalNavItems) {
-      prefetchRoute(item.href)
-    }
-  }, [internalNavItems, prefetchRoute])
 
   return (
     <div className="min-h-screen bg-background text-foreground overflow-x-hidden">
@@ -262,7 +254,7 @@ export function DashboardShell({
                 <Link
                   key={item.href}
                   href={item.href}
-                  prefetch
+                  prefetch={false}
                   onMouseEnter={() => prefetchRoute(item.href)}
                   onFocus={() => prefetchRoute(item.href)}
                   aria-current={isActive ? "page" : undefined}
@@ -316,7 +308,7 @@ export function DashboardShell({
                 <Link
                   key={item.href}
                   href={item.href}
-                  prefetch
+                  prefetch={false}
                   onMouseEnter={() => prefetchRoute(item.href)}
                   onFocus={() => prefetchRoute(item.href)}
                   aria-current={isActive ? "page" : undefined}


### PR DESCRIPTION
## Summary
- remove dashboard mount-time loop that prefetched every internal route
- keep targeted interaction prefetch via hover/focus
- disable default link prefetch on dashboard nav links to avoid eager background fetches

## Validation
- `pnpm --filter @memories.sh/web build`

Closes #265

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to Next.js route prefetching for dashboard nav links; no data/auth logic is touched, with primary risk being minor perceived navigation latency on first click.
> 
> **Overview**
> Reduces dashboard navigation network churn by removing the mount-time loop that prefetched every internal sidebar route.
> 
> Nav `Link`s now set `prefetch={false}` and rely on explicit `router.prefetch()` triggered by hover/focus for both desktop sidebar and mobile bottom nav.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba11a41f56269e54ed8984b00cffa288b74a5af9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->