### PR TITLE
feat(api/mcp/cli): consolidate endpoint/tool/command and review workflows

### DIFF
--- a/packages/cli/src/commands/consolidate.test.ts
+++ b/packages/cli/src/commands/consolidate.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { consolidateCommand } from "./consolidate.js";
+
+describe("consolidate command", () => {
+  it("registers run subcommand", () => {
+    const names = consolidateCommand.commands.map((command) => command.name());
+    expect(names).toEqual(expect.arrayContaining(["run"]));
+  });
+});

--- a/packages/cli/src/commands/consolidate.ts
+++ b/packages/cli/src/commands/consolidate.ts
@@ -1,0 +1,91 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import * as ui from "../lib/ui.js";
+import { consolidateMemories, isMemoryType, type MemoryType } from "../lib/memory.js";
+
+const DEFAULT_TYPES: readonly MemoryType[] = ["rule", "decision", "fact", "note"] as const;
+
+function parseTypesOption(value: string | undefined): MemoryType[] | undefined {
+  if (!value) return undefined;
+
+  const parsed = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (parsed.length === 0) return undefined;
+
+  const unique = [...new Set(parsed)];
+  const invalid = unique.filter((candidate) => !isMemoryType(candidate));
+  if (invalid.length > 0) {
+    throw new Error(`Invalid memory types: ${invalid.join(", ")}`);
+  }
+
+  return unique as MemoryType[];
+}
+
+export const consolidateCommand = new Command("consolidate")
+  .description("Run memory consolidation workflows");
+
+consolidateCommand.addCommand(
+  new Command("run")
+    .description("Consolidate duplicate memories and supersede outdated entries")
+    .option(
+      "--types <types>",
+      `Comma-separated memory types to include (default: ${DEFAULT_TYPES.join(",")})`
+    )
+    .option("--project-id <id>", "Explicit project id (defaults to current git project)")
+    .option("--global-only", "Restrict consolidation to global memories only")
+    .option("--no-include-global", "Exclude global memories from project-scoped runs")
+    .option("--dry-run", "Preview consolidation effects without mutating memory rows")
+    .option("--model <name>", "Optional model identifier used for audit metadata")
+    .option("--json", "Output as JSON")
+    .action(async (opts: {
+      types?: string;
+      projectId?: string;
+      globalOnly?: boolean;
+      includeGlobal?: boolean;
+      dryRun?: boolean;
+      model?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const types = parseTypesOption(opts.types) ?? [...DEFAULT_TYPES];
+        if (opts.globalOnly && opts.projectId?.trim()) {
+          ui.warn("Ignoring --project-id because --global-only was provided.");
+        }
+
+        const result = await consolidateMemories({
+          projectId: opts.globalOnly ? undefined : opts.projectId?.trim() || undefined,
+          includeGlobal: opts.includeGlobal,
+          globalOnly: opts.globalOnly,
+          types,
+          dryRun: opts.dryRun,
+          model: opts.model?.trim() || undefined,
+        });
+
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        const summary = opts.dryRun ? "Dry-run consolidation complete." : "Consolidation complete.";
+        ui.success(summary);
+        ui.dim(
+          `Run ${result.run.id}: input=${result.run.input_count}, merged=${result.run.merged_count}, superseded=${result.run.superseded_count}, conflicts=${result.run.conflicted_count}`
+        );
+
+        if (result.supersededMemoryIds.length > 0) {
+          console.log("");
+          console.log(
+            `${chalk.bold("Superseded memories:")} ${result.supersededMemoryIds.length} (${result.supersededMemoryIds
+              .slice(0, 8)
+              .join(", ")}${result.supersededMemoryIds.length > 8 ? ", ..." : ""})`
+          );
+        }
+      } catch (error) {
+        ui.error(`Failed to run consolidation: ${error instanceof Error ? error.message : "Unknown error"}`);
+        process.exit(1);
+      }
+    })
+);

