### PR TITLE
perf(web): defer stats charts with lazy client wrapper

### DIFF
--- a/packages/web/src/app/app/stats/page.tsx
+++ b/packages/web/src/app/app/stats/page.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { createClient } from "@/lib/supabase/server"
-import { StatsCharts } from "./stats-charts"
+import { LazyStatsCharts } from "./stats-charts-lazy"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
 import { resolveActiveMemoryContext } from "@/lib/active-memory-context"
 
@@ -254,7 +254,7 @@ export default async function StatsPage(): Promise<React.JSX.Element | null> {
         </div>
       </div>
 
-      <StatsCharts 
+      <LazyStatsCharts
         byType={stats.byType} 
         byDayAndType={stats.byDayAndType}
         byProject={stats.byProject}

--- a/packages/web/src/app/app/stats/stats-charts-lazy.tsx
+++ b/packages/web/src/app/app/stats/stats-charts-lazy.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import React from "react"
+import dynamic from "next/dynamic"
+import type { StatsChartsProps } from "./stats-charts"
+
+const StatsCharts = dynamic(
+  () => import("./stats-charts").then((mod) => mod.StatsCharts),
+  {
+    ssr: false,
+    loading: () => <StatsChartsSkeleton />,
+  },
+)
+
+function StatsChartsSkeleton(): React.JSX.Element {
+  return (
+    <div className="space-y-6" aria-hidden="true">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 border border-border bg-card/20 p-6">
+          <div className="h-3 w-40 rounded bg-muted/60 animate-pulse mb-6" />
+          <div className="h-[250px] rounded bg-muted/40 animate-pulse" />
+        </div>
+        <div className="border border-border bg-card/20 p-6">
+          <div className="h-3 w-24 rounded bg-muted/60 animate-pulse mb-6" />
+          <div className="h-[200px] rounded bg-muted/40 animate-pulse" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="border border-border bg-card/20 p-6">
+          <div className="h-3 w-24 rounded bg-muted/60 animate-pulse mb-4" />
+          <div className="space-y-3">
+            <div className="h-8 rounded bg-muted/40 animate-pulse" />
+            <div className="h-8 rounded bg-muted/40 animate-pulse" />
+            <div className="h-8 rounded bg-muted/40 animate-pulse" />
+          </div>
+        </div>
+        <div className="border border-border bg-card/20 p-6">
+          <div className="h-3 w-32 rounded bg-muted/60 animate-pulse mb-4" />
+          <div className="space-y-2">
+            <div className="h-12 rounded bg-muted/40 animate-pulse" />
+            <div className="h-12 rounded bg-muted/40 animate-pulse" />
+            <div className="h-12 rounded bg-muted/40 animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function LazyStatsCharts(props: StatsChartsProps): React.JSX.Element {
+  return <StatsCharts {...props} />
+}

--- a/packages/web/src/app/app/stats/stats-charts.tsx
+++ b/packages/web/src/app/app/stats/stats-charts.tsx
@@ -14,18 +14,18 @@ import {
   Legend,
 } from "recharts"
 
-interface TypeCount {
+export interface TypeCount {
   type: string
   count: number
 }
 
-interface DayTypeCount {
+export interface DayTypeCount {
   date: string
   type: string
   count: number
 }
 
-interface ProjectCount {
+export interface ProjectCount {
   project_id: string | null
   scope: string
   count: number
@@ -35,7 +35,7 @@ interface ProjectCount {
   note_count: number
 }
 
-interface RecentMemory {
+export interface RecentMemory {
   id: string
   content: string
   type: string
@@ -99,19 +99,21 @@ function truncateContent(content: string, maxLength: number = 60): string {
   return content.slice(0, maxLength).trim() + "..."
 }
 
+export interface StatsChartsProps {
+  byType: TypeCount[]
+  byDayAndType: DayTypeCount[]
+  byProject: ProjectCount[]
+  recent: RecentMemory[]
+  globalVsProject: { global: number; project: number }
+}
+
 export function StatsCharts({
   byType,
   byDayAndType,
   byProject,
   recent,
   globalVsProject,
-}: {
-  byType: TypeCount[]
-  byDayAndType: DayTypeCount[]
-  byProject: ProjectCount[]
-  recent: RecentMemory[]
-  globalVsProject: { global: number; project: number }
-}): React.JSX.Element {
+}: StatsChartsProps): React.JSX.Element {
   // Transform daily data for stacked bar chart
   const dailyData = byDayAndType.reduce((acc, item) => {
     const existing = acc.find(d => d.date === item.date)


### PR DESCRIPTION
## Summary
- add a dedicated client wrapper that lazy-loads the heavy `StatsCharts` module
- defer chart rendering with `dynamic(..., { ssr: false })` and a lightweight skeleton fallback
- keep server-side stats data loading unchanged while reducing initial chart payload pressure

## Validation
- `pnpm --filter @memories.sh/web build`

Closes #271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a performance-oriented rendering change (dynamic import + skeleton) with minimal logic changes; main risk is client-only chart rendering behavior/regressions on the Stats page.
> 
> **Overview**
> The Stats page now renders charts through a new `LazyStatsCharts` wrapper that dynamically imports `StatsCharts` with `ssr: false`, showing a lightweight skeleton while the chart bundle loads.
> 
> To support the wrapper, `stats-charts.tsx` exports a shared `StatsChartsProps` type (and related interfaces), replacing the inline props shape previously defined on `StatsCharts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d107ddf29a548d9024f198e8f8f6f416e6fb273d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->