### PR TITLE
Team members: pagination/search/bulk actions and avatar fallback

### DIFF
--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -30,6 +30,10 @@ const imageRemotePatterns = [
   },
   {
     protocol: "https",
+    hostname: "www.gravatar.com",
+  },
+  {
+    protocol: "https",
     hostname: "*.googleusercontent.com",
   },
 ];

--- a/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
@@ -294,6 +294,7 @@ describe("/api/orgs/[orgId]/members", () => {
     expect(body.members).toHaveLength(1)
     expect(body.members[0].role).toBe("owner")
     expect(body.members[0].user.email).toBe("charles@webrenew.io")
+    expect(body.members[0].user.avatar_url).toContain("gravatar.com/avatar/")
     expect(body.members[0].last_login_at).toBe("2026-02-12T10:00:00.000Z")
     expect(body.members[0].memory_count).toBe(0)
     expect(body.members[0].user_memory_count).toBe(0)


### PR DESCRIPTION
## Summary
- add member table search and role filtering controls
- add client-side pagination for large teams (10 rows/page)
- add bulk member actions (bulk role update for owners, bulk remove for admins/owners) with per-item error handling
- add Gravatar fallback avatar generation in members API and allow `www.gravatar.com` in Next image config

## Testing
- pnpm --filter web exec eslint "src/app/app/team/team-content.tsx" "src/app/api/orgs/[orgId]/members/route.ts" "src/app/api/orgs/[orgId]/members/route.test.ts"
- pnpm --filter web typecheck
- pnpm --filter web test -- "src/app/api/orgs/[orgId]/members/route.test.ts" "src/app/app/team/team-helpers.test.ts"

Closes #308

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: significant UI state/interaction changes in the team members table plus a behavioral change in the members API that now always returns an `avatar_url` (Gravatar fallback), which could affect downstream consumers and image loading.
> 
> **Overview**
> Improves the Team members table with **client-side search, role filtering, and pagination (10 per page)**, plus **bulk selection/actions** (owners can bulk change roles; admins/owners can bulk remove) with in-flight disabling and consolidated success/error messaging.
> 
> Updates `GET /api/orgs/[orgId]/members` to **generate a Gravatar `avatar_url` fallback** when missing/blank (and adjusts the route test accordingly), and allows Next/Image to load avatars from `www.gravatar.com` via `next.config.mjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab63abbc5c8bc82d21a612a81be6e4c3352f4e4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->