### PR TITLE
feat(eval): add replay harness for extraction and compaction quality

### DIFF
--- a/packages/web/src/app/api/sdk/v1/management/memory/eval/replay/__tests__/route.test.ts
+++ b/packages/web/src/app/api/sdk/v1/management/memory/eval/replay/__tests__/route.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  mockResolveManagementIdentity,
+  mockResolveTursoForScope,
+  mockRunReplayEval,
+} = vi.hoisted(() => ({
+  mockResolveManagementIdentity: vi.fn(),
+  mockResolveTursoForScope: vi.fn(),
+  mockRunReplayEval: vi.fn(),
+}))
+
+vi.mock("@/app/api/sdk/v1/management/identity", () => ({
+  resolveManagementIdentity: mockResolveManagementIdentity,
+}))
+
+vi.mock("@/lib/memory-service/eval", () => ({
+  runReplayEval: mockRunReplayEval,
+}))
+
+vi.mock("@/lib/sdk-api/runtime", () => ({
+  resolveTursoForScope: mockResolveTursoForScope,
+  successResponse: (endpoint: string, requestId: string, data: unknown, status = 200) =>
+    new Response(
+      JSON.stringify({
+        ok: true,
+        data,
+        error: null,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-26T00:00:00.000Z" },
+      }),
+      { status, headers: { "content-type": "application/json" } }
+    ),
+  errorResponse: (endpoint: string, requestId: string, detail: unknown) =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: detail,
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-26T00:00:00.000Z" },
+      }),
+      { status: 500, headers: { "content-type": "application/json" } }
+    ),
+  invalidRequestResponse: (endpoint: string, requestId: string, message = "Invalid request payload") =>
+    new Response(
+      JSON.stringify({
+        ok: false,
+        data: null,
+        error: {
+          type: "validation_error",
+          code: "INVALID_REQUEST",
+          message,
+          status: 400,
+          retryable: false,
+        },
+        meta: { endpoint, requestId, version: "test", timestamp: "2026-02-26T00:00:00.000Z" },
+      }),
+      { status: 400, headers: { "content-type": "application/json" } }
+    ),
+}))
+
+import { POST } from "../route"
+
+describe("/api/sdk/v1/management/memory/eval/replay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockResolveManagementIdentity.mockResolvedValue({
+      userId: "user-1",
+      apiKeyHash: "hash_123",
+      authMode: "api_key",
+    })
+
+    mockResolveTursoForScope.mockResolvedValue({ execute: vi.fn() })
+
+    mockRunReplayEval.mockReturnValue({
+      summary: {
+        evaluatedAt: "2026-02-26T00:00:00.000Z",
+        criteria: {
+          extractionF1: 0.7,
+          compactionRetention: 0.85,
+          triggerAccuracy: 0.9,
+          casePassRatio: 0.85,
+        },
+        scenarios: 1,
+        extractionCases: 1,
+        compactionCases: 0,
+        triggerCases: 1,
+        extractionF1Avg: 1,
+        compactionRetentionAvg: 0,
+        triggerAccuracy: 1,
+        passRate: 1,
+        scoreAvg: 1,
+        status: "pass",
+      },
+      scenarios: [
+        {
+          id: "scenario-1",
+          title: null,
+          score: 1,
+          status: "pass",
+          extraction: {
+            expectedCount: 1,
+            observedCount: 1,
+            truePositiveCount: 1,
+            falsePositiveCount: 0,
+            falseNegativeCount: 0,
+            precision: 1,
+            recall: 1,
+            f1: 1,
+            pass: true,
+          },
+          compaction: null,
+          trigger: {
+            expected: "semantic",
+            actual: "semantic",
+            matched: true,
+            pass: true,
+          },
+        },
+      ],
+    })
+  })
+
+  it("returns replay eval result envelope", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/sdk/v1/management/memory/eval/replay", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tenantId: "tenant-a",
+          projectId: "project-a",
+          scenarios: [
+            {
+              id: "scenario-1",
+              extraction: {
+                expected: ["Remember this"],
+                observed: ["Remember this"],
+              },
+              trigger: {
+                expected: "semantic",
+                observed: "semantic",
+              },
+            },
+          ],
+        }),
+      }) as never
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.summary.status).toBe("pass")
+    expect(body.data.scope).toEqual({
+      tenantId: "tenant-a",
+      projectId: "project-a",
+      userId: null,
+    })
+    expect(mockRunReplayEval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarios: [
+          expect.objectContaining({
+            id: "scenario-1",
+          }),
+        ],
+      })
+    )
+  })
+
+  it("returns validation envelope for invalid payload", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/sdk/v1/management/memory/eval/replay", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          scenarios: [],
+        }),
+      }) as never
+    )
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("INVALID_REQUEST")
+  })
+
+  it("returns internal error envelope when eval execution fails", async () => {
+    mockRunReplayEval.mockImplementation(() => {
+      throw new Error("eval crashed")
+    })
+
+    const response = await POST(
+      new Request("https://example.com/api/sdk/v1/management/memory/eval/replay", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          scenarios: [
+            {
+              extraction: {
+                expected: ["x"],
+                observed: ["x"],
+              },
+            },
+          ],
+        }),
+      }) as never
+    )
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe("MEMORY_EVAL_REPLAY_FAILED")
+  })
+})

