### PR TITLE
perf(web): migrate external fonts to next/font

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -9,7 +9,7 @@
     --color-background: var(--background);
     --color-background-secondary: var(--background-secondary);
     --color-foreground: var(--foreground);
-    --font-sans: 'Satoshi', var(--font-geist-sans);
+    --font-sans: var(--font-geist-sans);
     --font-mono: var(--font-geist-mono);
     --font-display: var(--font-departure-mono);
     --color-sidebar-ring: var(--sidebar-ring);
@@ -169,7 +169,7 @@
     }
     body {
       @apply bg-background text-foreground selection:bg-primary/30 antialiased;
-      font-family: 'Satoshi', var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+      font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
     }
     h1,
     h2,

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import localFont from "next/font/local";
 import "./globals.css";
 import { VisualEditsMessenger } from "orchids-visual-edits";
@@ -17,6 +17,18 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "700"],
+});
+
+const spaceGrotesk = Space_Grotesk({
+  variable: "--font-space-grotesk",
+  subsets: ["latin"],
+  weight: ["300", "400", "600", "700"],
 });
 
 const departureMono = localFont({
@@ -109,14 +121,8 @@ export default function RootLayout({
 }>): React.JSX.Element {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <link
-          href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap"
-          rel="stylesheet"
-        />
-      </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${departureMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${jetBrainsMono.variable} ${spaceGrotesk.variable} ${departureMono.variable} antialiased`}
       >
         <ThemeProvider
           attribute="class"

--- a/packages/web/src/components/openclaw/HeroIllustration.tsx
+++ b/packages/web/src/components/openclaw/HeroIllustration.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect, useRef } from "react";
 
 const style = `
-  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Space+Grotesk:wght@300;400;600&display=swap');
-
   .oc-root, .oc-root * { box-sizing: border-box; margin: 0; padding: 0; }
 
   .oc-root {
@@ -19,7 +17,7 @@ const style = `
     --text-dim: rgba(255,255,255,0.55);
 
     width: 100%;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-jetbrains-mono), var(--font-geist-mono), monospace;
     color: #e2e8f0;
     background: transparent;
     position: relative;
@@ -418,7 +416,7 @@ const style = `
     letter-spacing: -0.02em;
     line-height: 1;
     margin-bottom: 4px;
-    font-family: 'Space Grotesk', 'JetBrains Mono', sans-serif;
+    font-family: var(--font-space-grotesk), var(--font-jetbrains-mono), var(--font-geist-sans), sans-serif;
   }
 
   .oc-stat-label {


### PR DESCRIPTION
## Summary
- remove external Fontshare stylesheet from root layout
- add `JetBrains Mono` and `Space Grotesk` via `next/font/google` variables
- update OpenClaw hero illustration CSS to use app font variables instead of runtime `@import`
- remove `Satoshi` hardcoded fallback usage from global font stack

## Validation
- `pnpm --filter @memories.sh/web build`

Closes #268

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Font-loading and CSS font-stack changes only; main risk is small visual/typography regressions if weights or fallbacks differ.
> 
> **Overview**
> Moves web font loading fully onto `next/font` by removing external stylesheet imports (Fontshare `Satoshi` in `layout.tsx` and the Google Fonts `@import` in `HeroIllustration.tsx`) and registering `JetBrains Mono`/`Space Grotesk` as CSS variables on the root `body`.
> 
> Updates global and OpenClaw hero font stacks to reference these CSS variables (dropping hardcoded `Satoshi` fallbacks), so typography is driven by Next’s font pipeline instead of runtime CSS imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8038714c933bf843e283091280638db93625e95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->