### PR TITLE
docs(rfc): mark phase 7 rollout as completed

### DIFF
--- a/reports/agent-memory-lifecycle-spec.md
+++ b/reports/agent-memory-lifecycle-spec.md
@@ -1,9 +1,9 @@
 # RFC: Agent Memory Lifecycle (Session + Long-Term + OpenClaw File Mode)
 
-- Status: Proposed
+- Status: Implemented
 - Authors: memories team
 - Created: 2026-02-26
-- Target release: phased rollout over 7 phases
+- Target release: phased rollout over 7 phases (completed 2026-02-26)
 
 ## Summary
 
@@ -333,8 +333,8 @@ Write triggers:
 - [x] Phase 6 PRs (6.1-6.3)
 - [x] PR-7.1 `feat(obs): lifecycle metrics, compaction loss metrics, contradiction trend metrics` (merged: #306, 2026-02-26)
 - [x] PR-7.2 `feat(eval): replay/eval harness for memory extraction and compaction quality` (merged: #307, 2026-02-26)
-- [ ] PR-7.3 `chore(rollout): default-on flags, deprecate legacy paths, finalize docs` (in progress: codex/phase7-3-rollout-default-on)
-- [ ] Phase 7 PRs (7.1-7.3)
+- [x] PR-7.3 `chore(rollout): default-on flags, deprecate legacy paths, finalize docs` (merged: #309, 2026-02-26)
+- [x] Phase 7 PRs (7.1-7.3)
 
 ## Phase Gates and Acceptance
 


### PR DESCRIPTION
## Summary
- mark Phase 7.3 as merged in the lifecycle tracker artifact
- mark Phase 7 checklist as complete
- mark RFC status/target release as implemented and completed date

## Validation
- docs-only tracker closeout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to the RFC tracker/status with no runtime or behavior changes.
> 
> **Overview**
> Marks the Agent Memory Lifecycle RFC (`reports/agent-memory-lifecycle-spec.md`) as **Implemented** and notes the target release as completed on 2026-02-26.
> 
> Updates the delivery tracker to show **Phase 7.3 merged** and the overall **Phase 7 checklist completed**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea9caa80638065a545086f7efd7c0bd5663695b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->