### PR TITLE
fix(team): hide empty bulk toolbar and remove audit log inner scroll

### DIFF
--- a/packages/web/src/app/app/team/team-content.tsx
+++ b/packages/web/src/app/app/team/team-content.tsx
@@ -1216,7 +1216,7 @@ export function TeamContent({
                     <p className="text-xs text-emerald-400">{memberActionSuccess}</p>
                   ) : null}
 
-                  {isAdmin ? (
+                  {isAdmin && (selectedManageableMemberIds.length > 0 || bulkActionInFlight) ? (
                     <div className="border border-border bg-muted/10 px-3 py-2.5 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                       <p className="text-xs text-muted-foreground">
                         {selectedManageableMemberIds.length} selected
@@ -1475,7 +1475,7 @@ export function TeamContent({
                   ) : auditEvents.length === 0 ? (
                     <div className="p-4 text-sm text-muted-foreground">No audit events yet.</div>
                   ) : (
-                    <div className="divide-y divide-border max-h-[420px] overflow-y-auto">
+                    <div className="divide-y divide-border">
                       {auditEvents.map((event) => {
                         const actorLabel =
                           event.actor?.name ||


### PR DESCRIPTION
## Summary\n- hide member bulk-action toolbar unless there are selected manageable members (or a bulk action is in progress)\n- remove Audit Log fixed-height inner scroller so the list uses page scroll\n\nCloses #328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts when the members bulk-action toolbar renders and removes the audit log’s fixed-height inner scroller, with no data or auth logic touched.
> 
> **Overview**
> Tightens the members bulk-action UI so the toolbar only appears for admins when there are *manageable* selected members (or while a bulk action is running), avoiding an empty toolbar state.
> 
> Updates the Audit Log list layout to remove the fixed `max-h`/`overflow-y-auto` inner scroll container so events flow with normal page scrolling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de0ce3868ce7e5b29d867b61a015cd7702d40b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->