--- a/packages/web/src/app/api/sdk/v1/management/memory/eval/replay/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/memory/eval/replay/route.ts
@@ -1,0 +1,140 @@
+import { resolveManagementIdentity } from "@/app/api/sdk/v1/management/identity"
+import { apiError } from "@/lib/memory-service/tools"
+import { runReplayEval } from "@/lib/memory-service/eval"
+import { errorResponse, invalidRequestResponse, resolveTursoForScope, successResponse } from "@/lib/sdk-api/runtime"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+const ENDPOINT = "/api/sdk/v1/management/memory/eval/replay"
+
+const triggerTypeSchema = z.union([z.enum(["count", "time", "semantic"]), z.null()])
+
+const scenarioSchema = z
+  .object({
+    id: z.string().trim().min(1).max(160).optional(),
+    title: z.string().trim().min(1).max(240).optional(),
+    extraction: z
+      .object({
+        expected: z.array(z.string().trim().min(1)).max(200),
+        observed: z.array(z.string().trim().min(1)).max(200),
+      })
+      .optional(),
+    compaction: z
+      .object({
+        checkpoint: z.string().trim().min(1).max(50_000),
+        requiredFacts: z.array(z.string().trim().min(1)).max(200),
+      })
+      .optional(),
+    trigger: z
+      .object({
+        expected: triggerTypeSchema,
+        observed: triggerTypeSchema.optional(),
+        signals: z
+          .object({
+            estimatedTokens: z.number().int().nonnegative().optional(),
+            budgetTokens: z.number().int().positive().optional(),
+            turnCount: z.number().int().nonnegative().optional(),
+            turnBudget: z.number().int().positive().optional(),
+            lastActivityAt: z.string().trim().min(1).optional(),
+            inactivityThresholdMinutes: z.number().int().positive().optional(),
+            taskCompleted: z.boolean().optional(),
+            nowIso: z.string().trim().min(1).optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+  })
+  .refine((value) => Boolean(value.extraction || value.compaction || value.trigger), {
+    message: "Each scenario must include extraction, compaction, or trigger inputs",
+  })
+
+const postSchema = z.object({
+  tenantId: z.string().trim().min(1).max(120).optional(),
+  projectId: z.string().trim().min(1).max(240).optional(),
+  userId: z.string().trim().min(1).max(120).optional(),
+  nowIso: z.string().trim().min(1).optional(),
+  passCriteria: z
+    .object({
+      extractionF1: z.number().min(0).max(1).optional(),
+      compactionRetention: z.number().min(0).max(1).optional(),
+      triggerAccuracy: z.number().min(0).max(1).optional(),
+      casePassRatio: z.number().min(0).max(1).optional(),
+    })
+    .optional(),
+  scenarios: z.array(scenarioSchema).min(1).max(200),
+})
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const requestId = crypto.randomUUID()
+
+  const identity = await resolveManagementIdentity({
+    endpoint: ENDPOINT,
+    request,
+    requestId,
+    method: "POST",
+    missingApiKeyMessage: "Generate an API key before running memory replay evals",
+    expiredApiKeyMessage: "API key expired. Generate a new key before running memory replay evals.",
+    apiKeyMetadataLookupLogContext: "Failed to load API key metadata for memory replay eval:",
+  })
+  if (identity instanceof NextResponse) return identity
+
+  const parsed = postSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return invalidRequestResponse(
+      ENDPOINT,
+      requestId,
+      parsed.error.issues[0]?.message ?? "Invalid request payload"
+    )
+  }
+
+  const tenantId = parsed.data.tenantId ?? null
+  const projectId = parsed.data.projectId ?? null
+
+  try {
+    const turso = await resolveTursoForScope({
+      ownerUserId: identity.userId,
+      apiKeyHash: identity.apiKeyHash,
+      tenantId,
+      projectId,
+      endpoint: ENDPOINT,
+      requestId,
+    })
+    if (turso instanceof NextResponse) return turso
+
+    void turso
+
+    const result = runReplayEval({
+      nowIso: parsed.data.nowIso,
+      passCriteria: parsed.data.passCriteria,
+      scenarios: parsed.data.scenarios.map((scenario, index) => ({
+        id: scenario.id ?? `scenario-${index + 1}`,
+        title: scenario.title,
+        extraction: scenario.extraction,
+        compaction: scenario.compaction,
+        trigger: scenario.trigger,
+      })),
+    })
+
+    return successResponse(ENDPOINT, requestId, {
+      scope: {
+        tenantId,
+        projectId,
+        userId: parsed.data.userId ?? null,
+      },
+      ...result,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to run memory replay eval"
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "internal_error",
+        code: "MEMORY_EVAL_REPLAY_FAILED",
+        message,
+        status: 500,
+        retryable: true,
+      })
+    )
+  }
+}

--- a/packages/web/src/lib/memory-service/eval.test.ts
+++ b/packages/web/src/lib/memory-service/eval.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import { runReplayEval } from "./eval"
+
+describe("runReplayEval", () => {
+  it("scores extraction, compaction, and trigger quality for replay scenarios", () => {
+    const result = runReplayEval({
+      nowIso: "2026-02-26T00:00:00.000Z",
+      scenarios: [
+        {
+          id: "scenario-1",
+          title: "happy path",
+          extraction: {
+            expected: ["Prefer short pull requests", "Tag release notes"],
+            observed: ["Prefer short pull requests", "Tag release notes", "Tag release notes"],
+          },
+          compaction: {
+            checkpoint:
+              "Compaction checkpoint. Prefer short pull requests and tag release notes before shipping.",
+            requiredFacts: ["Prefer short pull requests", "Tag release notes"],
+          },
+          trigger: {
+            expected: "count",
+            signals: {
+              estimatedTokens: 1500,
+              budgetTokens: 400,
+            },
+          },
+        },
+      ],
+    })
+
+    expect(result.summary.status).toBe("pass")
+    expect(result.summary.passRate).toBe(1)
+    expect(result.summary.extractionF1Avg).toBe(1)
+    expect(result.summary.compactionRetentionAvg).toBe(1)
+    expect(result.summary.triggerAccuracy).toBe(1)
+    expect(result.scenarios[0]?.status).toBe("pass")
+  })
+
+  it("returns warn when only part of the replay set passes", () => {
+    const result = runReplayEval({
+      scenarios: [
+        {
+          id: "pass-case",
+          extraction: {
+            expected: ["Use canary rollout"],
+            observed: ["Use canary rollout"],
+          },
+          trigger: {
+            expected: "semantic",
+            observed: "semantic",
+          },
+        },
+        {
+          id: "fail-case",
+          extraction: {
+            expected: ["Always snapshot before reset"],
+            observed: ["Different fact"],
+          },
+          compaction: {
+            checkpoint: "Checkpoint without required data",
+            requiredFacts: ["Always snapshot before reset"],
+          },
+          trigger: {
+            expected: "time",
+            observed: "count",
+          },
+        },
+      ],
+    })
+
+    expect(result.summary.status).toBe("warn")
+    expect(result.summary.passRate).toBe(0.5)
+    expect(result.scenarios[0]?.status).toBe("pass")
+    expect(result.scenarios[1]?.status).toBe("fail")
+    expect(result.scenarios[1]?.compaction?.missingFacts).toEqual(["Always snapshot before reset"])
+  })
+
+  it("returns fail when the replay set is empty", () => {
+    const result = runReplayEval({
+      scenarios: [],
+    })
+
+    expect(result.summary.status).toBe("fail")
+    expect(result.summary.scenarios).toBe(0)
+  })
+})

--- a/packages/web/src/lib/memory-service/eval.ts
+++ b/packages/web/src/lib/memory-service/eval.ts
@@ -1,0 +1,382 @@
+export type ReplayEvalTriggerType = "count" | "time" | "semantic" | null
+export type ReplayEvalStatus = "pass" | "warn" | "fail"
+
+export interface ReplayEvalPassCriteria {
+  extractionF1: number
+  compactionRetention: number
+  triggerAccuracy: number
+  casePassRatio: number
+}
+
+export interface ReplayEvalExtractionInput {
+  expected: string[]
+  observed: string[]
+}
+
+export interface ReplayEvalCompactionInput {
+  checkpoint: string
+  requiredFacts: string[]
+}
+
+export interface ReplayEvalTriggerSignalsInput {
+  estimatedTokens?: number
+  budgetTokens?: number
+  turnCount?: number
+  turnBudget?: number
+  lastActivityAt?: string
+  inactivityThresholdMinutes?: number
+  taskCompleted?: boolean
+  nowIso?: string
+}
+
+export interface ReplayEvalTriggerInput {
+  expected: ReplayEvalTriggerType
+  observed?: ReplayEvalTriggerType
+  signals?: ReplayEvalTriggerSignalsInput
+}
+
+export interface ReplayEvalScenarioInput {
+  id: string
+  title?: string
+  extraction?: ReplayEvalExtractionInput
+  compaction?: ReplayEvalCompactionInput
+  trigger?: ReplayEvalTriggerInput
+}
+
+export interface ReplayEvalInput {
+  nowIso?: string
+  passCriteria?: Partial<ReplayEvalPassCriteria>
+  scenarios: ReplayEvalScenarioInput[]
+}
+
+export interface ReplayEvalExtractionResult {
+  expectedCount: number
+  observedCount: number
+  truePositiveCount: number
+  falsePositiveCount: number
+  falseNegativeCount: number
+  precision: number
+  recall: number
+  f1: number
+  pass: boolean
+}
+
+export interface ReplayEvalCompactionResult {
+  requiredCount: number
+  retainedCount: number
+  missingFacts: string[]
+  retention: number
+  pass: boolean
+}
+
+export interface ReplayEvalTriggerResult {
+  expected: ReplayEvalTriggerType
+  actual: ReplayEvalTriggerType
+  matched: boolean
+  pass: boolean
+}
+
+export interface ReplayEvalScenarioResult {
+  id: string
+  title: string | null
+  score: number
+  status: ReplayEvalStatus
+  extraction: ReplayEvalExtractionResult | null
+  compaction: ReplayEvalCompactionResult | null
+  trigger: ReplayEvalTriggerResult | null
+}
+
+export interface ReplayEvalSummary {
+  evaluatedAt: string
+  criteria: ReplayEvalPassCriteria
+  scenarios: number
+  extractionCases: number
+  compactionCases: number
+  triggerCases: number
+  extractionF1Avg: number
+  compactionRetentionAvg: number
+  triggerAccuracy: number
+  passRate: number
+  scoreAvg: number
+  status: ReplayEvalStatus
+}
+
+export interface ReplayEvalResult {
+  summary: ReplayEvalSummary
+  scenarios: ReplayEvalScenarioResult[]
+}
+
+const DEFAULT_PASS_CRITERIA: ReplayEvalPassCriteria = {
+  extractionF1: 0.7,
+  compactionRetention: 0.85,
+  triggerAccuracy: 0.9,
+  casePassRatio: 0.85,
+}
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ")
+}
+
+function uniqueNormalized(values: string[]): Set<string> {
+  const normalized = values
+    .map((value) => normalizeText(value))
+    .filter((value) => value.length > 0)
+  return new Set(normalized)
+}
+
+function safeRatio(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0
+  return numerator / denominator
+}
+
+function round(value: number, decimals = 4): number {
+  if (!Number.isFinite(value)) return 0
+  return Number(value.toFixed(decimals))
+}
+
+function normalizeCriteria(input: Partial<ReplayEvalPassCriteria> | undefined): ReplayEvalPassCriteria {
+  const parseUnitRatio = (value: number | undefined, fallback: number): number => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return fallback
+    if (value < 0) return 0
+    if (value > 1) return 1
+    return value
+  }
+
+  return {
+    extractionF1: parseUnitRatio(input?.extractionF1, DEFAULT_PASS_CRITERIA.extractionF1),
+    compactionRetention: parseUnitRatio(input?.compactionRetention, DEFAULT_PASS_CRITERIA.compactionRetention),
+    triggerAccuracy: parseUnitRatio(input?.triggerAccuracy, DEFAULT_PASS_CRITERIA.triggerAccuracy),
+    casePassRatio: parseUnitRatio(input?.casePassRatio, DEFAULT_PASS_CRITERIA.casePassRatio),
+  }
+}
+
+function parseIso(value: string | undefined): Date | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed
+}
+
+function evaluateTriggerSignals(input: ReplayEvalTriggerSignalsInput | undefined): ReplayEvalTriggerType {
+  if (!input) return null
+
+  const estimatedTokens = Number.isFinite(input.estimatedTokens) ? Math.max(0, Math.floor(input.estimatedTokens as number)) : null
+  const budgetTokens = Number.isFinite(input.budgetTokens) ? Math.max(0, Math.floor(input.budgetTokens as number)) : null
+  const turnCount = Number.isFinite(input.turnCount) ? Math.max(0, Math.floor(input.turnCount as number)) : null
+  const turnBudget = Number.isFinite(input.turnBudget) ? Math.max(0, Math.floor(input.turnBudget as number)) : null
+
+  const tokenExceeded = estimatedTokens !== null && budgetTokens !== null && budgetTokens > 0 && estimatedTokens > budgetTokens
+  const turnsExceeded = turnCount !== null && turnBudget !== null && turnBudget > 0 && turnCount > turnBudget
+  if (tokenExceeded || turnsExceeded) return "count"
+
+  const inactivityThresholdMinutes =
+    Number.isFinite(input.inactivityThresholdMinutes) && (input.inactivityThresholdMinutes as number) > 0
+      ? Math.floor(input.inactivityThresholdMinutes as number)
+      : null
+  const now = parseIso(input.nowIso) ?? new Date()
+  const lastActivityAt = parseIso(input.lastActivityAt)
+  if (inactivityThresholdMinutes !== null && lastActivityAt) {
+    const inactiveForMs = now.getTime() - lastActivityAt.getTime()
+    if (inactiveForMs >= inactivityThresholdMinutes * 60_000) {
+      return "time"
+    }
+  }
+
+  if (input.taskCompleted === true) return "semantic"
+  return null
+}
+
+function evaluateExtraction(
+  input: ReplayEvalExtractionInput,
+  criteria: ReplayEvalPassCriteria
+): ReplayEvalExtractionResult {
+  const expectedSet = uniqueNormalized(input.expected)
+  const observedSet = uniqueNormalized(input.observed)
+
+  let truePositiveCount = 0
+  for (const candidate of observedSet) {
+    if (expectedSet.has(candidate)) {
+      truePositiveCount += 1
+    }
+  }
+
+  const falsePositiveCount = observedSet.size - truePositiveCount
+  const falseNegativeCount = expectedSet.size - truePositiveCount
+  const precision = safeRatio(truePositiveCount, observedSet.size)
+  const recall = safeRatio(truePositiveCount, expectedSet.size)
+  const f1 =
+    precision > 0 || recall > 0
+      ? safeRatio(2 * precision * recall, precision + recall)
+      : 0
+
+  return {
+    expectedCount: expectedSet.size,
+    observedCount: observedSet.size,
+    truePositiveCount,
+    falsePositiveCount,
+    falseNegativeCount,
+    precision: round(precision),
+    recall: round(recall),
+    f1: round(f1),
+    pass: f1 >= criteria.extractionF1,
+  }
+}
+
+function evaluateCompaction(
+  input: ReplayEvalCompactionInput,
+  criteria: ReplayEvalPassCriteria
+): ReplayEvalCompactionResult {
+  const checkpoint = normalizeText(input.checkpoint)
+  const requiredFacts = input.requiredFacts
+    .map((fact) => fact.trim())
+    .filter((fact) => fact.length > 0)
+
+  const missingFacts: string[] = []
+  let retainedCount = 0
+
+  for (const fact of requiredFacts) {
+    const normalizedFact = normalizeText(fact)
+    if (!normalizedFact) continue
+    if (checkpoint.includes(normalizedFact)) {
+      retainedCount += 1
+    } else {
+      missingFacts.push(fact)
+    }
+  }
+
+  const requiredCount = requiredFacts.length
+  const retention = requiredCount > 0 ? safeRatio(retainedCount, requiredCount) : 1
+
+  return {
+    requiredCount,
+    retainedCount,
+    missingFacts,
+    retention: round(retention),
+    pass: retention >= criteria.compactionRetention,
+  }
+}
+
+function evaluateTrigger(
+  input: ReplayEvalTriggerInput,
+  criteria: ReplayEvalPassCriteria
+): ReplayEvalTriggerResult {
+  const actual = input.observed ?? evaluateTriggerSignals(input.signals)
+  const matched = actual === input.expected
+  const pass = safeRatio(matched ? 1 : 0, 1) >= criteria.triggerAccuracy
+
+  return {
+    expected: input.expected,
+    actual,
+    matched,
+    pass,
+  }
+}
+
+function deriveSummaryStatus(summary: Omit<ReplayEvalSummary, "status">): ReplayEvalStatus {
+  if (summary.scenarios === 0) return "fail"
+  const passesGate =
+    summary.passRate >= summary.criteria.casePassRatio &&
+    (summary.extractionCases === 0 || summary.extractionF1Avg >= summary.criteria.extractionF1) &&
+    (summary.compactionCases === 0 || summary.compactionRetentionAvg >= summary.criteria.compactionRetention) &&
+    (summary.triggerCases === 0 || summary.triggerAccuracy >= summary.criteria.triggerAccuracy)
+
+  if (passesGate) return "pass"
+  if (summary.passRate >= 0.5) return "warn"
+  return "fail"
+}
+
+export function runReplayEval(input: ReplayEvalInput): ReplayEvalResult {
+  const criteria = normalizeCriteria(input.passCriteria)
+  const evaluatedAt = parseIso(input.nowIso)?.toISOString() ?? new Date().toISOString()
+
+  const scenarios: ReplayEvalScenarioResult[] = input.scenarios.map((scenario) => {
+    const extraction = scenario.extraction ? evaluateExtraction(scenario.extraction, criteria) : null
+    const compaction = scenario.compaction ? evaluateCompaction(scenario.compaction, criteria) : null
+    const trigger = scenario.trigger ? evaluateTrigger(scenario.trigger, criteria) : null
+
+    const scoreParts: number[] = []
+    const componentPasses: boolean[] = []
+
+    if (extraction) {
+      scoreParts.push(extraction.f1)
+      componentPasses.push(extraction.pass)
+    }
+    if (compaction) {
+      scoreParts.push(compaction.retention)
+      componentPasses.push(compaction.pass)
+    }
+    if (trigger) {
+      scoreParts.push(trigger.matched ? 1 : 0)
+      componentPasses.push(trigger.pass)
+    }
+
+    const score = scoreParts.length > 0 ? scoreParts.reduce((sum, value) => sum + value, 0) / scoreParts.length : 0
+    const allPassed = componentPasses.length > 0 && componentPasses.every(Boolean)
+
+    return {
+      id: scenario.id,
+      title: scenario.title?.trim() || null,
+      score: round(score),
+      status: allPassed ? "pass" : scoreParts.length > 0 ? "fail" : "warn",
+      extraction,
+      compaction,
+      trigger,
+    }
+  })
+
+  const extractionResults = scenarios
+    .map((scenario) => scenario.extraction)
+    .filter((value): value is ReplayEvalExtractionResult => value !== null)
+  const compactionResults = scenarios
+    .map((scenario) => scenario.compaction)
+    .filter((value): value is ReplayEvalCompactionResult => value !== null)
+  const triggerResults = scenarios
+    .map((scenario) => scenario.trigger)
+    .filter((value): value is ReplayEvalTriggerResult => value !== null)
+
+  const extractionF1Avg =
+    extractionResults.length > 0
+      ? extractionResults.reduce((sum, result) => sum + result.f1, 0) / extractionResults.length
+      : 0
+  const compactionRetentionAvg =
+    compactionResults.length > 0
+      ? compactionResults.reduce((sum, result) => sum + result.retention, 0) / compactionResults.length
+      : 0
+  const triggerAccuracy =
+    triggerResults.length > 0
+      ? triggerResults.reduce((sum, result) => sum + (result.matched ? 1 : 0), 0) / triggerResults.length
+      : 0
+  const passRate =
+    scenarios.length > 0
+      ? scenarios.reduce((sum, scenario) => sum + (scenario.status === "pass" ? 1 : 0), 0) / scenarios.length
+      : 0
+  const scoreAvg =
+    scenarios.length > 0
+      ? scenarios.reduce((sum, scenario) => sum + scenario.score, 0) / scenarios.length
+      : 0
+
+  const summaryWithoutStatus: Omit<ReplayEvalSummary, "status"> = {
+    evaluatedAt,
+    criteria,
+    scenarios: scenarios.length,
+    extractionCases: extractionResults.length,
+    compactionCases: compactionResults.length,
+    triggerCases: triggerResults.length,
+    extractionF1Avg: round(extractionF1Avg),
+    compactionRetentionAvg: round(compactionRetentionAvg),
+    triggerAccuracy: round(triggerAccuracy),
+    passRate: round(passRate),
+    scoreAvg: round(scoreAvg),
+  }
+
+  return {
+    summary: {
+      ...summaryWithoutStatus,
+      status: deriveSummaryStatus(summaryWithoutStatus),
+    },
+    scenarios,
+  }
+}


