### PR TITLE
feat(obs): add memory lifecycle observability snapshot endpoint

### DIFF
--- a/packages/web/src/app/api/sdk/v1/management/memory/observability/__tests__/route.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/memory/observability/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockResolveManagementIdentity,
+  mockResolveTursoForScope,
+  mockEnsureMemoryUserIdSchema,
+  mockGetMemoryLifecycleObservabilitySnapshot,
+} = vi.hoisted(() => ({
+  mockResolveManagementIdentity: vi.fn(),
+  mockResolveTursoForScope: vi.fn(),
+  mockEnsureMemoryUserIdSchema: vi.fn(),
+  mockGetMemoryLifecycleObservabilitySnapshot: vi.fn(),
+}))
+
+vi.mock("@/app/api/sdk/v1/management/identity", () => ({
+  resolveManagementIdentity: mockResolveManagementIdentity,
+}))
+
+vi.mock("@/lib/memory-service/scope", () => ({
+  ensureMemoryUserIdSchema: mockEnsureMemoryUserIdSchema,
+}))
+
+vi.mock("@/lib/memory-service/observability", () => ({
+  getMemoryLifecycleObservabilitySnapshot: mockGetMemoryLifecycleObservabilitySnapshot,
+}))
+
+vi.mock("@/lib/sdk-api/runtime", () => ({
+  resolveTursoForScope: mockResolveTursoForScope,
+  successResponse: (endpoint: string, requestId: string, data: unknown, status = 200) =>
+    new Response(
+      JSON.stringify({
+        ok: true,
+        data,
+        error: null,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-26T00:00:00.000Z" },
+      }),
+      { status, headers: { "content-type": "application/json" } }
+    ),
+  errorResponse: (endpoint: string, requestId: string, detail: unknown) =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: detail,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-26T00:00:00.000Z" },
+      }),
+      { status: 500, headers: { "content-type": "application/json" } }
+    ),
+  invalidRequestResponse: (endpoint: string, requestId: string, message = "Invalid request payload") =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: {
+          type: "validation_error",
+          code: "INVALID_REQUEST",
+          message,
+          status: 400,
+          retryable: false,
+        },
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-26T00:00:00.000Z" },
+      }),
+      { status: 400, headers: { "content-type": "application/json" } }
+    ),
+}))
+
+import { GET } from "../route"
+
+describe("/api/sdk/v1/management/memory/observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockResolveManagementIdentity.mockResolvedValue({
+      userId: "user-1",
+      apiKeyHash: "hash_123",
+      authMode: "api_key",
+    })
+
+    mockResolveTursoForScope.mockResolvedValue({ execute: vi.fn() })
+    mockEnsureMemoryUserIdSchema.mockResolvedValue(undefined)
+    mockGetMemoryLifecycleObservabilitySnapshot.mockResolvedValue({
+      sampledAt: "2026-02-26T00:00:00.000Z",
+      windowHours: 24,
+      scope: {
+        tenantId: "tenant-a",
+        projectId: "project-a",
+        userId: null,
+      },
+      lifecycle: {
+        createdCount: 10,
+        updatedCount: 18,
+        deletedCount: 2,
+        activeCount: 48,
+        totalCount: 50,
+      },
+      compaction: {
+        totalEvents: 12,
+        byTrigger: { count: 8, time: 2, semantic: 2 },
+        compactedSessions: 5,
+        checkpointMissingCount: 1,
+        checkpointCoverage: 0.9167,
+      },
+      consolidation: {
+        runCount: 4,
+        mergedCount: 7,
+        supersededCount: 9,
+        conflictedCount: 2,
+        conflictRate: 0.5,
+        lastRunAt: "2026-02-26T00:00:00.000Z",
+      },
+      contradictions: {
+        totalCount: 14,
+        windowCount: 6,
+        trend: "up",
+        daily: [{ date: "2026-02-25", count: 3 }],
+      },
+      alarms: [],
+      health: "healthy",
+    })
+  })
+
+  it("returns memory observability snapshot", async () => {
+    const response = await GET(
+      new Request(
+        "https://example.com/api/sdk/v1/management/memory/observability?tenantId=tenant-a&projectId=project-a&windowHours=24"
+      ) as never
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.health).toBe("healthy")
+    expect(body.data.compaction.totalEvents).toBe(12)
+    expect(mockGetMemoryLifecycleObservabilitySnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant-a",
+        projectId: "project-a",
+        windowHours: 24,
+      })
+    )
+  })
+
+  it("returns validation envelope for invalid query", async () => {
+    const response = await GET(
+      new Request("https://example.com/api/sdk/v1/management/memory/observability?windowHours=0") as never
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("INVALID_REQUEST")
+  })
+
+  it("returns internal error envelope when lookup fails", async () => {
+    mockGetMemoryLifecycleObservabilitySnapshot.mockRejectedValue(new Error("db down"))
+
+    const response = await GET(
+      new Request("https://example.com/api/sdk/v1/management/memory/observability") as never
+    )
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("MEMORY_OBSERVABILITY_LOOKUP_FAILED")
+  })
+})

