### PR TITLE
feat(cli): add memory_layer + expiry schema parity

### DIFF
--- a/packages/cli/src/mcp/formatters.test.ts
+++ b/packages/cli/src/mcp/formatters.test.ts
@@ -14,6 +14,8 @@ function makeMemory(overrides: Partial<Memory> = {}): Memory {
     type: "rule",
     scope: "project",
     project_id: "github.com/org/repo",
+    memory_layer: "rule",
+    expires_at: null,
     tags: null,
     paths: null,
     category: null,

--- a/reports/agent-memory-lifecycle-spec.md
+++ b/reports/agent-memory-lifecycle-spec.md
@@ -306,6 +306,19 @@ Write triggers:
 2. PR-7.2 `feat(eval): replay/eval harness for memory extraction and compaction quality`
 3. PR-7.3 `chore(rollout): default-on flags, deprecate legacy paths, finalize docs`
 
+## Delivery Tracker
+
+- [x] Spec merged: `reports/agent-memory-lifecycle-spec.md` (PR #287, 2026-02-26)
+- [ ] PR-1.1 `feat(cli): add memory_layer + expiry schema parity` (in progress)
+- [ ] PR-1.2 `feat(cli/mcp): layer-aware add/list/search/recall and context modes`
+- [ ] PR-1.3 `test/docs: parity matrix tests and migration notes`
+- [ ] Phase 2 PRs (2.1-2.3)
+- [ ] Phase 3 PRs (3.1-3.3)
+- [ ] Phase 4 PRs (4.1-4.3)
+- [ ] Phase 5 PRs (5.1-5.3)
+- [ ] Phase 6 PRs (6.1-6.3)
+- [ ] Phase 7 PRs (7.1-7.3)
+
 ## Phase Gates and Acceptance
 
 1. Phase 1 gate: CLI and hosted return equivalent `layer` behavior for add/list/search/context.


### PR DESCRIPTION
## Summary
- add CLI migration parity for `memory_layer` + `expires_at` columns on `memories`
- backfill legacy rows (`rule` layer mapping, null layer defaulting, working-layer expiry backfill) and add new memory-layer indexes
- make CLI memory model layer-aware with default layer routing and working-memory TTL expiry assignment
- filter expired working memories out of read paths (`getMemoryById`, `searchMemories`, `listMemories`, `getRules`)
- add/extend tests for schema parity, layer defaults, working expiry behavior, and fixture compatibility
- add a delivery tracker checklist to the lifecycle spec artifact

## Test Plan
- `pnpm -C packages/cli test src/lib/memory.test.ts src/lib/db.test.ts src/mcp/formatters.test.ts`
- `pnpm -C packages/cli typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new columns/indexes and backfill logic to the local `memories` table and changes read queries to exclude expired rows, which could affect retrieval behavior or hide data if migrations/TTL handling are wrong.
> 
> **Overview**
> Adds local DB migration parity for memory lifecycle by introducing `memories.memory_layer` (default `long_term`) and `memories.expires_at`, plus backfills legacy rows (map `type='rule'` to `memory_layer='rule'`, default missing layers, and set a default expiry for existing `working` rows) and creates new lifecycle indexes.
> 
> Updates the CLI memory model and write/read paths to be layer-aware: `addMemory` now chooses a default layer from `type`, assigns a TTL-based `expires_at` for `working` memories (configurable via `MEMORIES_WORKING_MEMORY_TTL_HOURS`/`MCP_WORKING_MEMORY_TTL_HOURS`), and `getMemoryById`/`searchMemories`/`listMemories`/`getRules` now filter out expired memories.
> 
> Extends tests to assert the new schema/indexes, layer defaulting/expiry behavior, and that expired working memories are hidden; updates MCP formatter fixtures and adds a delivery-tracker section to `reports/agent-memory-lifecycle-spec.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e1a5e757f82d3d76dd6c936f40ef36ecd2fbf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->