### PR TITLE
feat(cli): harden cron, git remote, and env parsing

### DIFF
--- a/packages/cli/src/lib/env.test.ts
+++ b/packages/cli/src/lib/env.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getApiUrl, isDebug } from "./env.js";
+
+const ORIGINAL_API_URL = process.env.MEMORIES_API_URL;
+const ORIGINAL_DEBUG = process.env.DEBUG;
+
+afterEach(() => {
+  if (ORIGINAL_API_URL === undefined) {
+    delete process.env.MEMORIES_API_URL;
+  } else {
+    process.env.MEMORIES_API_URL = ORIGINAL_API_URL;
+  }
+
+  if (ORIGINAL_DEBUG === undefined) {
+    delete process.env.DEBUG;
+  } else {
+    process.env.DEBUG = ORIGINAL_DEBUG;
+  }
+});
+
+describe("env", () => {
+  it("uses the default API URL when MEMORIES_API_URL is unset", () => {
+    delete process.env.MEMORIES_API_URL;
+    expect(getApiUrl()).toBe("https://memories.sh");
+  });
+
+  it("normalizes MEMORIES_API_URL by trimming and removing trailing slashes", () => {
+    process.env.MEMORIES_API_URL = "  https://api.memories.sh///  ";
+    expect(getApiUrl()).toBe("https://api.memories.sh");
+  });
+
+  it("falls back to default URL when MEMORIES_API_URL normalizes to empty", () => {
+    process.env.MEMORIES_API_URL = "///";
+    expect(getApiUrl()).toBe("https://memories.sh");
+  });
+
+  it("treats empty and false-like DEBUG values as disabled", () => {
+    for (const value of ["", "0", "false", "FALSE", "off", "no", "n"]) {
+      process.env.DEBUG = value;
+      expect(isDebug()).toBe(false);
+    }
+
+    delete process.env.DEBUG;
+    expect(isDebug()).toBe(false);
+  });
+
+  it("enables debug for truthy DEBUG values", () => {
+    for (const value of ["1", "true", "yes", "verbose"]) {
+      process.env.DEBUG = value;
+      expect(isDebug()).toBe(true);
+    }
+  });
+});

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -8,7 +8,13 @@ export function getDataDir(): string {
 
 /** API URL for the memories.sh cloud service. */
 export function getApiUrl(): string {
-  return process.env.MEMORIES_API_URL || "https://memories.sh"
+  const configured = process.env.MEMORIES_API_URL?.trim()
+  if (!configured) {
+    return "https://memories.sh"
+  }
+
+  const normalized = configured.replace(/\/+$/, "")
+  return normalized || "https://memories.sh"
 }
 
 /** Turso platform API token (required for database provisioning). */
@@ -24,7 +30,17 @@ export function getTursoApiToken(): string {
 
 /** Whether debug logging is enabled. */
 export function isDebug(): boolean {
-  return Boolean(process.env.DEBUG)
+  const raw = process.env.DEBUG
+  if (!raw) {
+    return false
+  }
+
+  const normalized = raw.trim().toLowerCase()
+  if (!normalized) {
+    return false
+  }
+
+  return !["0", "false", "off", "no", "n"].includes(normalized)
 }
 
 /** Resolve the user's preferred text editor. */

--- a/packages/cli/src/lib/git.test.ts
+++ b/packages/cli/src/lib/git.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGitUrl } from "./git.js";
+
+describe("normalizeGitUrl", () => {
+  it("normalizes common git remote URL formats", () => {
+    const samples: Array<[string, string]> = [
+      ["git@github.com:webrenew/memories.git", "github.com/webrenew/memories"],
+      ["https://github.com/webrenew/memories.git", "github.com/webrenew/memories"],
+      ["https://github.com/webrenew/memories/", "github.com/webrenew/memories"],
+      ["ssh://git@github.com/webrenew/memories.git", "github.com/webrenew/memories"],
+      ["git+ssh://git@github.com/webrenew/memories.git", "github.com/webrenew/memories"],
+      ["git://github.com/webrenew/memories.git", "github.com/webrenew/memories"],
+      ["git@github.com:webrenew/memories.git/", "github.com/webrenew/memories"],
+    ];
+
+    for (const [input, expected] of samples) {
+      expect(normalizeGitUrl(input)).toBe(expected);
+    }
+  });
+
+  it("returns unknown remotes in trimmed form", () => {
+    expect(normalizeGitUrl("  custom-remote-format  ")).toBe("custom-remote-format");
+  });
+});

--- a/packages/cli/src/lib/reminders.test.ts
+++ b/packages/cli/src/lib/reminders.test.ts
@@ -35,6 +35,24 @@ describe("reminders", () => {
     if (!invalid.valid) {
       expect(invalid.error).toContain("5 fields");
     }
+
+    const invalidStep = validateCronExpression("*/a * * * *");
+    expect(invalidStep.valid).toBe(false);
+    if (!invalidStep.valid) {
+      expect(invalidStep.error).toContain("Invalid minute step");
+    }
+
+    const invalidSegment = validateCronExpression("*/2/3 * * * *");
+    expect(invalidSegment.valid).toBe(false);
+    if (!invalidSegment.valid) {
+      expect(invalidSegment.error).toContain("Invalid minute segment");
+    }
+
+    const invalidRange = validateCronExpression("1-2-3 * * * *");
+    expect(invalidRange.valid).toBe(false);
+    if (!invalidRange.valid) {
+      expect(invalidRange.error).toContain("Invalid minute range");
+    }
   });
 
   it("computes next reminder timestamp", () => {

--- a/packages/cli/src/lib/reminders.ts
+++ b/packages/cli/src/lib/reminders.ts
@@ -114,8 +114,17 @@ function parseField(field: string, min: number, max: number, label: string, allo
       throw new Error(`Invalid empty ${label} segment in "${field}"`);
     }
 
-    const [rangePartRaw, stepPartRaw] = segment.split("/");
-    const rangePart = rangePartRaw.trim();
+    const stepParts = segment.split("/");
+    if (stepParts.length > 2) {
+      throw new Error(`Invalid ${label} segment "${segment}"`);
+    }
+
+    const rangePart = stepParts[0].trim();
+    const stepPartRaw = stepParts[1]?.trim();
+    if (stepPartRaw !== undefined && !/^\d+$/.test(stepPartRaw)) {
+      throw new Error(`Invalid ${label} step in segment "${segment}"`);
+    }
+
     const step = stepPartRaw === undefined ? 1 : Number.parseInt(stepPartRaw, 10);
 
     if (!Number.isFinite(step) || step <= 0) {
@@ -127,8 +136,13 @@ function parseField(field: string, min: number, max: number, label: string, allo
       continue;
     }
 
-    if (rangePart.includes("-")) {
-      const [startRaw, endRaw] = rangePart.split("-");
+    const rangeParts = rangePart.split("-");
+    if (rangeParts.length > 2) {
+      throw new Error(`Invalid ${label} range in segment "${segment}"`);
+    }
+
+    if (rangeParts.length === 2) {
+      const [startRaw, endRaw] = rangeParts;
       const start = parseNumericValue(startRaw, min, max, label, allowDowSeven);
       const end = parseNumericValue(endRaw, min, max, label, allowDowSeven);
       addRangeWithStep(result, start, end, step, min, max, label, allowDowSeven);


### PR DESCRIPTION
## Summary
- harden cron segment parsing in reminders to reject malformed inputs (extra delimiters, non-numeric steps)
- broaden git remote normalization to support ssh://, git+ssh://, git:// and normalize trailing slash/.git suffixes
- normalize env parsing for MEMORIES_API_URL and DEBUG false-like values

## Testing
- pnpm -C packages/cli test -- src/lib/env.test.ts src/lib/git.test.ts src/lib/reminders.test.ts
- pnpm -C packages/cli typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parsing used to derive project IDs, API endpoints, and reminder schedules; while mostly hardening, normalization changes could alter behavior for previously accepted but non-standard inputs.
> 
> **Overview**
> Improves CLI robustness by normalizing `MEMORIES_API_URL` (trim + strip trailing slashes with safe fallback) and making `DEBUG` parsing treat common false-like values (`0`, `false`, `off`, etc.) as disabled, backed by new `env.test.ts`.
> 
> Expands git remote normalization by exporting `normalizeGitUrl()` and supporting additional URL-style remotes (`ssh://`, `git+ssh://`, `git://`), while consistently removing `.git` and trailing slashes; adds coverage in `git.test.ts`.
> 
> Tightens reminder cron parsing to explicitly reject malformed segments (extra `/` or `-` delimiters, non-numeric steps) and adds targeted validation tests for these error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3ad9dbe1089b474342a7fc9d3c16d111d73188b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->