### PR TITLE
chore(rollout): default-on lifecycle flags and deprecate legacy strategies

### DIFF
--- a/packages/core/src/__tests__/client-helpers.test.ts
+++ b/packages/core/src/__tests__/client-helpers.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { normalizeContextStrategy, resetLegacyStrategyWarningsForTest } from "../client-helpers"
+
+const originalSuppressFlag = process.env.MEMORIES_SUPPRESS_DEPRECATION_WARNINGS
+
+describe("client helper legacy strategy warnings", () => {
+  beforeEach(() => {
+    delete process.env.MEMORIES_SUPPRESS_DEPRECATION_WARNINGS
+    resetLegacyStrategyWarningsForTest()
+  })
+
+  afterEach(() => {
+    if (originalSuppressFlag === undefined) {
+      delete process.env.MEMORIES_SUPPRESS_DEPRECATION_WARNINGS
+    } else {
+      process.env.MEMORIES_SUPPRESS_DEPRECATION_WARNINGS = originalSuppressFlag
+    }
+    vi.restoreAllMocks()
+  })
+
+  it("warns once when baseline alias is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+    expect(normalizeContextStrategy("baseline")).toBe("lexical")
+    expect(normalizeContextStrategy("baseline")).toBe("lexical")
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[memories] retrieval strategy "baseline" is deprecated. Use "lexical" instead.'
+    )
+  })
+
+  it("warns once when hybrid_graph alias is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+    expect(normalizeContextStrategy("hybrid_graph")).toBe("hybrid")
+    expect(normalizeContextStrategy("hybrid_graph")).toBe("hybrid")
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[memories] retrieval strategy "hybrid_graph" is deprecated. Use "hybrid" instead.'
+    )
+  })
+
+  it("supports suppressing legacy warnings via env", () => {
+    process.env.MEMORIES_SUPPRESS_DEPRECATION_WARNINGS = "true"
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+    expect(normalizeContextStrategy("baseline")).toBe("lexical")
+    expect(normalizeContextStrategy("hybrid_graph")).toBe("hybrid")
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -379,6 +379,7 @@ describe("MemoriesClient", () => {
   })
 
   it("normalizes legacy hybrid_graph to hybrid on SDK context endpoint body", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       new Response(
         JSON.stringify({
@@ -424,6 +425,9 @@ describe("MemoriesClient", () => {
     expect(parsedBody.strategy).toBe("hybrid")
     expect(parsedBody.graphDepth).toBe(1)
     expect(parsedBody.graphLimit).toBe(8)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[memories] retrieval strategy "hybrid_graph" is deprecated. Use "hybrid" instead.'
+    )
   })
 
   it("forwards search strategy to SDK memories.search endpoint body", async () => {

--- a/packages/core/src/client-helpers.ts
+++ b/packages/core/src/client-helpers.ts
@@ -4,6 +4,7 @@ import type {
   ContextGetOptions,
   ContextMode,
   ContextStrategy,
+  LegacyContextStrategy,
   MemoriesErrorData,
   MemoriesResponseEnvelope,
   MemoryRecord,
@@ -57,6 +58,27 @@ export type ContextGetMethod = {
 
 const contextModes = new Set<ContextMode>(["all", "working", "long_term", "rules_only"])
 const contextStrategies = new Set<ContextStrategy>(["lexical", "semantic", "hybrid", "baseline", "hybrid_graph"])
+const legacyStrategyWarningSeen = new Set<LegacyContextStrategy>()
+
+function isLegacyWarningSuppressed(): boolean {
+  if (typeof process === "undefined") return false
+  const value = process.env.MEMORIES_SUPPRESS_DEPRECATION_WARNINGS
+  if (!value) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on"
+}
+
+function warnLegacyStrategy(strategy: LegacyContextStrategy, replacement: NormalizedRetrievalStrategy): void {
+  if (legacyStrategyWarningSeen.has(strategy) || isLegacyWarningSuppressed()) return
+  legacyStrategyWarningSeen.add(strategy)
+  if (typeof console !== "undefined" && typeof console.warn === "function") {
+    console.warn(`[memories] retrieval strategy "${strategy}" is deprecated. Use "${replacement}" instead.`)
+  }
+}
+
+export function resetLegacyStrategyWarningsForTest(): void {
+  legacyStrategyWarningSeen.clear()
+}
 
 function normalizeOptionalPositiveInt(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -217,8 +239,14 @@ export function normalizeContextMode(mode: unknown): ContextMode {
 
 export function normalizeContextStrategy(strategy: unknown): NormalizedRetrievalStrategy {
   if (typeof strategy === "string" && contextStrategies.has(strategy as ContextStrategy)) {
-    if (strategy === "baseline") return "lexical"
-    if (strategy === "hybrid_graph") return "hybrid"
+    if (strategy === "baseline") {
+      warnLegacyStrategy("baseline", "lexical")
+      return "lexical"
+    }
+    if (strategy === "hybrid_graph") {
+      warnLegacyStrategy("hybrid_graph", "hybrid")
+      return "hybrid"
+    }
     if (strategy === "lexical" || strategy === "semantic" || strategy === "hybrid") {
       return strategy
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 export type MemoryType = "rule" | "decision" | "fact" | "note" | "skill"
 export type MemoryLayer = "rule" | "working" | "long_term"
 export type RetrievalStrategy = "lexical" | "semantic" | "hybrid"
+/** @deprecated Use lexical/hybrid retrieval strategy names instead. */
 export type LegacyContextStrategy = "baseline" | "hybrid_graph"
 export type ContextStrategy = RetrievalStrategy | LegacyContextStrategy
 

--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -3,6 +3,19 @@ title: Changelog
 description: Product and documentation updates.
 ---
 
+## February 26, 2026
+
+- Added memory lifecycle observability endpoint: `GET /api/sdk/v1/management/memory/observability` (lifecycle, compaction, consolidation, contradiction trend metrics + alarms).
+- Added replay/eval harness endpoint: `POST /api/sdk/v1/management/memory/eval/replay` for extraction F1, compaction retention, and trigger-match scoring.
+- Added default-on lifecycle feature flags with explicit endpoint gating:
+  - `MEMORY_SESSION_ENABLED` (sessions API surface)
+  - `MEMORY_COMPACTION_ENABLED` (memory lifecycle observability/eval)
+  - `MEMORY_CONSOLIDATION_ENABLED` (`memories/consolidate`)
+  - `MEMORY_PROCEDURAL_ENABLED` (`skills/files/promote`)
+- Added typed disabled responses for lifecycle flags (`MEMORY_SESSION_DISABLED`, `MEMORY_COMPACTION_DISABLED`, `MEMORY_CONSOLIDATION_DISABLED`, `MEMORY_PROCEDURAL_DISABLED`).
+- Deprecated legacy strategy aliases in `@memories.sh/core` (`baseline`, `hybrid_graph`) with one-time warnings and suppression support via `MEMORIES_SUPPRESS_DEPRECATION_WARNINGS=true`.
+- Updated SDK docs/contract matrix with session, consolidate/promote, and memory management observability/eval routes plus Phase 7 rollout defaults.
+
 ## February 21, 2026
 
 - Added cron reminder support in CLI via `memories reminders` (`add`, `list`, `run`, `enable`, `disable`, `delete`).

--- a/packages/web/content/docs/sdk/client.mdx
+++ b/packages/web/content/docs/sdk/client.mdx
@@ -102,7 +102,7 @@ Enable graph-augmented recall per request:
 ```typescript
 const ctx = await client.context.get({
   query: "why did billing alerts spike?",
-  strategy: "hybrid_graph", // or "baseline"
+  strategy: "hybrid", // or "lexical"
   graphDepth: 1,            // 0 | 1 | 2
   graphLimit: 8,            // max graph-expanded memories
   userId: "user_123",
@@ -111,7 +111,7 @@ const ctx = await client.context.get({
 
 console.log(ctx.trace)
 // {
-//   requestedStrategy: "hybrid_graph",
+//   requestedStrategy: "hybrid",
 //   strategy: "baseline" | "hybrid_graph",
 //   rolloutMode: "off" | "shadow" | "canary",
 //   shadowExecuted: boolean,
@@ -124,6 +124,8 @@ console.log(ctx.trace)
 ```
 
 `trace.strategy` is the applied strategy after rollout guardrails. This lets you detect when a hybrid request safely falls back to baseline.
+
+Legacy aliases `baseline` and `hybrid_graph` are still accepted by the client, but they are deprecated and emit a one-time warning. You can silence warnings with `MEMORIES_SUPPRESS_DEPRECATION_WARNINGS=true`.
 
 With graph mapping enabled, hybrid retrieval can surface semantically related memories through `similar_to` edges even when lexical overlap is weak.
 

--- a/packages/web/content/docs/sdk/endpoint-contract.mdx
+++ b/packages/web/content/docs/sdk/endpoint-contract.mdx
@@ -32,9 +32,15 @@ https://memories.sh
 | Runtime | `/api/sdk/v1/memories/forget` | `POST` | Bearer API key (`mem_...`) |
 | Runtime | `/api/sdk/v1/memories/bulk-forget` | `POST` | Bearer API key (`mem_...`) |
 | Runtime | `/api/sdk/v1/memories/vacuum` | `POST` | Bearer API key (`mem_...`) |
+| Runtime | `/api/sdk/v1/memories/consolidate` | `POST` | Bearer API key (`mem_...`) |
 | Runtime | `/api/sdk/v1/skills/files/upsert` | `POST` | Bearer API key (`mem_...`) |
 | Runtime | `/api/sdk/v1/skills/files/list` | `POST` | Bearer API key (`mem_...`) |
 | Runtime | `/api/sdk/v1/skills/files/delete` | `POST` | Bearer API key (`mem_...`) |
+| Runtime | `/api/sdk/v1/skills/files/promote` | `POST` | Bearer API key (`mem_...`) |
+| Runtime | `/api/sdk/v1/sessions/start` | `POST` | Bearer API key (`mem_...`) |
+| Runtime | `/api/sdk/v1/sessions/checkpoint` | `POST` | Bearer API key (`mem_...`) |
+| Runtime | `/api/sdk/v1/sessions/end` | `POST` | Bearer API key (`mem_...`) |
+| Runtime | `/api/sdk/v1/sessions/{sessionId}/snapshot` | `GET` | Bearer API key (`mem_...`) |
 | Runtime | `/api/sdk/v1/embeddings/models` | `GET` | Bearer API key (`mem_...`) or session |
 | Graph | `/api/sdk/v1/graph/status` | `GET`, `POST` | Bearer API key (`mem_...`) |
 | Graph | `/api/sdk/v1/graph/trace` | `POST` | Bearer API key (`mem_...`) |
@@ -44,6 +50,8 @@ https://memories.sh
 | Management | `/api/sdk/v1/management/embeddings/usage` | `GET` | Bearer API key (`mem_...`) or session |
 | Management | `/api/sdk/v1/management/embeddings/backfill` | `GET`, `POST` | Bearer API key (`mem_...`) or session |
 | Management | `/api/sdk/v1/management/embeddings/observability` | `GET` | Bearer API key (`mem_...`) or session |
+| Management | `/api/sdk/v1/management/memory/observability` | `GET` | Bearer API key (`mem_...`) or session |
+| Management | `/api/sdk/v1/management/memory/eval/replay` | `POST` | Bearer API key (`mem_...`) or session |
 
 Legacy aliases are still available:
 
@@ -213,10 +221,13 @@ Defaults:
 - `graphDepth`: `1`
 - `graphLimit`: `8`
 
-Strategy aliases accepted for backward compatibility:
+Strategy aliases accepted for backward compatibility (deprecated):
 
 - `baseline` → `lexical`
 - `hybrid_graph` → `hybrid`
+
+When aliases are used through `@memories.sh/core`, the client emits a one-time deprecation warning.
+Set `MEMORIES_SUPPRESS_DEPRECATION_WARNINGS=true` to silence those warnings in controlled environments.
 
 Response `data`:
 
@@ -567,6 +578,9 @@ Request is similar to `context/get`, but defaults differ:
 - `strategy` default: policy default (`baseline` for lexical policy, `hybrid_graph` for hybrid policy)
 - `limit` default: `10`
 
+`graph/trace` currently accepts legacy strategy literals (`baseline`, `hybrid_graph`) for direct diagnostics parity.
+Use `context/get` with `lexical|hybrid` in new client integrations.
+
 Response `data` includes:
 
 - `mode`, `includeRules`, `query`
@@ -771,6 +785,81 @@ Response `data` includes:
 - `slos`
 - `alarms[]`
 - `health` (`healthy` | `degraded` | `critical`)
+
+### `GET /api/sdk/v1/management/memory/observability`
+
+Read lifecycle health snapshot for memory creation, compaction, consolidation, and contradiction trends.
+
+Query params:
+
+- `tenantId`
+- `projectId`
+- `userId`
+- `windowHours` (`1..336`)
+
+Response `data` includes:
+
+- `lifecycle` (created/updated/deleted/active/total counts)
+- `compaction` (trigger mix, checkpoint coverage)
+- `consolidation` (run totals + conflict rate)
+- `contradictions` (window totals + daily trend)
+- `alarms[]`
+- `health` (`healthy` | `degraded` | `critical`)
+
+### `POST /api/sdk/v1/management/memory/eval/replay`
+
+Run deterministic replay/eval scoring for extraction quality, compaction retention, and trigger matching.
+
+Request:
+
+```json
+{
+  "tenantId": "acme-prod",
+  "projectId": "github.com/acme/platform",
+  "passCriteria": {
+    "extractionF1": 0.7,
+    "compactionRetention": 0.85,
+    "triggerAccuracy": 0.9,
+    "casePassRatio": 0.85
+  },
+  "scenarios": [
+    {
+      "id": "release-1",
+      "extraction": {
+        "expected": ["Always snapshot before reset"],
+        "observed": ["Always snapshot before reset"]
+      },
+      "trigger": {
+        "expected": "semantic",
+        "observed": "semantic"
+      }
+    }
+  ]
+}
+```
+
+Response `data` includes:
+
+- `scope` (tenant/project/user echo)
+- `summary` (case counts, aggregate scores, pass/warn/fail)
+- `scenarios[]` (per-case extraction/compaction/trigger metrics)
+
+### Memory Lifecycle Feature Flags
+
+Default rollout posture:
+
+- `MEMORY_SESSION_ENABLED=true`
+- `MEMORY_COMPACTION_ENABLED=true`
+- `MEMORY_CONSOLIDATION_ENABLED=true`
+- `MEMORY_PROCEDURAL_ENABLED=true`
+- `MEMORY_OPENCLAW_FILE_MODE_ENABLED=false` (opt-in)
+
+When disabled, affected endpoints return `403` with a typed flag code:
+
+- `MEMORY_SESSION_DISABLED`
+- `MEMORY_COMPACTION_DISABLED`
+- `MEMORY_CONSOLIDATION_DISABLED`
+- `MEMORY_PROCEDURAL_DISABLED`
 
 ## cURL Quick Reference
 

--- a/packages/web/src/app/api/sdk/v1/sessions/[sessionId]/snapshot/route.ts
+++ b/packages/web/src/app/api/sdk/v1/sessions/[sessionId]/snapshot/route.ts
@@ -9,6 +9,7 @@ import {
   successResponse,
 } from "@/lib/sdk-api/runtime"
 import { scopeSchema } from "@/lib/sdk-api/schemas"
+import { isMemorySessionEnabled } from "@/lib/env"
 import { NextRequest, NextResponse } from "next/server"
 
 const ENDPOINT = "/api/sdk/v1/sessions/{id}/snapshot"
@@ -59,6 +60,21 @@ export async function GET(
   const authResult = await authenticateApiKey(apiKey, ENDPOINT, requestId)
   if (authResult instanceof NextResponse) {
     return authResult
+  }
+
+  if (!isMemorySessionEnabled()) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "validation_error",
+        code: "MEMORY_SESSION_DISABLED",
+        message: "Memory session lifecycle endpoints are disabled by MEMORY_SESSION_ENABLED=0.",
+        status: 403,
+        retryable: false,
+        details: { flag: "MEMORY_SESSION_ENABLED" },
+      })
+    )
   }
 
   let scope: ReturnType<typeof scopeSchema.parse>

--- a/packages/web/src/app/api/sdk/v1/sessions/checkpoint/route.ts
+++ b/packages/web/src/app/api/sdk/v1/sessions/checkpoint/route.ts
@@ -9,6 +9,7 @@ import {
   successResponse,
 } from "@/lib/sdk-api/runtime"
 import { scopeSchema } from "@/lib/sdk-api/schemas"
+import { isMemorySessionEnabled } from "@/lib/env"
 import { NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
 
@@ -46,6 +47,21 @@ export async function POST(request: NextRequest): Promise<Response> {
   const authResult = await authenticateApiKey(apiKey, ENDPOINT, requestId)
   if (authResult instanceof NextResponse) {
     return authResult
+  }
+
+  if (!isMemorySessionEnabled()) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "validation_error",
+        code: "MEMORY_SESSION_DISABLED",
+        message: "Memory session lifecycle endpoints are disabled by MEMORY_SESSION_ENABLED=0.",
+        status: 403,
+        retryable: false,
+        details: { flag: "MEMORY_SESSION_ENABLED" },
+      })
+    )
   }
 
   let parsedRequest: z.infer<typeof requestSchema>

--- a/packages/web/src/app/api/sdk/v1/sessions/start/route.ts
+++ b/packages/web/src/app/api/sdk/v1/sessions/start/route.ts
@@ -9,6 +9,7 @@ import {
   successResponse,
 } from "@/lib/sdk-api/runtime"
 import { scopeSchema } from "@/lib/sdk-api/schemas"
+import { isMemorySessionEnabled } from "@/lib/env"
 import { NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
 
@@ -42,6 +43,21 @@ export async function POST(request: NextRequest): Promise<Response> {
   const authResult = await authenticateApiKey(apiKey, ENDPOINT, requestId)
   if (authResult instanceof NextResponse) {
     return authResult
+  }
+
+  if (!isMemorySessionEnabled()) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "validation_error",
+        code: "MEMORY_SESSION_DISABLED",
+        message: "Memory session lifecycle endpoints are disabled by MEMORY_SESSION_ENABLED=0.",
+        status: 403,
+        retryable: false,
+        details: { flag: "MEMORY_SESSION_ENABLED" },
+      })
+    )
   }
 
   let parsedRequest: z.infer<typeof requestSchema>

--- a/packages/web/src/app/api/sdk/v1/skills/files/promote/route.ts
+++ b/packages/web/src/app/api/sdk/v1/skills/files/promote/route.ts
@@ -9,6 +9,7 @@ import {
   successResponse,
 } from "@/lib/sdk-api/runtime"
 import { scopeSchema } from "@/lib/sdk-api/schemas"
+import { isMemoryProceduralEnabled } from "@/lib/env"
 import { NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
 
@@ -45,6 +46,21 @@ export async function POST(request: NextRequest): Promise<Response> {
   const authResult = await authenticateApiKey(apiKey, ENDPOINT, requestId)
   if (authResult instanceof NextResponse) {
     return authResult
+  }
+
+  if (!isMemoryProceduralEnabled()) {
+    return errorResponse(
+      ENDPOINT,
+      requestId,
+      apiError({
+        type: "validation_error",
+        code: "MEMORY_PROCEDURAL_DISABLED",
+        message: "Procedural memory promotion is disabled by MEMORY_PROCEDURAL_ENABLED=0.",
+        status: 403,
+        retryable: false,
+        details: { flag: "MEMORY_PROCEDURAL_ENABLED" },
+      })
+    )
   }
 
   let parsedRequest: z.infer<typeof requestSchema>

--- a/packages/web/src/lib/env-memory-flags.test.ts
+++ b/packages/web/src/lib/env-memory-flags.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  isMemoryCompactionEnabled,
+  isMemoryConsolidationEnabled,
+  isMemoryOpenClawFileModeEnabled,
+  isMemoryProceduralEnabled,
+  isMemorySessionEnabled,
+} from "./env"
+
+const originalValues = {
+  session: process.env.MEMORY_SESSION_ENABLED,
+  compaction: process.env.MEMORY_COMPACTION_ENABLED,
+  consolidation: process.env.MEMORY_CONSOLIDATION_ENABLED,
+  procedural: process.env.MEMORY_PROCEDURAL_ENABLED,
+  openclaw: process.env.MEMORY_OPENCLAW_FILE_MODE_ENABLED,
+}
+
+function restoreEnv(): void {
+  if (originalValues.session === undefined) delete process.env.MEMORY_SESSION_ENABLED
+  else process.env.MEMORY_SESSION_ENABLED = originalValues.session
+
+  if (originalValues.compaction === undefined) delete process.env.MEMORY_COMPACTION_ENABLED
+  else process.env.MEMORY_COMPACTION_ENABLED = originalValues.compaction
+
+  if (originalValues.consolidation === undefined) delete process.env.MEMORY_CONSOLIDATION_ENABLED
+  else process.env.MEMORY_CONSOLIDATION_ENABLED = originalValues.consolidation
+
+  if (originalValues.procedural === undefined) delete process.env.MEMORY_PROCEDURAL_ENABLED
+  else process.env.MEMORY_PROCEDURAL_ENABLED = originalValues.procedural
+
+  if (originalValues.openclaw === undefined) delete process.env.MEMORY_OPENCLAW_FILE_MODE_ENABLED
+  else process.env.MEMORY_OPENCLAW_FILE_MODE_ENABLED = originalValues.openclaw
+}
+
+describe("memory lifecycle feature flags", () => {
+  beforeEach(() => {
+    delete process.env.MEMORY_SESSION_ENABLED
+    delete process.env.MEMORY_COMPACTION_ENABLED
+    delete process.env.MEMORY_CONSOLIDATION_ENABLED
+    delete process.env.MEMORY_PROCEDURAL_ENABLED
+    delete process.env.MEMORY_OPENCLAW_FILE_MODE_ENABLED
+  })
+
+  afterEach(() => {
+    restoreEnv()
+  })
+
+  it("uses default-on flags for session, compaction, consolidation, and procedural features", () => {
+    expect(isMemorySessionEnabled()).toBe(true)
+    expect(isMemoryCompactionEnabled()).toBe(true)
+    expect(isMemoryConsolidationEnabled()).toBe(true)
+    expect(isMemoryProceduralEnabled()).toBe(true)
+    expect(isMemoryOpenClawFileModeEnabled()).toBe(false)
+  })
+
+  it("supports explicit opt-out toggles", () => {
+    process.env.MEMORY_SESSION_ENABLED = "false"
+    process.env.MEMORY_COMPACTION_ENABLED = "0"
+    process.env.MEMORY_CONSOLIDATION_ENABLED = "off"
+    process.env.MEMORY_PROCEDURAL_ENABLED = "no"
+    process.env.MEMORY_OPENCLAW_FILE_MODE_ENABLED = "1"
+
+    expect(isMemorySessionEnabled()).toBe(false)
+    expect(isMemoryCompactionEnabled()).toBe(false)
+    expect(isMemoryConsolidationEnabled()).toBe(false)
+    expect(isMemoryProceduralEnabled()).toBe(false)
+    expect(isMemoryOpenClawFileModeEnabled()).toBe(true)
+  })
+})

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -273,6 +273,26 @@ export const MCP_MAX_CONNECTIONS_PER_KEY = parsePositiveInt(process.env.MCP_MAX_
 export const MCP_MAX_CONNECTIONS_PER_IP = parsePositiveInt(process.env.MCP_MAX_CONNECTIONS_PER_IP, 20)
 export const MCP_SESSION_IDLE_MS = parsePositiveInt(process.env.MCP_SESSION_IDLE_MS, 15 * 60 * 1000)
 
+export function isMemorySessionEnabled(): boolean {
+  return parseBooleanFlag(process.env.MEMORY_SESSION_ENABLED, true)
+}
+
+export function isMemoryCompactionEnabled(): boolean {
+  return parseBooleanFlag(process.env.MEMORY_COMPACTION_ENABLED, true)
+}
+
+export function isMemoryConsolidationEnabled(): boolean {
+  return parseBooleanFlag(process.env.MEMORY_CONSOLIDATION_ENABLED, true)
+}
+
+export function isMemoryProceduralEnabled(): boolean {
+  return parseBooleanFlag(process.env.MEMORY_PROCEDURAL_ENABLED, true)
+}
+
+export function isMemoryOpenClawFileModeEnabled(): boolean {
+  return parseBooleanFlag(process.env.MEMORY_OPENCLAW_FILE_MODE_ENABLED, false)
+}
+
 // ── Graph Features ───────────────────────────────────────────────────
 
 export const GRAPH_MAPPING_ENABLED = parseBooleanFlag(process.env.GRAPH_MAPPING_ENABLED, false)

--- a/reports/agent-memory-lifecycle-spec.md
+++ b/reports/agent-memory-lifecycle-spec.md
@@ -311,7 +311,7 @@ Write triggers:
 - [x] Spec merged: `reports/agent-memory-lifecycle-spec.md` (PR #287, 2026-02-26)
 - [x] PR-1.1 `feat(cli): add memory_layer + expiry schema parity` (merged: #288, 2026-02-26)
 - [x] PR-1.2 `feat(cli/mcp): layer-aware add/list/search/recall and context modes` (merged: #290, 2026-02-26)
-- [ ] PR-1.3 `test/docs: parity matrix tests and migration notes` (open: #291, auto-merge enabled)
+- [x] PR-1.3 `test/docs: parity matrix tests and migration notes` (merged: #291, 2026-02-26)
 - [x] PR-2.1 `feat(schema): memory_sessions + events + snapshots` (merged: #292, 2026-02-26)
 - [x] PR-2.2 `feat(cli/mcp): session commands and session tools` (merged: #293, 2026-02-26)
 - [x] PR-2.3 `feat(sdk): /sessions/start|checkpoint|end|snapshot endpoints` (merged: #294, 2026-02-26)
@@ -324,9 +324,16 @@ Write triggers:
 - [x] PR-4.3 `feat(openclaw): DB↔file import/export sync and docs` (merged: #300, 2026-02-26)
 - [x] Phase 4 PRs (4.1-4.3)
 - [x] PR-5.1 `feat(schema): upsert_key + supersession fields + consolidation run table` (merged: #301, 2026-02-26)
-- [ ] PR-5.2 `feat(consolidation): candidate extraction, dedupe, overwrite policy, conflict links` (in progress)
-- [ ] Phase 5 PRs (5.1-5.3)
-- [ ] Phase 6 PRs (6.1-6.3)
+- [x] PR-5.2 `feat(consolidation): candidate extraction, dedupe, overwrite policy, conflict links` (merged: #302, 2026-02-26)
+- [x] PR-5.3 `feat(api/mcp/cli): consolidate endpoint/tool/command and review workflows` (merged: #303, 2026-02-26)
+- [x] Phase 5 PRs (5.1-5.3)
+- [x] PR-6.1 `feat(skill-files): procedural usage metadata and ranking hooks` (merged: #304, 2026-02-26)
+- [x] PR-6.2 `feat(retrieval): procedural-first ranking when intent matches workflows` (merged inside #304, 2026-02-26)
+- [x] PR-6.3 `feat(tooling): promote successful episodes to procedural memory` (merged: #305, 2026-02-26)
+- [x] Phase 6 PRs (6.1-6.3)
+- [x] PR-7.1 `feat(obs): lifecycle metrics, compaction loss metrics, contradiction trend metrics` (merged: #306, 2026-02-26)
+- [x] PR-7.2 `feat(eval): replay/eval harness for memory extraction and compaction quality` (merged: #307, 2026-02-26)
+- [ ] PR-7.3 `chore(rollout): default-on flags, deprecate legacy paths, finalize docs` (in progress: codex/phase7-3-rollout-default-on)
 - [ ] Phase 7 PRs (7.1-7.3)
 
 ## Phase Gates and Acceptance
@@ -369,6 +376,14 @@ Write triggers:
 3. `MEMORY_OPENCLAW_FILE_MODE_ENABLED`
 4. `MEMORY_CONSOLIDATION_ENABLED`
 5. `MEMORY_PROCEDURAL_ENABLED`
+
+Default rollout posture (Phase 7):
+
+1. `MEMORY_SESSION_ENABLED=true`
+2. `MEMORY_COMPACTION_ENABLED=true`
+3. `MEMORY_CONSOLIDATION_ENABLED=true`
+4. `MEMORY_PROCEDURAL_ENABLED=true`
+5. `MEMORY_OPENCLAW_FILE_MODE_ENABLED=false` (still opt-in by design)
 
 ## Risks and Mitigations
 


### PR DESCRIPTION
## Summary
- add default-on lifecycle feature flags in web env helpers and enforce them across session, consolidation, procedural, and memory observability/eval endpoints
- add deprecation handling for legacy retrieval strategy aliases (`baseline`, `hybrid_graph`) in `@memories.sh/core` with one-time warnings and opt-out env suppression
- finalize rollout documentation and tracker updates for Phase 7 (endpoint contract matrix, client guidance, changelog, delivery tracker)

## Validation
- pnpm -C packages/web test src/app/api/sdk/v1/sessions/__tests__/routes.test.ts src/app/api/sdk/v1/memories/__tests__/routes.test.ts src/app/api/sdk/v1/management/memory/observability/__tests__/route.test.ts src/app/api/sdk/v1/management/memory/eval/replay/__tests__/route.test.ts
- pnpm -C packages/web test src/lib/env-memory-flags.test.ts
- pnpm -C packages/web typecheck
- pnpm -C packages/core test src/__tests__/client-helpers.test.ts src/__tests__/client.test.ts
- pnpm -C packages/core typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new feature-flag gating that can change runtime behavior of multiple SDK endpoints (403s when disabled) and introduces new deprecation warning side effects in the core client; risk is mitigated by default-on behavior and added tests.
> 
> **Overview**
> **Adds rollout controls for memory lifecycle features and deprecates legacy retrieval strategy aliases.**
> 
> In `packages/web`, introduces default-on env flag helpers (`MEMORY_SESSION_ENABLED`, `MEMORY_COMPACTION_ENABLED`, `MEMORY_CONSOLIDATION_ENABLED`, `MEMORY_PROCEDURAL_ENABLED`, plus `MEMORY_OPENCLAW_FILE_MODE_ENABLED` default-off) and enforces them across sessions, `memories/consolidate`, `skills/files/promote`, and memory management observability/eval routes by returning typed `403` errors when disabled.
> 
> In `@memories.sh/core`, keeps accepting legacy strategies (`baseline`, `hybrid_graph`) but now emits a one-time `console.warn` per alias (suppressible via `MEMORIES_SUPPRESS_DEPRECATION_WARNINGS`) and marks `LegacyContextStrategy` as deprecated. Updates tests and docs (client + endpoint contract + changelog + lifecycle tracker) to reflect the new defaults, endpoints, and deprecation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 397f029a038bd15daf0ecdebdc687a37ae7f9a84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->