### PR TITLE
feat(tooling): promote session snapshots to procedural skill files

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,6 +25,7 @@ import type {
   MemoryAddInput,
   SkillFileDeleteInput,
   SkillFileListOptions,
+  SkillFilePromoteInput,
   SkillFileRecord,
   SkillFileUpsertInput,
   MemoryEditInput,
@@ -530,6 +531,33 @@ export class MemoriesClient {
       })
 
       const message = (messageFromEnvelope(result.envelope) ?? result.raw) || `Deleted skill file ${input.path}`
+      return {
+        ok: true,
+        message,
+        raw: result.raw,
+        envelope: result.envelope ?? undefined,
+      }
+    },
+
+    promoteFromSession: async (input: SkillFilePromoteInput): Promise<MutationResult> => {
+      const rawScope = this.withDefaultScopeSdk({
+        projectId: input.projectId,
+        userId: input.userId,
+        tenantId: input.tenantId,
+      })
+      const sdkScope = rawScope && Object.keys(rawScope).length > 0 ? rawScope : undefined
+      const result = await this.callSdkEndpoint("/api/sdk/v1/skills/files/promote", {
+        sessionId: input.sessionId,
+        snapshotId: input.snapshotId,
+        path: input.path,
+        title: input.title,
+        procedureKey: input.procedureKey,
+        maxSteps: input.maxSteps,
+        scope: sdkScope,
+      })
+
+      const message =
+        (messageFromEnvelope(result.envelope) ?? result.raw) || `Promoted session ${input.sessionId} to ${input.path}`
       return {
         ok: true,
         message,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -175,6 +175,15 @@ export interface SkillFileDeleteInput extends SkillFileScopeOptions {
   path: string
 }
 
+export interface SkillFilePromoteInput extends SkillFileScopeOptions {
+  sessionId: string
+  snapshotId?: string
+  path: string
+  title?: string
+  procedureKey?: string
+  maxSteps?: number
+}
+
 export interface MemoryAddInput {
   content: string
   type?: MemoryType

--- a/packages/web/src/app/api/sdk/v1/skills/files/promote/route.ts
+++ b/packages/web/src/app/api/sdk/v1/skills/files/promote/route.ts
@@ -1,0 +1,116 @@
+import { promoteSnapshotToSkillFilePayload } from "@/lib/memory-service/skill-files"
+import { apiError, ensureMemoryUserIdSchema, parseTenantId, parseUserId, ToolExecutionError } from "@/lib/memory-service/tools"
+import {
+  authenticateApiKey,
+  errorResponse,
+  getApiKey,
+  invalidRequestResponse,
+  resolveTursoForScope,
+  successResponse,
+} from "@/lib/sdk-api/runtime"
+import { scopeSchema } from "@/lib/sdk-api/schemas"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+const ENDPOINT = "/api/sdk/v1/skills/files/promote"
+
+const requestSchema = z.object({
+  sessionId: z.string().trim().min(1).max(120),
+  snapshotId: z.string().trim().min(1).max(120).optional(),
+  path: z.string().trim().min(1).max(400),
+  title: z.string().trim().min(1).max(200).optional(),
+  procedureKey: z.string().trim().min(1).max(120).optional(),
+  maxSteps: z.number().int().min(3).max(20).optional(),
+  scope: scopeSchema,
+})
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const apiKey = getApiKey(request)
+  if (!apiKey) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "auth_error",
+        code: "MISSING_API_KEY",
+        message: "Missing API key",
+        status: 401,
+        retryable: false,
+      })
+    )
+  }
+
+  const authResult = await authenticateApiKey(apiKey, ENDPOINT, requestId)
+  if (authResult instanceof NextResponse) {
+    return authResult
+  }
+
+  let parsedRequest: z.infer<typeof requestSchema>
+  try {
+    parsedRequest = requestSchema.parse(await request.json())
+  } catch {
+    return invalidRequestResponse(ENDPOINT, requestId)
+  }
+
+  try {
+    const tenantId = parseTenantId({ tenant_id: parsedRequest.scope?.tenantId })
+    const userId = parseUserId({ user_id: parsedRequest.scope?.userId })
+    const projectId = parsedRequest.scope?.projectId
+
+    const turso = await resolveTursoForScope({
+      ownerUserId: authResult.userId,
+      apiKeyHash: authResult.apiKeyHash,
+      tenantId,
+      projectId,
+      endpoint: ENDPOINT,
+      requestId,
+    })
+
+    if (turso instanceof NextResponse) {
+      return turso
+    }
+
+    await ensureMemoryUserIdSchema(turso)
+
+    const payload = await promoteSnapshotToSkillFilePayload({
+      turso,
+      sessionId: parsedRequest.sessionId,
+      snapshotId: parsedRequest.snapshotId,
+      path: parsedRequest.path,
+      title: parsedRequest.title,
+      procedureKey: parsedRequest.procedureKey,
+      maxSteps: parsedRequest.maxSteps,
+      projectId,
+      userId,
+      nowIso: new Date().toISOString(),
+    })
+
+    return successResponse(ENDPOINT, requestId, payload.data, payload.data.created ? 201 : 200)
+  } catch (error) {
+    const detail =
+      error instanceof ToolExecutionError
+        ? error.detail
+        : apiError({
+            type: "internal_error",
+            code: "INTERNAL_ERROR",
+            message: "Internal error",
+            status: 500,
+            retryable: true,
+          })
+
+    return errorResponse(ENDPOINT, requestId, detail)
+  }
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  })
+}

