### PR TITLE
docs(sdk): add lifecycle workflow examples

### DIFF
--- a/packages/web/content/docs/sdk/client.mdx
+++ b/packages/web/content/docs/sdk/client.mdx
@@ -95,6 +95,87 @@ Legacy signature remains supported:
 await client.context.get("auth", { projectId: "github.com/acme/platform", limit: 20 })
 ```
 
+### Session Lifecycle Pattern
+
+`MemoriesClient` exposes session-aware retrieval fields on `context.get()`, but session lifecycle writes are currently HTTP endpoint calls (`/api/sdk/v1/sessions/*`).
+
+```typescript
+import { MemoriesClient } from "@memories.sh/core"
+
+const apiKey = process.env.MEMORIES_API_KEY!
+const baseUrl = "https://memories.sh"
+const scope = {
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "github.com/acme/platform",
+}
+
+const client = new MemoriesClient({
+  apiKey,
+  tenantId: scope.tenantId,
+  userId: scope.userId,
+})
+
+async function sdkPost(path: string, body: Record<string, unknown>) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`SDK request failed: ${res.status}`)
+  return res.json()
+}
+
+async function sdkGet(path: string) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!res.ok) throw new Error(`SDK request failed: ${res.status}`)
+  return res.json()
+}
+
+const started = await sdkPost("/api/sdk/v1/sessions/start", {
+  title: "Investigate checkout timeout",
+  client: "my-agent",
+  scope,
+})
+const sessionId = started.data.sessionId as string
+
+const ctx = await client.context.get({
+  query: "checkout timeout investigation",
+  projectId: scope.projectId,
+  sessionId,
+  budgetTokens: 6000,
+  turnCount: 3,
+  turnBudget: 24,
+  lastActivityAt: new Date().toISOString(),
+  inactivityThresholdMinutes: 45,
+})
+
+await sdkPost("/api/sdk/v1/sessions/checkpoint", {
+  sessionId,
+  content: `Recalled ${ctx.memories.length} memories`,
+  kind: "summary",
+  scope,
+})
+
+await sdkPost("/api/sdk/v1/sessions/end", {
+  sessionId,
+  status: "closed",
+  scope,
+})
+
+// Optional: read latest snapshot if one was created by lifecycle hooks
+const snapshot = await sdkGet(
+  `/api/sdk/v1/sessions/${sessionId}/snapshot?tenantId=${scope.tenantId}&userId=${scope.userId}&projectId=${encodeURIComponent(scope.projectId)}`
+)
+```
+
+If you require explicit snapshot creation in this flow, create it via local CLI/MCP (`memories session snapshot` or `snapshot_session`) and then read it through the SDK endpoint above.
+
 ### Hybrid Retrieval Usage
 
 Enable graph-augmented recall per request:
@@ -222,6 +303,32 @@ const result = await client.memories.vacuum()
 console.log(result.purged) // number of permanently removed records
 ```
 
+### Consolidation Run (HTTP Endpoint)
+
+Consolidation currently runs through the SDK endpoint (`/api/sdk/v1/memories/consolidate`).
+
+```typescript
+const consolidate = await fetch("https://memories.sh/api/sdk/v1/memories/consolidate", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.MEMORIES_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    types: ["rule", "decision", "fact"],
+    dryRun: true,
+    scope: {
+      tenantId: "acme-prod",
+      userId: "user_123",
+      projectId: "github.com/acme/platform",
+    },
+  }),
+})
+
+const consolidateJson = await consolidate.json()
+console.log(consolidateJson.data.runId, consolidateJson.data.run)
+```
+
 ### `client.buildSystemPrompt(context)`
 
 Format rules and memories into a system prompt block.
@@ -345,6 +452,18 @@ const skillFiles = await client.skills.listFiles({
 
 await client.skills.deleteFile({
   path: ".agents/skills/review/SKILL.md",
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "github.com/acme/platform",
+})
+
+await client.skills.promoteFromSession({
+  sessionId: "sess_abc123",
+  snapshotId: "snap_987", // optional; latest snapshot is used when omitted
+  path: ".agents/skills/incident-response/SKILL.md",
+  title: "Incident response procedure",
+  procedureKey: "incident-response-v1",
+  maxSteps: 8,
   tenantId: "acme-prod",
   userId: "user_123",
   projectId: "github.com/acme/platform",

--- a/packages/web/content/docs/sdk/index.mdx
+++ b/packages/web/content/docs/sdk/index.mdx
@@ -122,6 +122,80 @@ const response = await anthropic.messages.create({
 })
 ```
 
+## Lifecycle Workflow (Session + Consolidation)
+
+`MemoriesClient` already supports budget/session-aware retrieval through `context.get()`. Session lifecycle write endpoints (`/sessions/*`) and consolidation (`/memories/consolidate`) are currently called through SDK HTTP routes.
+
+```typescript
+import { MemoriesClient } from "@memories.sh/core"
+
+const apiKey = process.env.MEMORIES_API_KEY!
+const baseUrl = "https://memories.sh"
+const scope = {
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "github.com/acme/platform",
+}
+
+const client = new MemoriesClient({
+  apiKey,
+  tenantId: scope.tenantId,
+  userId: scope.userId,
+})
+
+async function sdkPost(path: string, body: Record<string, unknown>) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`SDK request failed: ${res.status}`)
+  return res.json()
+}
+
+const started = await sdkPost("/api/sdk/v1/sessions/start", {
+  title: "Checkout timeout investigation",
+  client: "my-agent",
+  scope,
+})
+const sessionId = started.data.sessionId as string
+
+const context = await client.context.get({
+  query: "Find likely timeout root causes",
+  projectId: scope.projectId,
+  sessionId,
+  budgetTokens: 6000,
+  turnCount: 4,
+  turnBudget: 24,
+  lastActivityAt: new Date().toISOString(),
+  inactivityThresholdMinutes: 45,
+})
+
+await sdkPost("/api/sdk/v1/sessions/checkpoint", {
+  sessionId,
+  content: `Captured ${context.memories.length} relevant memories`,
+  kind: "summary",
+  scope,
+})
+
+await sdkPost("/api/sdk/v1/memories/consolidate", {
+  types: ["rule", "decision", "fact"],
+  dryRun: true,
+  scope,
+})
+
+await sdkPost("/api/sdk/v1/sessions/end", {
+  sessionId,
+  status: "closed",
+  scope,
+})
+```
+
+If you need explicit raw snapshot creation in the same flow, use local CLI/MCP lifecycle tools (`memories session snapshot` or `snapshot_session`) and then consume `/api/sdk/v1/sessions/{sessionId}/snapshot`.
+
 ## Management APIs (Copy-Paste)
 
 ### `MemoriesClient.management.*`

--- a/packages/web/content/docs/sdk/tools.mdx
+++ b/packages/web/content/docs/sdk/tools.mdx
@@ -5,6 +5,8 @@ description: memoriesTools() gives LLMs direct access to read and write memory.
 
 For agent loops where the LLM should actively manage its own memory, use `memoriesTools()`. This gives the model tools to get context, store memories, search, edit, list, and forget.
 
+`memoriesTools()` currently focuses on memory + skill-file CRUD. Session lifecycle endpoints (`/sessions/*`) and consolidation (`/memories/consolidate`) are called directly via SDK HTTP routes from your backend.
+
 ## Tool Bundle
 
 ```typescript
@@ -92,6 +94,22 @@ const { text } = await generateText({
 
 Fetches rules and relevant memories for a query. The primary "read" tool.
 
+You can pass lifecycle/compaction hints through the same tool input:
+
+```typescript
+const ctx = await getContext({ tenantId: "acme-prod" })({
+  query: "summarize checkout timeout findings",
+  projectId: "github.com/acme/platform",
+  sessionId: "sess_abc123",
+  budgetTokens: 6000,
+  turnCount: 5,
+  turnBudget: 24,
+  lastActivityAt: new Date().toISOString(),
+  inactivityThresholdMinutes: 45,
+  taskCompleted: false,
+})
+```
+
 ### `storeMemory(config?)`
 
 Stores a new memory. Accepts `content`, `type`, `tags`, and `paths`.
@@ -119,6 +137,60 @@ Bulk soft-delete memories matching filters. Accepts `types`, `tags`, `olderThanD
 ### `vacuumMemories(config?)`
 
 Permanently purge all soft-deleted memories to reclaim storage space.
+
+## Lifecycle Writes via SDK HTTP
+
+Use direct SDK endpoint calls for session lifecycle and consolidation flows:
+
+```typescript
+const apiKey = process.env.MEMORIES_API_KEY!
+const baseUrl = "https://memories.sh"
+const scope = {
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "github.com/acme/platform",
+}
+
+async function sdkPost(path: string, body: Record<string, unknown>) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`SDK request failed: ${res.status}`)
+  return res.json()
+}
+
+const started = await sdkPost("/api/sdk/v1/sessions/start", {
+  title: "Investigate timeout",
+  client: "agent-loop",
+  scope,
+})
+
+await sdkPost("/api/sdk/v1/sessions/checkpoint", {
+  sessionId: started.data.sessionId,
+  content: "Captured checkpoint from tool loop",
+  kind: "summary",
+  scope,
+})
+
+await sdkPost("/api/sdk/v1/memories/consolidate", {
+  types: ["rule", "decision", "fact"],
+  dryRun: true,
+  scope,
+})
+
+await sdkPost("/api/sdk/v1/sessions/end", {
+  sessionId: started.data.sessionId,
+  status: "closed",
+  scope,
+})
+```
+
+For explicit snapshot creation in local/dev agents, use CLI/MCP lifecycle tools (`memories session snapshot` or `snapshot_session`), then read snapshots through `/api/sdk/v1/sessions/{sessionId}/snapshot`.
 
 ## System Prompt Helper
 


### PR DESCRIPTION
Closes #317

## What changed
- Added end-to-end lifecycle workflow examples in SDK overview docs
- Updated core client docs with session-aware pattern + consolidation HTTP flow
- Updated tools docs to include session-aware `getContext` hints and lifecycle endpoint usage
- Clarified surface split: tool bundle/client APIs vs direct SDK lifecycle endpoints

## Validation
- `pnpm -C packages/web lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add examples and clarify which operations require direct SDK HTTP calls versus client/tool APIs.
> 
> **Overview**
> Adds end-to-end **session lifecycle + consolidation** workflow examples to the SDK docs, showing how to start/checkpoint/end sessions via `/api/sdk/v1/sessions/*`, run `/api/sdk/v1/memories/consolidate`, and optionally read `/sessions/{id}/snapshot`.
> 
> Updates the core client and tools references to highlight session-aware fields on `context.get()`/`getContext` (budget/turn/inactivity hints), and adds an example of `client.skills.promoteFromSession` to promote a skill file from a session snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 614da6261d6791f022e6b0af0027d12cdde0eeb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->