--- a/packages/web/src/app/api/sdk/v1/management/memory/observability/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/memory/observability/route.ts
@@ -1,0 +1,90 @@
+import { resolveManagementIdentity } from "@/app/api/sdk/v1/management/identity"
+import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope"
+import { apiError } from "@/lib/memory-service/tools"
+import { errorResponse, invalidRequestResponse, resolveTursoForScope, successResponse } from "@/lib/sdk-api/runtime"
+import { getMemoryLifecycleObservabilitySnapshot } from "@/lib/memory-service/observability"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+const ENDPOINT = "/api/sdk/v1/management/memory/observability"
+
+const querySchema = z.object({
+  tenantId: z.string().trim().min(1).max(120).optional(),
+  projectId: z.string().trim().min(1).max(240).optional(),
+  userId: z.string().trim().min(1).max(120).optional(),
+  windowHours: z.coerce.number().int().min(1).max(24 * 14).optional(),
+})
+
+function parseQuery(request: NextRequest): z.input<typeof querySchema> {
+  const url = new URL(request.url)
+  return {
+    tenantId: url.searchParams.get("tenantId") ?? undefined,
+    projectId: url.searchParams.get("projectId") ?? undefined,
+    userId: url.searchParams.get("userId") ?? undefined,
+    windowHours: url.searchParams.get("windowHours") ?? undefined,
+  }
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const identity = await resolveManagementIdentity({
+    endpoint: ENDPOINT,
+    request,
+    requestId,
+    method: "GET",
+    missingApiKeyMessage: "Generate an API key before viewing memory observability metrics",
+    expiredApiKeyMessage: "API key expired. Generate a new key before viewing memory observability metrics.",
+    apiKeyMetadataLookupLogContext: "Failed to load API key metadata for memory observability:",
+  })
+  if (identity instanceof NextResponse) return identity
+
+  const parsed = querySchema.safeParse(parseQuery(request))
+  if (!parsed.success) {
+    return invalidRequestResponse(
+      ENDPOINT,
+      requestId,
+      parsed.error.issues[0]?.message ?? "Invalid request payload"
+    )
+  }
+
+  const tenantId = parsed.data.tenantId ?? null
+  const projectId = parsed.data.projectId ?? null
+
+  try {
+    const turso = await resolveTursoForScope({
+      ownerUserId: identity.userId,
+      apiKeyHash: identity.apiKeyHash,
+      tenantId,
+      projectId,
+      endpoint: ENDPOINT,
+      requestId,
+    })
+    if (turso instanceof NextResponse) return turso
+
+    await ensureMemoryUserIdSchema(turso)
+
+    const snapshot = await getMemoryLifecycleObservabilitySnapshot({
+      turso,
+      tenantId,
+      projectId,
+      userId: parsed.data.userId ?? null,
+      windowHours: parsed.data.windowHours,
+    })
+
+    return successResponse(ENDPOINT, requestId, snapshot)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load memory observability snapshot"
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "MEMORY_OBSERVABILITY_LOOKUP_FAILED",
+        message,
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+}

--- a/packages/web/src/lib/memory-service/observability.test.ts
+++ b/packages/web/src/lib/memory-service/observability.test.ts
@@ -1,0 +1,146 @@
+import { createClient } from "@libsql/client"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { getMemoryLifecycleObservabilitySnapshot } from "./observability"
+import { ensureMemoryUserIdSchema } from "./scope-schema"
+
+type DbClient = ReturnType<typeof createClient>
+
+const testDatabases: DbClient[] = []
+
+async function setupDb(prefix: string): Promise<DbClient> {
+  const dbDir = mkdtempSync(join(tmpdir(), `${prefix}-`))
+  const db = createClient({ url: `file:${join(dbDir, "observability.db")}` })
+  testDatabases.push(db)
+
+  await db.execute(
+    `CREATE TABLE memories (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      project_id TEXT,
+      tags TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )`
+  )
+
+  await ensureMemoryUserIdSchema(db, { cacheKey: `observability:${prefix}` })
+  return db
+}
+
+afterEach(() => {
+  for (const db of testDatabases.splice(0, testDatabases.length)) {
+    db.close()
+  }
+})
+
+describe("memory observability snapshot", () => {
+  it("summarizes lifecycle, compaction, consolidation, and contradiction signals", async () => {
+    const db = await setupDb("memories-observability-summary")
+
+    await db.execute(
+      `CREATE TABLE memory_links (
+        id TEXT PRIMARY KEY,
+        source_id TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        link_type TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      )`
+    )
+
+    await db.execute({
+      sql: `INSERT INTO memories
+            (id, content, type, scope, project_id, user_id, created_at, updated_at, deleted_at)
+            VALUES (?, ?, 'rule', 'project', ?, ?, ?, ?, NULL)`,
+      args: [
+        "mem_1",
+        "Use canary deploys",
+        "github.com/acme/platform",
+        "user-1",
+        "2026-02-26T00:00:00.000Z",
+        "2026-02-26T01:00:00.000Z",
+      ],
+    })
+    await db.execute({
+      sql: `INSERT INTO memories
+            (id, content, type, scope, project_id, user_id, created_at, updated_at, deleted_at)
+            VALUES (?, ?, 'rule', 'project', ?, ?, ?, ?, ?)`,
+      args: [
+        "mem_2",
+        "Use full rollout immediately",
+        "github.com/acme/platform",
+        "user-1",
+        "2026-02-25T12:00:00.000Z",
+        "2026-02-26T02:00:00.000Z",
+        "2026-02-26T03:00:00.000Z",
+      ],
+    })
+
+    await db.execute({
+      sql: `INSERT INTO memory_sessions
+            (id, scope, project_id, user_id, client, status, title, started_at, last_activity_at, ended_at, metadata)
+            VALUES (?, 'project', ?, ?, 'codex', 'compacted', 'session', ?, ?, ?, NULL)`,
+      args: [
+        "sess_1",
+        "github.com/acme/platform",
+        "user-1",
+        "2026-02-26T00:00:00.000Z",
+        "2026-02-26T02:00:00.000Z",
+        "2026-02-26T02:00:00.000Z",
+      ],
+    })
+    await db.execute({
+      sql: `INSERT INTO memory_compaction_events
+            (id, session_id, trigger_type, reason, token_count_before, turn_count_before, summary_tokens, checkpoint_memory_id, created_at)
+            VALUES (?, ?, 'count', 'budget exceeded', 2400, 22, 220, NULL, ?)`,
+      args: ["cmp_1", "sess_1", "2026-02-26T02:00:00.000Z"],
+    })
+
+    await db.execute({
+      sql: `INSERT INTO memory_consolidation_runs
+            (id, scope, project_id, user_id, input_count, merged_count, superseded_count, conflicted_count, model, created_at, metadata)
+            VALUES (?, 'project', ?, ?, 8, 2, 3, 1, 'gpt-5-mini', ?, '{}')`,
+      args: ["run_1", "github.com/acme/platform", "user-1", "2026-02-26T03:00:00.000Z"],
+    })
+
+    await db.execute({
+      sql: `INSERT INTO memory_links (id, source_id, target_id, link_type, created_at) VALUES (?, ?, ?, 'contradicts', ?)`,
+      args: ["lnk_1", "mem_1", "mem_2", "2026-02-26T03:00:00.000Z"],
+    })
+
+    const snapshot = await getMemoryLifecycleObservabilitySnapshot({
+      turso: db,
+      projectId: "github.com/acme/platform",
+      userId: "user-1",
+      nowIso: "2026-02-26T04:00:00.000Z",
+      windowHours: 24,
+    })
+
+    expect(snapshot.lifecycle.createdCount).toBeGreaterThanOrEqual(1)
+    expect(snapshot.lifecycle.deletedCount).toBe(1)
+    expect(snapshot.compaction.totalEvents).toBe(1)
+    expect(snapshot.compaction.checkpointMissingCount).toBe(1)
+    expect(snapshot.consolidation.runCount).toBe(1)
+    expect(snapshot.consolidation.conflictedCount).toBe(1)
+    expect(snapshot.contradictions.windowCount).toBe(1)
+  })
+
+  it("handles missing contradiction link table by returning zeroed contradiction metrics", async () => {
+    const db = await setupDb("memories-observability-no-links")
+
+    const snapshot = await getMemoryLifecycleObservabilitySnapshot({
+      turso: db,
+      nowIso: "2026-02-26T04:00:00.000Z",
+      windowHours: 24,
+    })
+
+    expect(snapshot.contradictions.totalCount).toBe(0)
+    expect(snapshot.contradictions.windowCount).toBe(0)
+    expect(snapshot.contradictions.daily).toEqual([])
+  })
+})

--- a/packages/web/src/lib/memory-service/observability.ts
+++ b/packages/web/src/lib/memory-service/observability.ts
@@ -1,0 +1,441 @@
+import type { TursoClient } from "./types"
+
+type AlarmSeverity = "warning" | "critical"
+type SnapshotHealth = "healthy" | "degraded" | "critical"
+type TrendDirection = "up" | "down" | "flat"
+
+interface ObservabilityScope {
+  tenantId: string | null
+  projectId: string | null
+  userId: string | null
+}
+
+interface ScopeFilterResult {
+  clause: string
+  args: string[]
+}
+
+export interface MemoryLifecycleObservabilityAlarm {
+  code: string
+  severity: AlarmSeverity
+  message: string
+  observed: number
+  threshold: number
+  unit: "ratio" | "count"
+}
+
+export interface MemoryLifecycleObservabilitySnapshot {
+  sampledAt: string
+  windowHours: number
+  scope: ObservabilityScope
+  lifecycle: {
+    createdCount: number
+    updatedCount: number
+    deletedCount: number
+    activeCount: number
+    totalCount: number
+  }
+  compaction: {
+    totalEvents: number
+    byTrigger: { count: number; time: number; semantic: number }
+    compactedSessions: number
+    checkpointMissingCount: number
+    checkpointCoverage: number
+  }
+  consolidation: {
+    runCount: number
+    mergedCount: number
+    supersededCount: number
+    conflictedCount: number
+    conflictRate: number
+    lastRunAt: string | null
+  }
+  contradictions: {
+    totalCount: number
+    windowCount: number
+    trend: TrendDirection
+    daily: Array<{ date: string; count: number }>
+  }
+  alarms: MemoryLifecycleObservabilityAlarm[]
+  health: SnapshotHealth
+}
+
+export interface GetMemoryLifecycleObservabilitySnapshotInput {
+  turso: TursoClient
+  nowIso?: string
+  windowHours?: number
+  tenantId?: string | null
+  projectId?: string | null
+  userId?: string | null
+}
+
+const DEFAULT_WINDOW_HOURS = 24
+const MAX_WINDOW_HOURS = 24 * 14
+
+const MEMORY_OBSERVABILITY_SLOS = {
+  checkpointCoverage: {
+    warning: 0.9,
+    critical: 0.75,
+    minSamples: 5,
+  },
+  consolidationConflictRate: {
+    warning: 0.4,
+    critical: 0.7,
+    minSamples: 3,
+  },
+  contradictionWindowCount: {
+    warning: 5,
+    critical: 12,
+  },
+} as const
+
+function trimNullable(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function toNumber(value: unknown): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 0
+  return parsed
+}
+
+function toCount(value: unknown): number {
+  const parsed = toNumber(value)
+  if (parsed <= 0) return 0
+  return Math.floor(parsed)
+}
+
+function roundMetric(value: number, decimals = 4): number {
+  if (!Number.isFinite(value)) return 0
+  return Number(value.toFixed(decimals))
+}
+
+function normalizeWindowHours(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_WINDOW_HOURS
+  return Math.max(1, Math.min(Math.floor(value ?? DEFAULT_WINDOW_HOURS), MAX_WINDOW_HOURS))
+}
+
+function toWindowStartIso(nowIso: string, windowHours: number): string {
+  return new Date(Date.parse(nowIso) - windowHours * 60 * 60 * 1_000).toISOString()
+}
+
+function buildScopeFilter(params: {
+  projectId: string | null
+  userId: string | null
+  alias?: string
+}): ScopeFilterResult {
+  const alias = params.alias ? `${params.alias}.` : ""
+  const clauses: string[] = []
+  const args: string[] = []
+
+  if (params.projectId) {
+    clauses.push(`${alias}project_id = ?`)
+    args.push(params.projectId)
+  }
+  if (params.userId) {
+    clauses.push(`${alias}user_id = ?`)
+    args.push(params.userId)
+  }
+
+  return {
+    clause: clauses.length > 0 ? clauses.join(" AND ") : "1 = 1",
+    args,
+  }
+}
+
+async function tableExists(turso: TursoClient, tableName: string): Promise<boolean> {
+  const result = await turso.execute({
+    sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+    args: [tableName],
+  })
+  return result.rows.length > 0
+}
+
+async function queryScalarCount(
+  turso: TursoClient,
+  sql: string,
+  args: (string | number)[]
+): Promise<number> {
+  const result = await turso.execute({ sql, args })
+  return toCount(result.rows[0]?.count ?? 0)
+}
+
+function computeTrend(daily: Array<{ date: string; count: number }>): TrendDirection {
+  if (daily.length < 2) return "flat"
+  const midpoint = Math.floor(daily.length / 2)
+  const first = daily.slice(0, midpoint)
+  const second = daily.slice(midpoint)
+  const avg = (values: Array<{ count: number }>) =>
+    values.length > 0 ? values.reduce((sum, item) => sum + item.count, 0) / values.length : 0
+  const firstAvg = avg(first)
+  const secondAvg = avg(second)
+  if (secondAvg > firstAvg * 1.1) return "up"
+  if (secondAvg < firstAvg * 0.9) return "down"
+  return "flat"
+}
+
+function deriveHealth(alarms: MemoryLifecycleObservabilityAlarm[]): SnapshotHealth {
+  if (alarms.some((alarm) => alarm.severity === "critical")) return "critical"
+  if (alarms.some((alarm) => alarm.severity === "warning")) return "degraded"
+  return "healthy"
+}
+
+export async function getMemoryLifecycleObservabilitySnapshot(
+  input: GetMemoryLifecycleObservabilitySnapshotInput
+): Promise<MemoryLifecycleObservabilitySnapshot> {
+  const nowIso = trimNullable(input.nowIso) ?? new Date().toISOString()
+  const windowHours = normalizeWindowHours(input.windowHours)
+  const windowStartIso = toWindowStartIso(nowIso, windowHours)
+  const scope: ObservabilityScope = {
+    tenantId: trimNullable(input.tenantId) ?? null,
+    projectId: trimNullable(input.projectId) ?? null,
+    userId: trimNullable(input.userId) ?? null,
+  }
+
+  const memoryScope = buildScopeFilter({ projectId: scope.projectId, userId: scope.userId, alias: "m" })
+
+  const createdCount = await queryScalarCount(
+    input.turso,
+    `SELECT COUNT(*) AS count
+     FROM memories m
+     WHERE ${memoryScope.clause}
+       AND m.created_at >= ?`,
+    [...memoryScope.args, windowStartIso]
+  )
+
+  const updatedCount = await queryScalarCount(
+    input.turso,
+    `SELECT COUNT(*) AS count
+     FROM memories m
+     WHERE ${memoryScope.clause}
+       AND m.updated_at >= ?`,
+    [...memoryScope.args, windowStartIso]
+  )
+
+  const deletedCount = await queryScalarCount(
+    input.turso,
+    `SELECT COUNT(*) AS count
+     FROM memories m
+     WHERE ${memoryScope.clause}
+       AND m.deleted_at IS NOT NULL
+       AND m.deleted_at >= ?`,
+    [...memoryScope.args, windowStartIso]
+  )
+
+  const activeCount = await queryScalarCount(
+    input.turso,
+    `SELECT COUNT(*) AS count
+     FROM memories m
+     WHERE ${memoryScope.clause}
+       AND m.deleted_at IS NULL`,
+    [...memoryScope.args]
+  )
+
+  const totalCount = await queryScalarCount(
+    input.turso,
+    `SELECT COUNT(*) AS count
+     FROM memories m
+     WHERE ${memoryScope.clause}`,
+    [...memoryScope.args]
+  )
+
+  const sessionScope = buildScopeFilter({ projectId: scope.projectId, userId: scope.userId, alias: "s" })
+  const compactionResult = await input.turso.execute({
+    sql: `SELECT
+            COALESCE(e.trigger_type, 'count') AS trigger_type,
+            COUNT(*) AS event_count,
+            SUM(CASE WHEN e.checkpoint_memory_id IS NULL OR e.checkpoint_memory_id = '' THEN 1 ELSE 0 END) AS missing_count,
+            COUNT(DISTINCT e.session_id) AS session_count
+          FROM memory_compaction_events e
+          LEFT JOIN memory_sessions s ON s.id = e.session_id
+          WHERE e.created_at >= ?
+            AND ${sessionScope.clause}
+          GROUP BY e.trigger_type`,
+    args: [windowStartIso, ...sessionScope.args],
+  })
+
+  const compactionByTrigger = { count: 0, time: 0, semantic: 0 }
+  let compactionTotal = 0
+  let compactedSessions = 0
+  let checkpointMissingCount = 0
+  for (const row of compactionResult.rows) {
+    const trigger = String(row.trigger_type ?? "count")
+    const eventCount = toCount(row.event_count)
+    const missingCount = toCount(row.missing_count)
+    const sessionCount = toCount(row.session_count)
+    if (trigger === "count" || trigger === "time" || trigger === "semantic") {
+      compactionByTrigger[trigger] = eventCount
+    }
+    compactionTotal += eventCount
+    checkpointMissingCount += missingCount
+    compactedSessions += sessionCount
+  }
+
+  const checkpointCoverage =
+    compactionTotal > 0 ? roundMetric((compactionTotal - checkpointMissingCount) / compactionTotal) : 1
+
+  const consolidationScope = buildScopeFilter({
+    projectId: scope.projectId,
+    userId: scope.userId,
+    alias: "r",
+  })
+  const consolidationResult = await input.turso.execute({
+    sql: `SELECT
+            COUNT(*) AS run_count,
+            SUM(merged_count) AS merged_count,
+            SUM(superseded_count) AS superseded_count,
+            SUM(conflicted_count) AS conflicted_count,
+            MAX(created_at) AS last_run_at
+          FROM memory_consolidation_runs r
+          WHERE r.created_at >= ?
+            AND ${consolidationScope.clause}`,
+    args: [windowStartIso, ...consolidationScope.args],
+  })
+  const consolidationRow = consolidationResult.rows[0] ?? {}
+  const consolidationRunCount = toCount((consolidationRow as { run_count?: unknown }).run_count)
+  const mergedCount = toCount((consolidationRow as { merged_count?: unknown }).merged_count)
+  const supersededCount = toCount((consolidationRow as { superseded_count?: unknown }).superseded_count)
+  const conflictedCount = toCount((consolidationRow as { conflicted_count?: unknown }).conflicted_count)
+  const conflictRate = consolidationRunCount > 0 ? roundMetric(conflictedCount / consolidationRunCount) : 0
+  const lastRunAt =
+    typeof (consolidationRow as { last_run_at?: unknown }).last_run_at === "string"
+      ? String((consolidationRow as { last_run_at?: unknown }).last_run_at)
+      : null
+
+  let contradictionsTotalCount = 0
+  let contradictionWindowCount = 0
+  let contradictionDaily: Array<{ date: string; count: number }> = []
+  if (await tableExists(input.turso, "memory_links")) {
+    const contradictionScope = buildScopeFilter({
+      projectId: scope.projectId,
+      userId: scope.userId,
+      alias: "m",
+    })
+
+    contradictionsTotalCount = await queryScalarCount(
+      input.turso,
+      `SELECT COUNT(*) AS count
+       FROM memory_links l
+       LEFT JOIN memories m ON m.id = l.source_id
+       WHERE l.link_type = 'contradicts'
+         AND ${contradictionScope.clause}`,
+      [...contradictionScope.args]
+    )
+
+    contradictionWindowCount = await queryScalarCount(
+      input.turso,
+      `SELECT COUNT(*) AS count
+       FROM memory_links l
+       LEFT JOIN memories m ON m.id = l.source_id
+       WHERE l.link_type = 'contradicts'
+         AND l.created_at >= ?
+         AND ${contradictionScope.clause}`,
+      [windowStartIso, ...contradictionScope.args]
+    )
+
+    const dailyResult = await input.turso.execute({
+      sql: `SELECT substr(l.created_at, 1, 10) AS day, COUNT(*) AS day_count
+            FROM memory_links l
+            LEFT JOIN memories m ON m.id = l.source_id
+            WHERE l.link_type = 'contradicts'
+              AND l.created_at >= ?
+              AND ${contradictionScope.clause}
+            GROUP BY day
+            ORDER BY day ASC`,
+      args: [windowStartIso, ...contradictionScope.args],
+    })
+    contradictionDaily = dailyResult.rows.map((row) => ({
+      date: String(row.day ?? ""),
+      count: toCount(row.day_count),
+    }))
+  }
+
+  const contradictionTrend = computeTrend(contradictionDaily)
+
+  const alarms: MemoryLifecycleObservabilityAlarm[] = []
+  if (
+    compactionTotal >= MEMORY_OBSERVABILITY_SLOS.checkpointCoverage.minSamples &&
+    checkpointCoverage < MEMORY_OBSERVABILITY_SLOS.checkpointCoverage.warning
+  ) {
+    const critical = checkpointCoverage < MEMORY_OBSERVABILITY_SLOS.checkpointCoverage.critical
+    alarms.push({
+      code: "LOW_CHECKPOINT_COVERAGE",
+      severity: critical ? "critical" : "warning",
+      message: `Compaction checkpoint coverage is ${Math.round(checkpointCoverage * 100)}%`,
+      observed: checkpointCoverage,
+      threshold: critical
+        ? MEMORY_OBSERVABILITY_SLOS.checkpointCoverage.critical
+        : MEMORY_OBSERVABILITY_SLOS.checkpointCoverage.warning,
+      unit: "ratio",
+    })
+  }
+
+  if (
+    consolidationRunCount >= MEMORY_OBSERVABILITY_SLOS.consolidationConflictRate.minSamples &&
+    conflictRate >= MEMORY_OBSERVABILITY_SLOS.consolidationConflictRate.warning
+  ) {
+    const critical = conflictRate >= MEMORY_OBSERVABILITY_SLOS.consolidationConflictRate.critical
+    alarms.push({
+      code: "HIGH_CONSOLIDATION_CONFLICT_RATE",
+      severity: critical ? "critical" : "warning",
+      message: `Consolidation conflict rate is ${Math.round(conflictRate * 100)}%`,
+      observed: conflictRate,
+      threshold: critical
+        ? MEMORY_OBSERVABILITY_SLOS.consolidationConflictRate.critical
+        : MEMORY_OBSERVABILITY_SLOS.consolidationConflictRate.warning,
+      unit: "ratio",
+    })
+  }
+
+  if (contradictionWindowCount >= MEMORY_OBSERVABILITY_SLOS.contradictionWindowCount.warning) {
+    const critical = contradictionWindowCount >= MEMORY_OBSERVABILITY_SLOS.contradictionWindowCount.critical
+    alarms.push({
+      code: "CONTRADICTION_TREND_VOLUME",
+      severity: critical ? "critical" : "warning",
+      message: `Contradiction links in window: ${contradictionWindowCount}`,
+      observed: contradictionWindowCount,
+      threshold: critical
+        ? MEMORY_OBSERVABILITY_SLOS.contradictionWindowCount.critical
+        : MEMORY_OBSERVABILITY_SLOS.contradictionWindowCount.warning,
+      unit: "count",
+    })
+  }
+
+  return {
+    sampledAt: nowIso,
+    windowHours,
+    scope,
+    lifecycle: {
+      createdCount,
+      updatedCount,
+      deletedCount,
+      activeCount,
+      totalCount,
+    },
+    compaction: {
+      totalEvents: compactionTotal,
+      byTrigger: compactionByTrigger,
+      compactedSessions,
+      checkpointMissingCount,
+      checkpointCoverage,
+    },
+    consolidation: {
+      runCount: consolidationRunCount,
+      mergedCount,
+      supersededCount,
+      conflictedCount,
+      conflictRate,
+      lastRunAt,
+    },
+    contradictions: {
+      totalCount: contradictionsTotalCount,
+      windowCount: contradictionWindowCount,
+      trend: contradictionTrend,
+      daily: contradictionDaily,
+    },
+    alarms,
+    health: deriveHealth(alarms),
+  }
+}


### PR DESCRIPTION
## Summary
- add memory lifecycle observability snapshot aggregation for lifecycle, compaction, consolidation, and contradiction trends
- add management SDK endpoint: `GET /api/sdk/v1/management/memory/observability`
- derive warning/critical alarms and overall health from configurable SLO thresholds

## Validation
- pnpm -C packages/web test src/lib/memory-service/observability.test.ts src/app/api/sdk/v1/management/memory/observability/__tests__/route.test.ts
- pnpm -C packages/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authenticated management endpoint and non-trivial aggregation queries over multiple memory tables, so correctness and query performance/edge-case handling are the main risks. Changes are read-only and isolated to a new route/module.
> 
> **Overview**
> Adds `GET /api/sdk/v1/management/memory/observability`, including query validation (`tenantId`, `projectId`, `userId`, `windowHours`), management auth, Turso scope resolution, and standardized success/error envelopes.
> 
> Implements `getMemoryLifecycleObservabilitySnapshot` to aggregate lifecycle counts, compaction and consolidation metrics, and contradiction trends, and to derive **warning/critical alarms** plus overall `health` from SLO thresholds (with a guard for missing `memory_links`).
> 
> Adds Vitest coverage for both the API route (success, validation error, internal error) and the observability aggregation logic (including the missing-link-table fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd03fa7d6c6f5d5f921b67ba675a62f4f0d9dca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->