### PR TITLE
feat(cli): harden bulk forget filtering and deletion counts

### DIFF
--- a/packages/cli/src/commands/forget.ts
+++ b/packages/cli/src/commands/forget.ts
@@ -68,6 +68,12 @@ export const forgetCommand = new Command("forget")
       const olderThanDays = opts.olderThan === undefined
         ? undefined
         : parsePositiveIntegerOption(opts.olderThan, "--older-than");
+      const projectId = opts.projectOnly ? (getProjectId() ?? undefined) : undefined;
+
+      if (opts.projectOnly && !projectId) {
+        ui.warn("Not in a git repository. No project memories to forget.");
+        return;
+      }
 
       // Bulk delete — need at least one filter
       const hasBulkFilter = opts.type || normalizedTag || olderThanDays !== undefined || normalizedPattern || opts.all;
@@ -95,7 +101,8 @@ export const forgetCommand = new Command("forget")
         olderThanDays,
         pattern: normalizedPattern,
         all: opts.all,
-        projectId: opts.projectOnly ? (getProjectId() ?? undefined) : undefined,
+        projectId,
+        projectOnly: opts.projectOnly ?? false,
       };
 
       // Preview

--- a/packages/cli/src/lib/memory-bulk.test.ts
+++ b/packages/cli/src/lib/memory-bulk.test.ts
@@ -1,0 +1,53 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+process.env.MEMORIES_DATA_DIR = mkdtempSync(join(tmpdir(), "memories-bulk-test-"));
+
+import { getDb } from "./db.js";
+import { addMemory, getMemoryById } from "./memory.js";
+import { bulkForgetByIds, findMemoriesToForget } from "./memory-bulk.js";
+
+describe("memory bulk", () => {
+  beforeAll(async () => {
+    await getDb();
+  });
+
+  it("returns no matches when projectOnly is requested without projectId", async () => {
+    await addMemory("global memory only", { global: true, type: "note" });
+
+    const matches = await findMemoriesToForget({ projectOnly: true });
+    expect(matches).toEqual([]);
+  });
+
+  it("normalizes tag filters by trimming and dropping empty entries", async () => {
+    const target = await addMemory("tag normalized target", {
+      global: true,
+      type: "note",
+      tags: ["bulk-filter-target"],
+    });
+    const other = await addMemory("tag normalized other", {
+      global: true,
+      type: "note",
+      tags: ["different-tag"],
+    });
+
+    const matches = await findMemoriesToForget({
+      tags: ["", "   ", " bulk-filter-target ", "bulk-filter-target"],
+    });
+
+    expect(matches.some((memory) => memory.id === target.id)).toBe(true);
+    expect(matches.some((memory) => memory.id === other.id)).toBe(false);
+  });
+
+  it("returns actual affected rows for duplicate and unknown IDs", async () => {
+    const one = await addMemory("bulk delete count one", { global: true, type: "note" });
+    const two = await addMemory("bulk delete count two", { global: true, type: "note" });
+
+    const count = await bulkForgetByIds([one.id, one.id, two.id, "missing-id", ""]);
+    expect(count).toBe(2);
+    expect(await getMemoryById(one.id)).toBeNull();
+    expect(await getMemoryById(two.id)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- make project-only bulk forget safe when no project is available by returning no matches instead of broad deletion
- normalize bulk forget filter inputs (trim and de-duplicate tags, trim pattern, escape backslashes in LIKE patterns)
- make bulk soft-delete counts accurate by de-duplicating IDs and returning actual rows affected

## Testing
- pnpm -C packages/cli test -- src/lib/memory-bulk.test.ts src/commands/forget.test.ts
- pnpm -C packages/cli typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bulk deletion and SQL filtering logic, which can affect what data gets deleted and what counts are reported. Changes are additive hardening with focused tests, but should be reviewed for query correctness across edge cases.
> 
> **Overview**
> Hardens `forget` bulk operations to avoid accidental broad deletes when `--project-only` is used outside a git repo, by short-circuiting with a warning and ensuring `findMemoriesToForget` returns no matches when `projectOnly` lacks a `projectId`.
> 
> Improves bulk filter robustness by trimming/de-duping tag filters, trimming patterns, and escaping backslashes in the generated SQL `LIKE` pattern. Bulk deletion now de-dupes/cleans input IDs and returns the actual SQLite `rowsAffected` count instead of the requested ID count, with new tests covering these edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b19d78de10cb58a89640439d5022a764966db514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->