--- a/packages/cli/src/commands/stale.ts
+++ b/packages/cli/src/commands/stale.ts
@@ -2,7 +2,6 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as ui from "../lib/ui.js";
 import { getDb } from "../lib/db.js";
-import { getProjectId } from "../lib/git.js";
 import { forgetMemory, isMemoryType, MEMORY_TYPES, type MemoryType } from "../lib/memory.js";
 import { createInterface } from "node:readline/promises";
 import { parsePositiveIntegerOption } from "../lib/cli-options.js";
@@ -19,9 +18,40 @@ interface StaleMemory {
   content: string;
   type: MemoryType;
   scope: string;
+  superseded_by: string | null;
+  superseded_at: string | null;
+  has_conflict: number;
   created_at: string;
   updated_at: string;
   days_old: number;
+}
+
+function buildSupersessionFilter(opts: {
+  includeSuperseded?: boolean;
+  supersededOnly?: boolean;
+}): string {
+  if (opts.supersededOnly) {
+    return "m.superseded_at IS NOT NULL";
+  }
+  if (opts.includeSuperseded) {
+    return "1 = 1";
+  }
+  return "m.superseded_at IS NULL";
+}
+
+async function ensureMemoryLinksTable(): Promise<void> {
+  const db = await getDb();
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS memory_links (
+      id TEXT PRIMARY KEY,
+      source_id TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      link_type TEXT NOT NULL DEFAULT 'related',
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  await db.execute(`CREATE INDEX IF NOT EXISTS idx_links_source ON memory_links(source_id)`);
+  await db.execute(`CREATE INDEX IF NOT EXISTS idx_links_target ON memory_links(target_id)`);
 }
 
 async function prompt(message: string): Promise<string> {
@@ -35,30 +65,59 @@ export const staleCommand = new Command("stale")
   .description("Find memories that haven't been updated in a while")
   .option("--days <n>", "Staleness threshold in days (default: 90)", "90")
   .option("--type <type>", "Filter by memory type: rule, decision, fact, note")
+  .option("--include-superseded", "Include already superseded memories")
+  .option("--superseded-only", "Only show superseded memories")
+  .option("--conflicts-only", "Only show memories with contradiction links")
   .option("--json", "Output as JSON")
-  .action(async (opts: { days: string; type?: string; json?: boolean }) => {
+  .action(async (opts: {
+    days: string;
+    type?: string;
+    includeSuperseded?: boolean;
+    supersededOnly?: boolean;
+    conflictsOnly?: boolean;
+    json?: boolean;
+  }) => {
     try {
       const db = await getDb();
+      await ensureMemoryLinksTable();
       const days = parsePositiveIntegerOption(opts.days, "--days");
-      const projectId = getProjectId() ?? undefined;
 
       if (opts.type && !isMemoryType(opts.type)) {
         ui.error(`Invalid type "${opts.type}". Valid: ${MEMORY_TYPES.join(", ")}`);
         process.exit(1);
       }
 
+      if (opts.includeSuperseded && opts.supersededOnly) {
+        ui.error("Cannot combine --include-superseded with --superseded-only");
+        process.exit(1);
+      }
+
       let sql = `
-        SELECT id, content, type, scope, created_at, updated_at,
-               CAST((julianday('now') - julianday(COALESCE(updated_at, created_at))) AS INTEGER) as days_old
-        FROM memories 
-        WHERE deleted_at IS NULL 
-          AND (julianday('now') - julianday(COALESCE(updated_at, created_at))) > ?
+        SELECT m.id, m.content, m.type, m.scope, m.superseded_by, m.superseded_at, m.created_at, m.updated_at,
+               CAST((julianday('now') - julianday(COALESCE(m.updated_at, m.created_at))) AS INTEGER) as days_old,
+               CASE
+                 WHEN EXISTS (
+                   SELECT 1 FROM memory_links l
+                   WHERE (l.source_id = m.id OR l.target_id = m.id) AND l.link_type = 'contradicts'
+                 ) THEN 1 ELSE 0
+               END as has_conflict
+        FROM memories m
+        WHERE m.deleted_at IS NULL
+          AND ${buildSupersessionFilter(opts)}
+          AND (julianday('now') - julianday(COALESCE(m.updated_at, m.created_at))) > ?
       `;
       const args: (string | number)[] = [days];
 
       if (opts.type) {
-        sql += " AND type = ?";
+        sql += " AND m.type = ?";
         args.push(opts.type);
+      }
+
+      if (opts.conflictsOnly) {
+        sql += ` AND EXISTS (
+          SELECT 1 FROM memory_links l
+          WHERE (l.source_id = m.id OR l.target_id = m.id) AND l.link_type = 'contradicts'
+        )`;
       }
 
       sql += " ORDER BY days_old DESC";
@@ -82,7 +141,10 @@ export const staleCommand = new Command("stale")
         const icon = TYPE_ICONS[m.type] || "📝";
         const scope = m.scope === "global" ? chalk.dim("G") : chalk.dim("P");
         const preview = m.content.length > 50 ? m.content.slice(0, 47) + "..." : m.content;
-        console.log(`  ${icon} ${scope} ${chalk.dim(m.id)}  ${preview}  ${chalk.yellow(`${m.days_old}d`)}`);
+        const superseded = m.superseded_at ? chalk.magenta("superseded") : "";
+        const conflict = m.has_conflict ? chalk.red("conflict") : "";
+        const status = [superseded, conflict].filter(Boolean).join(" ");
+        console.log(`  ${icon} ${scope} ${chalk.dim(m.id)}  ${preview}  ${chalk.yellow(`${m.days_old}d`)} ${status}`.trimEnd());
       }
 
       if (stale.length > 30) {
@@ -106,18 +168,40 @@ export const staleCommand = new Command("stale")
 export const reviewCommand = new Command("review")
   .description("Interactively review and clean up stale memories")
   .option("--days <n>", "Staleness threshold in days (default: 90)", "90")
-  .action(async (opts: { days: string }) => {
+  .option("--include-superseded", "Include already superseded memories")
+  .option("--superseded-only", "Only review superseded memories")
+  .option("--conflicts-only", "Only review memories with contradiction links")
+  .action(async (opts: {
+    days: string;
+    includeSuperseded?: boolean;
+    supersededOnly?: boolean;
+    conflictsOnly?: boolean;
+  }) => {
     try {
       const db = await getDb();
+      await ensureMemoryLinksTable();
       const days = parsePositiveIntegerOption(opts.days, "--days");
+
+      if (opts.includeSuperseded && opts.supersededOnly) {
+        ui.error("Cannot combine --include-superseded with --superseded-only");
+        process.exit(1);
+      }
 
       const result = await db.execute({
         sql: `
-          SELECT id, content, type, scope, created_at, updated_at,
-                 CAST((julianday('now') - julianday(COALESCE(updated_at, created_at))) AS INTEGER) as days_old
-          FROM memories 
-          WHERE deleted_at IS NULL 
-            AND (julianday('now') - julianday(COALESCE(updated_at, created_at))) > ?
+          SELECT m.id, m.content, m.type, m.scope, m.superseded_by, m.superseded_at, m.created_at, m.updated_at,
+                 CAST((julianday('now') - julianday(COALESCE(m.updated_at, m.created_at))) AS INTEGER) as days_old,
+                 CASE
+                   WHEN EXISTS (
+                     SELECT 1 FROM memory_links l
+                     WHERE (l.source_id = m.id OR l.target_id = m.id) AND l.link_type = 'contradicts'
+                   ) THEN 1 ELSE 0
+                 END as has_conflict
+          FROM memories m
+          WHERE m.deleted_at IS NULL
+            AND ${buildSupersessionFilter(opts)}
+            AND (julianday('now') - julianday(COALESCE(m.updated_at, m.created_at))) > ?
+            ${opts.conflictsOnly ? "AND EXISTS (SELECT 1 FROM memory_links l WHERE (l.source_id = m.id OR l.target_id = m.id) AND l.link_type = 'contradicts')" : ""}
           ORDER BY days_old DESC
         `,
         args: [days],
@@ -137,7 +221,11 @@ export const reviewCommand = new Command("review")
         const icon = TYPE_ICONS[m.type] || "📝";
         console.log(`${icon} ${chalk.bold(m.type.toUpperCase())} (${m.scope})`);
         console.log(`   "${m.content}"`);
-        console.log(chalk.dim(`   Last updated: ${m.days_old} days ago`));
+        const status = [
+          m.superseded_at ? "superseded" : null,
+          m.has_conflict ? "conflict" : null,
+        ].filter(Boolean).join(", ");
+        console.log(chalk.dim(`   Last updated: ${m.days_old} days ago${status ? ` | ${status}` : ""}`));
         console.log("");
 
         const answer = await prompt("   [k]eep  [d]elete  [s]kip  [q]uit > ");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import { remindersCommand } from "./commands/reminders.js";
 import { sessionCommand } from "./commands/session.js";
 import { compactCommand } from "./commands/compact.js";
 import { openclawCommand } from "./commands/openclaw.js";
+import { consolidateCommand } from "./commands/consolidate.js";
 import { CLI_VERSION } from "./lib/version.js";
 
 const program = new Command()
@@ -80,6 +81,7 @@ program.addCommand(remindersCommand);
 program.addCommand(sessionCommand);
 program.addCommand(compactCommand);
 program.addCommand(openclawCommand);
+program.addCommand(consolidateCommand);
 
 // Auth commands
 program.addCommand(loginCommand);

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -28,6 +28,7 @@ describe("registerCoreTools", () => {
     expect(names).toContain("checkpoint_session");
     expect(names).toContain("end_session");
     expect(names).toContain("snapshot_session");
+    expect(names).toContain("consolidate_memories");
 
     expect(schemas.get("get_context")).toHaveProperty("mode");
     expect(schemas.get("get_context")).toHaveProperty("session_id");
@@ -44,6 +45,9 @@ describe("registerCoreTools", () => {
     expect(schemas.get("end_session")).toHaveProperty("status");
     expect(schemas.get("snapshot_session")).toHaveProperty("source_trigger");
     expect(schemas.get("snapshot_session")).toHaveProperty("transcript_md");
+    expect(schemas.get("consolidate_memories")).toHaveProperty("types");
+    expect(schemas.get("consolidate_memories")).toHaveProperty("dry_run");
+    expect(schemas.get("consolidate_memories")).toHaveProperty("project_id");
 
     // Backward + forward compatibility for core SDK client and existing callers.
     expect(schemas.get("search_memories")).toHaveProperty("type");

--- a/packages/web/src/app/api/sdk/v1/memories/consolidate/route.ts
+++ b/packages/web/src/app/api/sdk/v1/memories/consolidate/route.ts
@@ -1,0 +1,116 @@
+import { consolidateMemoriesPayload } from "@/lib/memory-service/mutations"
+import { apiError, ensureMemoryUserIdSchema, parseTenantId, parseUserId, ToolExecutionError } from "@/lib/memory-service/tools"
+import {
+  authenticateApiKey,
+  errorResponse,
+  getApiKey,
+  invalidRequestResponse,
+  resolveTursoForScope,
+  successResponse,
+} from "@/lib/sdk-api/runtime"
+import { memoryTypeSchema, scopeSchema } from "@/lib/sdk-api/schemas"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+const ENDPOINT = "/api/sdk/v1/memories/consolidate"
+
+const requestSchema = z.object({
+  scope: scopeSchema,
+  types: z.array(memoryTypeSchema).min(1).optional(),
+  includeGlobal: z.boolean().optional(),
+  globalOnly: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+  model: z.string().trim().min(1).max(160).optional(),
+})
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const apiKey = getApiKey(request)
+  if (!apiKey) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "auth_error",
+        code: "MISSING_API_KEY",
+        message: "Missing API key",
+        status: 401,
+        retryable: false,
+      })
+    )
+  }
+
+  const authResult = await authenticateApiKey(apiKey, ENDPOINT, requestId)
+  if (authResult instanceof NextResponse) {
+    return authResult
+  }
+
+  let parsedRequest: z.infer<typeof requestSchema>
+  try {
+    parsedRequest = requestSchema.parse(await request.json())
+  } catch {
+    return invalidRequestResponse(ENDPOINT, requestId)
+  }
+
+  try {
+    const tenantId = parseTenantId({ tenant_id: parsedRequest.scope?.tenantId })
+    const userId = parseUserId({ user_id: parsedRequest.scope?.userId })
+    const projectId = parsedRequest.scope?.projectId
+
+    const turso = await resolveTursoForScope({
+      ownerUserId: authResult.userId,
+      apiKeyHash: authResult.apiKeyHash,
+      tenantId,
+      projectId,
+      endpoint: ENDPOINT,
+      requestId,
+    })
+
+    if (turso instanceof NextResponse) {
+      return turso
+    }
+
+    await ensureMemoryUserIdSchema(turso)
+
+    const payload = await consolidateMemoriesPayload({
+      turso,
+      args: {
+        types: parsedRequest.types,
+        includeGlobal: parsedRequest.includeGlobal,
+        globalOnly: parsedRequest.globalOnly,
+        dryRun: parsedRequest.dryRun,
+        model: parsedRequest.model,
+      },
+      projectId,
+      userId,
+      nowIso: new Date().toISOString(),
+    })
+
+    return successResponse(ENDPOINT, requestId, payload.data)
+  } catch (error) {
+    const detail =
+      error instanceof ToolExecutionError
+        ? error.detail
+        : apiError({
+            type: "internal_error",
+            code: "INTERNAL_ERROR",
+            message: "Internal error",
+            status: 500,
+            retryable: true,
+          })
+
+    return errorResponse(ENDPOINT, requestId, detail)
+  }
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add `memories consolidate run` CLI command
- add MCP `consolidate_memories` tool
- add SDK endpoint `POST /api/sdk/v1/memories/consolidate`
- add stale/review consolidation-aware filters for superseded/conflict workflows

## Validation
- pnpm -C packages/cli test src/commands/consolidate.test.ts src/mcp/tools.test.ts src/commands/stale.test.ts
- pnpm -C packages/cli typecheck
- pnpm -C packages/web test src/app/api/sdk/v1/memories/__tests__/routes.test.ts
- pnpm -C packages/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new consolidation workflow that can update/supersede memory rows, create `memory_links`, and record audit runs via CLI/MCP/SDK API; mistakes could incorrectly mark memories as superseded or create unexpected links. Stale/review query logic is also expanded with new filters, which could change what users see by default.
> 
> **Overview**
> Introduces a **memory consolidation workflow** exposed three ways: `memories consolidate run` in the CLI, an MCP tool `consolidate_memories`, and a new SDK endpoint `POST /api/sdk/v1/memories/consolidate` that returns a run summary envelope.
> 
> Implements server-side consolidation in `consolidateMemoriesPayload`: groups candidate memories by a derived/normalized `upsert_key`, selects winners by recency, supersedes losers (and optionally creates `memory_links` of type `supersedes`/`contradicts`), and always records a `memory_consolidation_runs` audit row (including dry-run metadata).
> 
> Updates `stale`/`review` CLI workflows to be **consolidation-aware**: default queries exclude superseded memories, add `--include-superseded`, `--superseded-only`, and `--conflicts-only` flags, and surface `superseded`/`conflict` status in output; tests are added/updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8fa2e84541ccc284358f61cff462a72ed41900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->