### PR TITLE
Fix files scope isolation and canonical path keys

### DIFF
--- a/packages/cli/src/commands/files-constants.test.ts
+++ b/packages/cli/src/commands/files-constants.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  joinSyncedPath,
+  listOptionalConfigPaths,
+  normalizeSyncedPath,
+  OPTIONAL_CONFIG_INTEGRATIONS,
+} from "./files-constants.js";
+
+describe("files-constants path normalization", () => {
+  it("normalizes windows separators and relative prefixes", () => {
+    expect(normalizeSyncedPath(".\\.openclaw\\openclaw.json")).toBe(".openclaw/openclaw.json");
+    expect(normalizeSyncedPath("./.config/opencode/opencode.json")).toBe(".config/opencode/opencode.json");
+  });
+
+  it("joins synced path keys in canonical POSIX format", () => {
+    expect(joinSyncedPath(".config/opencode", "opencode.json")).toBe(".config/opencode/opencode.json");
+    expect(joinSyncedPath(".openclaw", "openclaw.json")).toBe(".openclaw/openclaw.json");
+  });
+
+  it("keeps optional config keys compatible with normalized paths", () => {
+    const paths = listOptionalConfigPaths();
+    expect(paths).toContain(".config/opencode/opencode.json");
+    expect(paths).toContain(".openclaw/openclaw.json");
+    expect(paths.every((path) => !path.includes("\\"))).toBe(true);
+
+    expect(OPTIONAL_CONFIG_INTEGRATIONS.get(".config/opencode/opencode.json")).toBe("opencode");
+    expect(OPTIONAL_CONFIG_INTEGRATIONS.get(".openclaw/openclaw.json")).toBe("openclaw");
+  });
+});

--- a/packages/cli/src/commands/files-helpers.test.ts
+++ b/packages/cli/src/commands/files-helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildApplyScopeFilter,
+  resolveProjectScope,
+  scanTarget,
+  selectScopedFileMatch,
+} from "./files-helpers.js";
+
+describe("files-helpers scope resolution", () => {
+  it("normalizes project scope ids", () => {
+    expect(resolveProjectScope(" github.com/acme/repo ")).toBe("github.com/acme/repo");
+    expect(resolveProjectScope("")).toBeNull();
+    expect(resolveProjectScope(null)).toBeNull();
+  });
+
+  it("builds apply filter for project-only and mixed scopes", () => {
+    expect(buildApplyScopeFilter({ project: true }, "github.com/acme/repo")).toEqual({
+      clause: "scope = ?",
+      args: ["github.com/acme/repo"],
+    });
+
+    expect(buildApplyScopeFilter({ global: true, project: true }, "github.com/acme/repo")).toEqual({
+      clause: "(scope = 'global' OR scope = ?)",
+      args: ["github.com/acme/repo"],
+    });
+  });
+
+  it("returns safe filters and warnings when project scope is unavailable", () => {
+    const projectOnly = buildApplyScopeFilter({ project: true }, null);
+    expect(projectOnly.clause).toBe("scope = 'global' AND 1 = 0");
+    expect(projectOnly.args).toEqual([]);
+    expect(projectOnly.warning).toBeTruthy();
+
+    const mixed = buildApplyScopeFilter({ global: true, project: true }, null);
+    expect(mixed).toEqual({
+      clause: "scope = 'global'",
+      args: [],
+      warning: "Project scope requested, but no git project id was detected. Applying global files only.",
+    });
+  });
+
+  it("detects ambiguous path matches and resolves explicit scope selection", () => {
+    const rows = [
+      { scope: "global", value: "g" },
+      { scope: "github.com/acme/repo", value: "p" },
+    ];
+
+    const ambiguous = selectScopedFileMatch(rows);
+    expect(ambiguous.ambiguous).toBe(true);
+    expect(ambiguous.match).toBeNull();
+    expect(ambiguous.availableScopes).toEqual(["github.com/acme/repo", "global"]);
+
+    const scoped = selectScopedFileMatch(rows, "github.com/acme/repo");
+    expect(scoped.ambiguous).toBe(false);
+    expect(scoped.match).toEqual({ scope: "github.com/acme/repo", value: "p" });
+  });
+});
+
+describe("files-helpers scanTarget", () => {
+  it("returns normalized synced paths for discovered files", async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), "memories-files-scan-"));
+    const targetDir = join(baseDir, ".agents", "commands");
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, "review.md"), "# review");
+
+    const files = await scanTarget(baseDir, { dir: ".agents/commands", pattern: /\.md$/ });
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(".agents/commands/review.md");
+  });
+});


### PR DESCRIPTION
## Summary\n- persist project file records using the actual git project scope id instead of literal `project`\n- make `files apply` scope filtering explicit for global/project combinations and warn when project scope is unavailable\n- require disambiguation for `files show`/`files forget` when a path exists in multiple scopes and add `--scope` support\n- canonicalize synced file keys to POSIX-style paths to avoid cross-platform key mismatches\n- add regression tests for scope filter logic, scoped row selection, and path normalization\n\n## Validation\n- pnpm --filter @memories.sh/cli typecheck\n- pnpm --filter @memories.sh/cli test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how file records are keyed and filtered by scope/path, which can affect which files are applied/shown/forgotten and may expose existing data inconsistencies across scopes or OS path formats.
> 
> **Overview**
> **Fixes scope isolation and cross-platform key consistency** for the `memories files` CLI by storing project files under the actual git project id (instead of a literal `project`) and by canonicalizing synced file paths to POSIX-style keys.
> 
> `files apply` now uses an explicit, safe SQL scope filter (with warnings when `--project` is requested but no project id is available), and `files show`/`files forget` now normalize input paths and require `--scope` disambiguation when the same path exists in multiple scopes.
> 
> Adds Vitest coverage for path normalization/joining, scope filter construction, scoped row selection, and `scanTarget` path output normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f8f9b0c57ddffb216a2e95877184bc2e876d01a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->