### PR DESCRIPTION
## Summary
- add a deterministic replay/eval harness for memory extraction quality, compaction retention, and trigger matching
- add management endpoint `POST /api/sdk/v1/management/memory/eval/replay`
- return case-level scores and aggregate pass/warn/fail summary for rollout gating

## Validation
- pnpm -C packages/web test src/lib/memory-service/eval.test.ts src/app/api/sdk/v1/management/memory/eval/replay/__tests__/route.test.ts
- pnpm -C packages/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated management endpoint that accepts user-provided payloads and returns computed evaluation results; main risk is request validation/edge cases and ensuring errors are consistently enveloped (no persistence side-effects).
> 
> **Overview**
> Adds `runReplayEval` in `lib/memory-service/eval.ts`, which computes per-scenario extraction F1, compaction retention, and trigger matching, then aggregates a pass/warn/fail summary with configurable pass criteria.
> 
> Exposes this via a new authenticated `POST /api/sdk/v1/management/memory/eval/replay` route with Zod validation, scope-aware Turso resolution, and consistent success/validation/internal-error envelopes (`MEMORY_EVAL_REPLAY_FAILED`). Includes unit tests for the scorer and route behavior (happy path, invalid payload, and thrown error).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 843187bac3f29e60201674017f7937ee5d80f676. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->