### PR TITLE
feat(cli/mcp): layer-aware add/list/search/recall and context modes

### DIFF
--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -15,11 +15,12 @@ describe("list", () => {
     await addMemory("Decision one", { type: "decision", global: true });
     await addMemory("Fact one", { type: "fact", global: true, tags: ["api"] });
     await addMemory("Note one", { type: "note", global: true, tags: ["api", "testing"] });
+    await addMemory("Working scratchpad", { type: "note", layer: "working", global: true, tags: ["wip"] });
   });
 
   it("should list all memories", async () => {
     const memories = await listMemories({ limit: 50 });
-    expect(memories.length).toBe(4);
+    expect(memories.length).toBe(5);
   });
 
   it("should filter by type", async () => {
@@ -40,9 +41,20 @@ describe("list", () => {
 
   it("should filter global-only memories", async () => {
     const global = await listMemories({ limit: 50, globalOnly: true });
-    expect(global.length).toBe(4);
+    expect(global.length).toBe(5);
     for (const m of global) {
       expect(m.scope).toBe("global");
     }
+  });
+
+  it("should filter by layer", async () => {
+    const working = await listMemories({ limit: 50, layers: ["working"] });
+    expect(working.length).toBe(1);
+    expect(working[0].memory_layer).toBe("working");
+
+    const longTerm = await listMemories({ limit: 50, layers: ["long_term"] });
+    expect(longTerm.length).toBeGreaterThan(0);
+    expect(longTerm.every((m) => m.memory_layer === "long_term" || m.memory_layer === null)).toBe(true);
+    expect(longTerm.some((m) => m.memory_layer === "working")).toBe(false);
   });
 });

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,6 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listMemories, isMemoryType, MEMORY_TYPES, type Memory, type MemoryType } from "../lib/memory.js";
+import {
+  listMemories,
+  isMemoryType,
+  MEMORY_TYPES,
+  isMemoryLayer,
+  MEMORY_LAYERS,
+  type Memory,
+  type MemoryLayer,
+  type MemoryType,
+} from "../lib/memory.js";
 import * as ui from "../lib/ui.js";
 import { getProjectId } from "../lib/git.js";
 
@@ -42,6 +51,7 @@ export const listCommand = new Command("list")
   .option("-l, --limit <n>", "Max results", "50")
   .option("-t, --tags <tags>", "Filter by comma-separated tags")
   .option("--type <type>", "Filter by type: rule, decision, fact, note")
+  .option("--layer <layer>", "Filter by layer: rule, working, long_term")
   .option("-g, --global", "Show only global memories")
   .option("--project-only", "Show only project memories (exclude global)")
   .option("--json", "Output as JSON")
@@ -49,6 +59,7 @@ export const listCommand = new Command("list")
     limit: string; 
     tags?: string; 
     type?: string;
+    layer?: string;
     global?: boolean; 
     projectOnly?: boolean;
     json?: boolean;
@@ -64,6 +75,15 @@ export const listCommand = new Command("list")
           process.exit(1);
         }
         types = [opts.type];
+      }
+
+      let layers: MemoryLayer[] | undefined;
+      if (opts.layer) {
+        if (!isMemoryLayer(opts.layer)) {
+          ui.error(`Invalid layer "${opts.layer}". Valid layers: ${MEMORY_LAYERS.join(", ")}`);
+          process.exit(1);
+        }
+        layers = [opts.layer];
       }
       
       // Determine scope filtering
@@ -86,6 +106,7 @@ export const listCommand = new Command("list")
         limit: parseInt(opts.limit, 10),
         tags,
         types,
+        layers,
         projectId,
         includeGlobal,
         globalOnly,

