### PR TITLE
fix(team): enforce stable members row alignment

### DIFF
--- a/packages/web/src/app/app/team/team-content.tsx
+++ b/packages/web/src/app/app/team/team-content.tsx
@@ -43,6 +43,8 @@ function roleIcon(role: string) {
 const MEMBER_PAGE_SIZE = 10
 const MEMBER_ROLE_FILTERS = ["all", "owner", "admin", "member"] as const
 type MemberRoleFilter = (typeof MEMBER_ROLE_FILTERS)[number]
+const MEMBER_DESKTOP_GRID_CLASS =
+  "md:grid-cols-[36px_minmax(0,2fr)_130px_220px_220px_170px]"
 
 export function TeamContent({ 
   organizations, 
@@ -1263,7 +1265,7 @@ export function TeamContent({
                     </div>
                   ) : null}
                 </div>
-                <div className="hidden md:grid md:grid-cols-[36px_minmax(0,2fr)_130px_220px_220px_auto] gap-3 px-4 py-2 border-b border-border text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+                <div className={`hidden md:grid ${MEMBER_DESKTOP_GRID_CLASS} gap-3 px-4 py-2 border-b border-border text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70`}>
                   <span className="flex items-center">
                     <input
                       type="checkbox"
@@ -1293,7 +1295,7 @@ export function TeamContent({
                       return (
                         <div
                           key={member.id}
-                          className="p-4 grid grid-cols-1 md:grid-cols-[36px_minmax(0,2fr)_130px_220px_220px_auto] gap-3 md:items-center"
+                          className={`p-4 grid grid-cols-1 ${MEMBER_DESKTOP_GRID_CLASS} gap-3 md:items-center`}
                         >
                           <div className="hidden md:flex items-center justify-center">
                             <input


### PR DESCRIPTION
## Summary\n- define one shared desktop grid template for Team members header + rows\n- replace content-sized final actions column with fixed width to prevent per-row drift\n\nCloses #330

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: updates CSS grid classes for the members table header/rows to prevent column drift, with no data or behavior changes.
> 
> **Overview**
> Introduces a shared `MEMBER_DESKTOP_GRID_CLASS` for the Team members list and applies it to both the desktop header and each member row.
> 
> The desktop grid template also changes the last (Actions) column from `auto` to a fixed width to keep action controls aligned consistently across rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 287f0598c77a0570dcfceeec90e9901e40c36f31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->