### PR TITLE
Fix team member login hydration and user-scoped memory counts

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
@@ -5,12 +5,16 @@ const {
   mockSupabaseFrom,
   mockAdminFrom,
   mockAdminListUsers,
+  mockAdminGetUserById,
+  mockTursoExecute,
   mockCheckRateLimit,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockSupabaseFrom: vi.fn(),
   mockAdminFrom: vi.fn(),
   mockAdminListUsers: vi.fn(),
+  mockAdminGetUserById: vi.fn(),
+  mockTursoExecute: vi.fn(),
   mockCheckRateLimit: vi.fn(),
 }))
 
@@ -29,8 +33,15 @@ vi.mock("@/lib/supabase/admin", () => ({
     auth: {
       admin: {
         listUsers: mockAdminListUsers,
+        getUserById: mockAdminGetUserById,
       },
     },
+  })),
+}))
+
+vi.mock("@libsql/client", () => ({
+  createClient: vi.fn(() => ({
+    execute: mockTursoExecute,
   })),
 }))
 
@@ -52,6 +63,11 @@ describe("/api/orgs/[orgId]/members", () => {
       },
       error: null,
     })
+    mockAdminGetUserById.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    })
+    mockTursoExecute.mockResolvedValue({ rows: [] })
   })
 
   it("returns 401 when unauthenticated", async () => {
@@ -281,6 +297,217 @@ describe("/api/orgs/[orgId]/members", () => {
     expect(body.members[0].last_login_at).toBe("2026-02-12T10:00:00.000Z")
     expect(body.members[0].memory_count).toBe(0)
     expect(body.members[0].user_memory_count).toBe(0)
+  })
+
+  it("falls back to getUserById when listUsers does not include member login data", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    mockAdminListUsers.mockResolvedValue({
+      data: {
+        users: [{ id: "other-user", last_sign_in_at: "2026-02-01T10:00:00.000Z" }],
+        total: 1,
+      },
+      error: null,
+    })
+    mockAdminGetUserById.mockResolvedValue({
+      data: {
+        user: {
+          id: "user-1",
+          user_metadata: { last_sign_in_at: "2026-02-14T09:30:00.000Z" },
+        },
+      },
+      error: null,
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === "role") {
+              const single = vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null })
+              const eqUser = vi.fn().mockReturnValue({ single })
+              const eqOrg = vi.fn().mockReturnValue({ eq: eqUser })
+              return { eq: eqOrg }
+            }
+
+            const order = vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: "member-1",
+                  user_id: "user-1",
+                  role: "owner",
+                  created_at: "2026-02-12T00:00:00.000Z",
+                },
+              ],
+              error: null,
+            })
+            const eqOrg = vi.fn().mockReturnValue({ order })
+            return { eq: eqOrg }
+          }),
+        }
+      }
+
+      if (table === "users") {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: "user-1",
+                  email: "charles@webrenew.io",
+                  name: "Charles Howard",
+                  avatar_url: null,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === "organizations") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { turso_db_url: null, turso_db_token: null },
+                error: null,
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), in: vi.fn(), single: vi.fn(), order: vi.fn() })),
+      }
+    })
+
+    const response = await GET(
+      new Request("https://example.com/api/orgs/org-1/members"),
+      { params: Promise.resolve({ orgId: "org-1" }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.members).toHaveLength(1)
+    expect(body.members[0].last_login_at).toBe("2026-02-14T09:30:00.000Z")
+    expect(mockAdminGetUserById).toHaveBeenCalledWith("user-1")
+  })
+
+  it("normalizes user ids when mapping user-scoped memory counts", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+    mockAdminListUsers.mockResolvedValue({
+      data: {
+        users: [
+          { id: "user-1", last_sign_in_at: "2026-02-12T10:00:00.000Z" },
+          { id: "user-2", last_sign_in_at: "2026-02-11T10:00:00.000Z" },
+        ],
+        total: 2,
+      },
+      error: null,
+    })
+
+    mockTursoExecute
+      .mockResolvedValueOnce({ rows: [{ count: 12 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { user_id: " user-1 ", count: 7 },
+          { user_id: "USER-2", count: 5 },
+        ],
+      })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === "role") {
+              const single = vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null })
+              const eqUser = vi.fn().mockReturnValue({ single })
+              const eqOrg = vi.fn().mockReturnValue({ eq: eqUser })
+              return { eq: eqOrg }
+            }
+
+            const order = vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: "member-1",
+                  user_id: "user-1",
+                  role: "owner",
+                  created_at: "2026-02-12T00:00:00.000Z",
+                },
+                {
+                  id: "member-2",
+                  user_id: "user-2",
+                  role: "member",
+                  created_at: "2026-02-13T00:00:00.000Z",
+                },
+              ],
+              error: null,
+            })
+            const eqOrg = vi.fn().mockReturnValue({ order })
+            return { eq: eqOrg }
+          }),
+        }
+      }
+
+      if (table === "users") {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: "user-1",
+                  email: "owner@webrenew.io",
+                  name: "Owner",
+                  avatar_url: null,
+                },
+                {
+                  id: "user-2",
+                  email: "member@webrenew.io",
+                  name: "Member",
+                  avatar_url: null,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === "organizations") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { turso_db_url: "libsql://workspace-db", turso_db_token: "token" },
+                error: null,
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), in: vi.fn(), single: vi.fn(), order: vi.fn() })),
+      }
+    })
+
+    const response = await GET(
+      new Request("https://example.com/api/orgs/org-1/members"),
+      { params: Promise.resolve({ orgId: "org-1" }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.members).toHaveLength(2)
+
+    const owner = body.members.find((member: { user: { id: string } }) => member.user.id === "user-1")
+    const member = body.members.find((row: { user: { id: string } }) => row.user.id === "user-2")
+    expect(owner?.memory_count).toBe(12)
+    expect(owner?.user_memory_count).toBe(7)
+    expect(member?.memory_count).toBe(12)
+    expect(member?.user_memory_count).toBe(5)
+    expect(mockTursoExecute).toHaveBeenCalledTimes(2)
   })
 
   it("falls back when created_at is missing from org_members", async () => {


### PR DESCRIPTION
## Summary
- harden member last-login lookup by extracting timestamps from multiple auth payload fields and falling back to `getUserById` for unresolved IDs
- normalize Turso `memories.user_id` values when aggregating per-member memory counts so mixed casing/whitespace still map correctly
- add route regression coverage for both behaviors

## Testing
- pnpm --filter web test -- "src/app/api/orgs/[orgId]/members/route.test.ts"

Related to #308

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the org members API response by changing how `last_login_at` and per-user memory counts are computed, including new fallback calls to Supabase Admin and revised Turso aggregation SQL. Risk is moderate due to potential performance/edge-case impacts from additional lookups and normalization logic.
> 
> **Overview**
> **Improves member login hydration in `/api/orgs/[orgId]/members`.** `listUsers` results are now normalized by user id and `last_login_at` is extracted from multiple auth payload fields; any members not found in paged `listUsers` now fall back to `admin.getUserById` instead of defaulting to null.
> 
> **Fixes per-member memory counts from Turso.** The Turso aggregation query now trims/lowercases `memories.user_id` (and ignores blank IDs) and member mapping uses the same normalization so casing/whitespace mismatches don’t drop `user_memory_count`. Adds regression tests covering the `getUserById` fallback and user-id normalization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9b6be64a359231c65410b6cf95dbff23cda58ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->