--- a/packages/cli/src/commands/recall.test.ts
+++ b/packages/cli/src/commands/recall.test.ts
@@ -15,6 +15,8 @@ describe("recall", () => {
     await addMemory("Prefer functional components", { type: "rule", global: true });
     await addMemory("API limit is 100/min", { type: "fact", global: true });
     await addMemory("Chose React over Vue", { type: "decision", global: true });
+    await addMemory("API working draft notes", { type: "note", layer: "working", global: true });
+    await addMemory("API long-term architecture", { type: "note", layer: "long_term", global: true });
   });
 
   it("should return rules via getRules", async () => {
@@ -36,5 +38,25 @@ describe("recall", () => {
     expect(rules.length).toBe(2);
     // Without query, memories may be empty or contain recent non-rule memories
     expect(Array.isArray(memories)).toBe(true);
+  });
+
+  it("should support working mode", async () => {
+    const { rules, memories } = await getContext("API", { limit: 10, mode: "working" });
+    expect(rules.length).toBe(2);
+    expect(memories.length).toBeGreaterThan(0);
+    expect(memories.every((memory) => memory.memory_layer === "working")).toBe(true);
+  });
+
+  it("should support long_term mode", async () => {
+    const { rules, memories } = await getContext("API", { limit: 10, mode: "long_term" });
+    expect(rules.length).toBe(2);
+    expect(memories.length).toBeGreaterThan(0);
+    expect(memories.every((memory) => memory.memory_layer === "long_term" || memory.memory_layer === null)).toBe(true);
+  });
+
+  it("should support rules_only mode", async () => {
+    const { rules, memories } = await getContext("API", { limit: 10, mode: "rules_only" });
+    expect(rules.length).toBe(2);
+    expect(memories).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/search.test.ts
+++ b/packages/cli/src/commands/search.test.ts
@@ -15,6 +15,8 @@ describe("search", () => {
     await addMemory("API rate limit is 100 requests per minute", { type: "fact", global: true });
     await addMemory("Chose PostgreSQL for JSONB support", { type: "decision", global: true });
     await addMemory("Meeting notes from January standup", { type: "note", global: true });
+    await addMemory("Deployment draft checklist", { type: "note", layer: "working", global: true });
+    await addMemory("Deployment runbook finalized", { type: "fact", layer: "long_term", global: true });
   });
 
   it("should find memories by keyword", async () => {
@@ -39,5 +41,16 @@ describe("search", () => {
   it("should respect limit", async () => {
     const results = await searchMemories("a", { limit: 1 });
     expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it("should filter search by layer", async () => {
+    const working = await searchMemories("Deployment", { limit: 10, layers: ["working"] });
+    expect(working.length).toBeGreaterThan(0);
+    expect(working.every((entry) => entry.memory_layer === "working")).toBe(true);
+
+    const longTerm = await searchMemories("Deployment", { limit: 10, layers: ["long_term"] });
+    expect(longTerm.length).toBeGreaterThan(0);
+    expect(longTerm.some((entry) => entry.content.includes("runbook finalized"))).toBe(true);
+    expect(longTerm.every((entry) => entry.memory_layer === "long_term" || entry.memory_layer === null)).toBe(true);
   });
 });

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -5,10 +5,14 @@ import { registerCoreTools } from "./tools.js";
 describe("registerCoreTools", () => {
   it("registers reminder MCP tools", () => {
     const names: string[] = [];
+    const schemas = new Map<string, Record<string, unknown>>();
 
     const server = {
-      tool(name: string) {
+      tool(name: string, _description?: string, schema?: Record<string, unknown>) {
         names.push(name);
+        if (schema) {
+          schemas.set(name, schema);
+        }
       },
     } as unknown as McpServer;
 
@@ -20,5 +24,18 @@ describe("registerCoreTools", () => {
     expect(names).toContain("enable_reminder");
     expect(names).toContain("disable_reminder");
     expect(names).toContain("delete_reminder");
+
+    expect(schemas.get("get_context")).toHaveProperty("mode");
+    expect(schemas.get("add_memory")).toHaveProperty("layer");
+
+    // Backward + forward compatibility for core SDK client and existing callers.
+    expect(schemas.get("search_memories")).toHaveProperty("type");
+    expect(schemas.get("search_memories")).toHaveProperty("types");
+    expect(schemas.get("search_memories")).toHaveProperty("layer");
+
+    expect(schemas.get("list_memories")).toHaveProperty("type");
+    expect(schemas.get("list_memories")).toHaveProperty("types");
+    expect(schemas.get("list_memories")).toHaveProperty("layer");
+    expect(schemas.get("list_memories")).toHaveProperty("tags");
   });
 });

--- a/reports/agent-memory-lifecycle-spec.md
+++ b/reports/agent-memory-lifecycle-spec.md
@@ -309,8 +309,8 @@ Write triggers:
 ## Delivery Tracker
 
 - [x] Spec merged: `reports/agent-memory-lifecycle-spec.md` (PR #287, 2026-02-26)
-- [ ] PR-1.1 `feat(cli): add memory_layer + expiry schema parity` (in progress)
-- [ ] PR-1.2 `feat(cli/mcp): layer-aware add/list/search/recall and context modes`
+- [ ] PR-1.1 `feat(cli): add memory_layer + expiry schema parity` (open: #288, auto-merge enabled)
+- [ ] PR-1.2 `feat(cli/mcp): layer-aware add/list/search/recall and context modes` (in progress)
 - [ ] PR-1.3 `test/docs: parity matrix tests and migration notes`
 - [ ] Phase 2 PRs (2.1-2.3)
 - [ ] Phase 3 PRs (3.1-3.3)


### PR DESCRIPTION
## Summary
- add context mode support in CLI memory retrieval (`all`, `working`, `long_term`, `rules_only`) and wire it into `getContext`
- add layer filtering support to core CLI memory search/list paths and semantic search (`rule`, `working`, `long_term`)
- update CLI command surfaces:
  - `memories add --layer`
  - `memories list --layer`
  - `memories search --layer`
  - `memories recall --mode`
- update MCP tool schemas/handlers for parity:
  - `get_context` now accepts `mode`
  - `add_memory` now accepts `layer`
  - `search_memories`/`list_memories` now accept `type` + `layer` while keeping `types` compatibility
  - `list_memories` now accepts `tags` as array or comma-separated string for core SDK MCP compatibility
- extend tests for layer filters, context modes, and MCP schema registration coverage
- update delivery tracker artifact to mark PR-1.2 in progress

## Test Plan
- `pnpm -C packages/cli test src/lib/memory.test.ts src/commands/list.test.ts src/commands/search.test.ts src/commands/recall.test.ts src/mcp/tools.test.ts`
- `pnpm -C packages/cli typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core memory retrieval/filtering behavior (new `layer` semantics and context modes) across CLI, MCP tools, and semantic search, which could affect what results users/agents see. Compatibility is mostly preserved, but query logic changes warrant careful review/testing.
> 
> **Overview**
> Adds **layer-aware** memory operations end-to-end: `memories add` can set `--layer`, and `list`/`search`/semantic search now accept a `--layer` filter that is enforced in SQL via a shared layer filter helper.
> 
> Extends context retrieval with **modes** (`all`, `working`, `long_term`, `rules_only`): `memories recall --mode` and MCP `get_context` pass through to `getContext`, which conditionally restricts returned memories (or returns rules only).
> 
> Updates MCP tool schemas/handlers for parity and compatibility: `add_memory` accepts `layer`, `search_memories`/`list_memories` add single `type`/`layer` while keeping `types`, and `list_memories` accepts `tags` as array or comma-separated string; tests are expanded to cover layer filters, modes, and schema registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cada5719897b1101a032c650feeb483423fd8c08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->