--- a/packages/web/src/lib/memory-service/skill-files.ts
+++ b/packages/web/src/lib/memory-service/skill-files.ts
@@ -17,6 +17,14 @@ interface SkillFileRow {
   updated_at: string
 }
 
+interface SessionSnapshotRow {
+  id: string
+  session_id: string
+  slug: string
+  transcript_md: string
+  created_at: string
+}
+
 function normalizeScope(projectId?: string | null): SkillFileScope {
   return projectId ? "project" : "global"
 }
@@ -63,6 +71,72 @@ function deriveProcedureKeyFromQuery(query: string | null | undefined): string |
     ? firstLine.split(":")[0]
     : firstLine.split(/\s+/).slice(0, 6).join(" ")
   return normalizeProcedureKey(seed)
+}
+
+function normalizeStepText(input: string): string | null {
+  const normalized = input
+    .trim()
+    .replace(/^\d+\.\s+/, "")
+    .replace(/^[-*+]\s+/, "")
+    .replace(/\s+/g, " ")
+  return normalized.length >= 8 ? normalized : null
+}
+
+function extractProcedureSteps(transcript: string, maxSteps: number): string[] {
+  const lines = transcript
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter(
+      (line) =>
+        !line.startsWith("#") &&
+        !line.startsWith("```") &&
+        !line.startsWith("Session ID:") &&
+        !line.startsWith("### user") &&
+        !line.startsWith("### assistant")
+    )
+
+  const steps: string[] = []
+  for (const line of lines) {
+    const normalized = normalizeStepText(line)
+    if (!normalized) continue
+    steps.push(normalized)
+    if (steps.length >= maxSteps) break
+  }
+  return steps
+}
+
+function buildProcedureMarkdown(args: {
+  title: string
+  sessionId: string
+  snapshotId: string
+  snapshotSlug: string
+  snapshotCreatedAt: string
+  transcript: string
+  maxSteps: number
+}): string {
+  const steps = extractProcedureSteps(args.transcript, args.maxSteps)
+  const numberedSteps =
+    steps.length > 0
+      ? steps.map((step, index) => `${index + 1}. ${step}`)
+      : [
+          "1. Review the source transcript and confirm the desired outcome.",
+          "2. Execute the same sequence of actions in a clean environment.",
+          "3. Record any project-specific adjustments discovered during execution.",
+        ]
+
+  return [
+    `# ${args.title}`,
+    "",
+    "## Source Episode",
+    `- Session ID: ${args.sessionId}`,
+    `- Snapshot ID: ${args.snapshotId}`,
+    `- Snapshot Slug: ${args.snapshotSlug}`,
+    `- Captured At: ${args.snapshotCreatedAt}`,
+    "",
+    "## Workflow Steps",
+    ...numberedSteps,
+  ].join("\n")
 }
 
 function toStructuredSkillFile(row: SkillFileRow) {
@@ -289,6 +363,156 @@ export async function markSkillFilesUsedPayload(params: {
   })
 
   return Number(result.rowsAffected ?? 0)
+}
+
+export async function promoteSnapshotToSkillFilePayload(params: {
+  turso: TursoClient
+  sessionId: string
+  path: string
+  snapshotId?: string | null
+  title?: string | null
+  procedureKey?: string | null
+  maxSteps?: number
+  projectId?: string | null
+  userId: string | null
+  nowIso: string
+}): Promise<{
+  text: string
+  data: {
+    skillFile: ReturnType<typeof toStructuredSkillFile>
+    created: boolean
+    source: {
+      sessionId: string
+      snapshotId: string
+      snapshotSlug: string
+      snapshotCreatedAt: string
+    }
+    message: string
+  }
+}> {
+  const { turso, projectId, userId } = params
+  const sessionId = params.sessionId.trim()
+  const snapshotId = params.snapshotId?.trim() || null
+  const path = params.path.trim()
+  const rawMaxSteps = typeof params.maxSteps === "number" && Number.isFinite(params.maxSteps) ? params.maxSteps : 8
+  const maxSteps = Math.max(3, Math.min(20, Math.floor(rawMaxSteps)))
+
+  if (!sessionId) {
+    throw new ToolExecutionError(
+      apiError({
+        type: "validation_error",
+        code: "SESSION_ID_REQUIRED",
+        message: "session id is required",
+        status: 400,
+        retryable: false,
+        details: { field: "sessionId" },
+      }),
+      { rpcCode: -32602 }
+    )
+  }
+
+  if (!path) {
+    throw new ToolExecutionError(
+      apiError({
+        type: "validation_error",
+        code: "SKILL_FILE_PATH_REQUIRED",
+        message: "skill file path is required",
+        status: 400,
+        retryable: false,
+        details: { field: "path" },
+      }),
+      { rpcCode: -32602 }
+    )
+  }
+
+  const whereClauses = ["snap.session_id = ?"]
+  const whereArgs: string[] = [sessionId]
+
+  if (snapshotId) {
+    whereClauses.push("snap.id = ?")
+    whereArgs.push(snapshotId)
+  }
+
+  if (userId) {
+    whereClauses.push("sess.user_id = ?")
+    whereArgs.push(userId)
+  } else {
+    whereClauses.push("sess.user_id IS NULL")
+  }
+
+  if (projectId) {
+    whereClauses.push("sess.project_id = ?")
+    whereArgs.push(projectId)
+  } else {
+    whereClauses.push("sess.project_id IS NULL")
+  }
+
+  const snapshotResult = await turso.execute({
+    sql: `SELECT snap.id, snap.session_id, snap.slug, snap.transcript_md, snap.created_at
+          FROM memory_session_snapshots snap
+          JOIN memory_sessions sess ON sess.id = snap.session_id
+          WHERE ${whereClauses.join(" AND ")}
+          ORDER BY snap.created_at DESC
+          LIMIT 1`,
+    args: whereArgs,
+  })
+
+  const snapshot = snapshotResult.rows[0] as unknown as SessionSnapshotRow | undefined
+  if (!snapshot) {
+    throw new ToolExecutionError(
+      apiError({
+        type: "not_found_error",
+        code: "SESSION_SNAPSHOT_NOT_FOUND",
+        message: "No session snapshot found for promotion",
+        status: 404,
+        retryable: false,
+        details: {
+          sessionId,
+          snapshotId,
+          projectId: projectId ?? null,
+          userId,
+        },
+      }),
+      { rpcCode: -32004 }
+    )
+  }
+
+  const title = params.title?.trim() || `Procedure from ${snapshot.slug}`
+  const content = buildProcedureMarkdown({
+    title,
+    sessionId: snapshot.session_id,
+    snapshotId: snapshot.id,
+    snapshotSlug: snapshot.slug,
+    snapshotCreatedAt: snapshot.created_at,
+    transcript: snapshot.transcript_md,
+    maxSteps,
+  })
+
+  const upserted = await upsertSkillFilePayload({
+    turso,
+    path,
+    content,
+    procedureKey: params.procedureKey ?? snapshot.slug,
+    projectId,
+    userId,
+    nowIso: params.nowIso,
+  })
+
+  const message = `Promoted snapshot ${snapshot.id} to skill file ${path}`
+  return {
+    text: message,
+    data: {
+      skillFile: upserted.data.skillFile,
+      created: upserted.data.created,
+      source: {
+        sessionId: snapshot.session_id,
+        snapshotId: snapshot.id,
+        snapshotSlug: snapshot.slug,
+        snapshotCreatedAt: snapshot.created_at,
+      },
+      message,
+    },
+  }
 }
 
 export async function deleteSkillFilePayload(params: {


### PR DESCRIPTION
## Summary
- add `promoteSnapshotToSkillFilePayload` in skill-files service
- add `POST /api/sdk/v1/skills/files/promote` SDK endpoint
- add core client API `skills.promoteFromSession`
- add tests for snapshot-to-skill-file promotion

## Validation
- pnpm -C packages/web test src/lib/memory-service/skill-files.test.ts
- pnpm -C packages/web typecheck
- pnpm -C packages/core typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated SDK write endpoint that reads session snapshot transcripts and writes/updates `skill_files`; risk is mainly around scope/ownership filtering and generating procedural content from potentially large transcripts.
> 
> **Overview**
> Adds support for promoting a `memory_session_snapshots` record into a procedural `skill_files` entry.
> 
> Introduces `POST /api/sdk/v1/skills/files/promote` (with Zod validation, API key auth, scoped Turso resolution, and 201 vs 200 responses) plus core SDK support via `skills.promoteFromSession` and a new `SkillFilePromoteInput` type.
> 
> Implements `promoteSnapshotToSkillFilePayload` in the skill-files service to select the latest (or specified) snapshot for the given scope, generate procedure-style markdown steps from the transcript (bounded by `maxSteps`), upsert the target skill file, and returns source metadata; includes a new unit test covering snapshot promotion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8efa4e7775cfe48e301438234073910e04b8cbf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->