### PR TITLE
docs: add memory segmentation lifecycle concept docs

### DIFF
--- a/packages/web/content/docs/concepts/memory-segmentation.mdx
+++ b/packages/web/content/docs/concepts/memory-segmentation.mdx
@@ -1,0 +1,121 @@
+---
+title: Memory Segmentation
+description: How memories.sh separates session, semantic, episodic, and procedural memory so context survives resets and compaction.
+---
+
+<Callout>
+Memory segmentation is a second axis on top of [Memory Types](/docs/concepts/memory-types).
+Types describe the kind of memory (`rule`, `decision`, `fact`, `note`, `skill`).
+Segmentation describes where memory lives across the lifecycle (session, semantic, episodic, procedural).
+</Callout>
+
+## Why Segmentation Exists
+
+Agent context fails when all history is treated as one blob. memories.sh segments memory so each store has one job:
+
+- **Session memory** for active work
+- **Semantic memory** for durable truths
+- **Episodic memory** for chronological history
+- **Procedural memory** for repeatable workflows
+
+## The Segmented Stores
+
+### 1) Session Memory (working context)
+
+Use explicit sessions for long-running tasks:
+
+```bash
+memories session start --title "Auth refactor" --client codex
+memories session checkpoint <session-id> "User approved rollout plan"
+memories session status <session-id>
+```
+
+Session memory tracks active conversation state and supports checkpoints and snapshots before boundaries like reset or compaction.
+
+### 2) Long-term Semantic Memory (stable truths)
+
+Store durable facts, preferences, and rules in semantic memory:
+
+- CLI/local database memory records
+- OpenClaw `memory.md` for deterministic file-mode semantic context
+
+Semantic memory should stay concise and current. Use consolidation/edits to avoid contradictory duplicates.
+
+### 3) Long-term Episodic Memory (history)
+
+Store chronological events in append-friendly logs:
+
+- OpenClaw daily logs: `memory/daily/YYYY-MM-DD.md`
+- Session snapshots: `memory/snapshots/YYYY-MM-DD/<slug>.md`
+
+Episodic memory is where timeline and fidelity live. Use it when you need what happened, not just the final truth.
+
+### 4) Procedural Memory (how-to patterns)
+
+Procedural memory captures reusable workflows and successful operating patterns:
+
+- Skills and workflow artifacts
+- Retrieval signals for intent-matched workflow recall
+
+Use procedural memory for repeatable tasks like release checklists, incident response, or migration runbooks.
+
+## Compaction and Lifecycle Triggers
+
+Compaction is context compression with checkpoints to avoid losing important state.
+
+| Trigger | When it fires | Typical mechanism |
+|--------|----------------|-------------------|
+| Count-based | Token/turn budget is near limit | Session checkpoint + snapshot |
+| Time-based | Session inactive past threshold | `memories compact run` |
+| Event-based | Task boundary (`/new`, `/reset`, handoff) | Snapshot with explicit trigger |
+
+Examples:
+
+```bash
+memories compact run --inactivity-minutes 60
+memories session snapshot <session-id> --trigger auto_compaction
+memories session snapshot <session-id> --trigger reset
+```
+
+## OpenClaw File-Mode Flow
+
+Use deterministic file operations around session boundaries:
+
+```bash
+# 1) Read semantic + recent episodic context
+memories openclaw memory bootstrap
+
+# 2) Flush meaningful events before compaction/reset
+memories openclaw memory flush <session-id>
+
+# 3) Write DB snapshot + file snapshot
+memories openclaw memory snapshot <session-id> --trigger reset
+
+# 4) Keep DB and files aligned
+memories openclaw memory sync --direction both
+```
+
+## What Goes Where
+
+| Memory content | Best store | Why |
+|---------------|------------|-----|
+| Durable coding standards | Semantic (`rule`) | Must always be injected |
+| Stable project constraints | Semantic (`fact`/`decision`) | High-value truth over time |
+| Conversation milestones | Session checkpoints | Keeps active task coherent |
+| End-of-task transcript slice | Snapshot (episodic) | Preserves high-fidelity boundary state |
+| Daily work chronology | Daily logs (episodic) | Append-only timeline for recall |
+| Repeatable runbook/process | Procedural (skills/workflows) | Reuse successful patterns |
+
+## Anti-patterns
+
+- Storing full raw transcripts in semantic memory
+- Treating all memory as one flat list
+- Letting conflicting semantic entries stack without consolidation
+- Skipping pre-compaction/session-boundary checkpoints
+
+## Next Steps
+
+- [Memory Types](/docs/concepts/memory-types)
+- [memories session](/docs/cli/session)
+- [memories compact](/docs/cli/compact)
+- [openclaw memory](/docs/cli/openclaw-memory)

--- a/packages/web/content/docs/concepts/memory-types.mdx
+++ b/packages/web/content/docs/concepts/memory-types.mdx
@@ -5,6 +5,12 @@ description: Understanding the five memory types — rules, decisions, facts, no
 
 Every memory in memories.sh has a **type** that describes its purpose. The type affects how the memory is presented to AI agents and how it's prioritized in context.
 
+<Callout>
+Types answer "what kind of memory is this?" (`rule`, `decision`, `fact`, `note`, `skill`).
+For lifecycle segmentation (session vs semantic vs episodic vs procedural), see
+[Memory Segmentation](/docs/concepts/memory-segmentation).
+</Callout>
+
 ## Types
 
 ### Rule

--- a/packages/web/content/docs/concepts/meta.json
+++ b/packages/web/content/docs/concepts/meta.json
@@ -2,6 +2,7 @@
   "title": "Concepts",
   "pages": [
     "memory-types",
+    "memory-segmentation",
     "scopes",
     "project-detection",
     "generation-targets",

--- a/packages/web/content/docs/index.mdx
+++ b/packages/web/content/docs/index.mdx
@@ -87,6 +87,24 @@ memories search "how to handle user login" --semantic
 
 The semantic search model runs entirely locally — no API calls, no data leaves your machine.
 
+## Memory Segmentation Lifecycle
+
+memories.sh now separates memory by lifecycle role, not just type:
+
+- **Session memory** for active working context
+- **Semantic memory** for stable truths and preferences
+- **Episodic memory** for daily logs and raw snapshots
+- **Procedural memory** for reusable workflows
+
+This keeps context coherent across long tasks, reset boundaries, and compaction windows.
+
+Explore the lifecycle model:
+
+- [Memory Segmentation](/docs/concepts/memory-segmentation)
+- [memories session](/docs/cli/session)
+- [memories compact](/docs/cli/compact)
+- [openclaw memory](/docs/cli/openclaw-memory)
+
 ## Sync Config Files
 
 Beyond memories, sync your entire AI tool setup:
@@ -105,6 +123,7 @@ This syncs files from `.agents/`, `.claude/`, `.cursor/`, `.codex/`, and other t
 
 - [Getting Started](/docs/getting-started) — Full installation and setup guide
 - [Starter Apps Quickstart](/docs/starter-apps-quickstart) — Run add/search/context in under 10 minutes
+- [Memory Segmentation](/docs/concepts/memory-segmentation) — Session + long-term memory lifecycle
 - [CLI Reference](/docs/cli) — Complete command documentation
 - [MCP Server](/docs/mcp-server) — Fallback for real-time agent access
 - [Files Sync](/docs/cli/files) — Sync config files across machines

--- a/reports/memory-segmentation-marketing-plan.md
+++ b/reports/memory-segmentation-marketing-plan.md
@@ -1,0 +1,203 @@
+# Memory Segmentation Marketing Plan
+
+Date: 2026-02-28  
+Owner: Marketing + Product + Docs
+
+## Goal
+
+Update memories.sh positioning so it clearly reflects the memory lifecycle now implemented:
+
+- Session memory (active working context)
+- Long-term semantic memory (stable facts/rules/preferences)
+- Long-term episodic memory (daily logs + raw snapshots)
+- Procedural memory (reusable workflow memory via skills/ranking signals)
+- Compaction safety (write-ahead checkpoints before context loss)
+
+## What Is Already Implemented (source of truth for claims)
+
+1. Session lifecycle commands: `memories session start|checkpoint|status|end|snapshot`
+2. Inactivity compaction worker: `memories compact run`
+3. OpenClaw file-mode lifecycle:
+   - `memory.md` (semantic)
+   - `memory/daily/YYYY-MM-DD.md` (episodic append-only)
+   - `memory/snapshots/YYYY-MM-DD/<slug>.md` (raw snapshots)
+4. Lifecycle + compaction APIs and context hints in SDK/docs.
+5. Procedural memory signals and retrieval support (workflow-oriented ranking).
+
+## Messaging Problem to Fix
+
+Current copy still mostly describes:
+
+- Memory **types** (`rule`, `decision`, `fact`, `note`, `skill`)
+- Semantic recall and local-first storage
+
+But it does not clearly explain:
+
+- The **segmented architecture** (session + long-term + procedural)
+- How memories survive reset/compaction boundaries
+- Why this is better than naive transcript replay
+
+## Positioning Update (core narrative)
+
+Use this narrative consistently:
+
+> memories.sh is a segmented memory system for agents: short-term session memory plus long-term semantic, episodic, and procedural memory, with compaction-safe checkpoints and deterministic file mode for OpenClaw.
+
+## Message Pillars (with proof)
+
+### Pillar 1: Session Memory That Survives Long Tasks
+
+- Message: Keep active work coherent across long chats and compaction events.
+- Proof points:
+  - `memories session` lifecycle commands
+  - `memories compact run`
+  - Snapshot triggers (`new_session`, `reset`, `manual`, `auto_compaction`)
+
+### Pillar 2: Long-Term Memory Is Segmented, Not Blended
+
+- Message: Different memory jobs need different stores.
+- Proof points:
+  - Semantic memory (`memory.md`) for durable truths
+  - Episodic daily logs + snapshots for chronology and fidelity
+  - Consolidation/overwrite model in lifecycle RFC
+
+### Pillar 3: Procedural Memory Improves Repeated Work
+
+- Message: Successful workflows become retrievable operating patterns.
+- Proof points:
+  - Skill/procedural usage signals and retrieval hooks
+  - Workflow-oriented ranking behavior
+
+### Pillar 4: Deterministic File Mode for OpenClaw
+
+- Message: Human-readable, git-friendly memory continuity without vector infra complexity.
+- Proof points:
+  - `memories openclaw memory bootstrap|flush|snapshot|sync`
+  - fixed file contract (`memory.md`, daily logs, snapshots)
+
+## Copy Architecture Changes (by surface)
+
+### 1) Homepage (highest priority)
+
+Update:
+
+- Hero subheadline to mention segmented memory lifecycle.
+- Feature cards:
+  - Replace generic “Durable Local State” with “Segmented Memory Architecture”.
+  - Add “Compaction-Safe Checkpoints”.
+  - Add “Session + Long-Term + Procedural Retrieval”.
+- How It Works section:
+  - Add a segmentation explainer block with a 3-lane mental model.
+
+### 2) README + docs index (high priority)
+
+Update:
+
+- Add “Memory Segmentation” section near “Memory Types”.
+- Clarify two axes:
+  1. Purpose/type (`rule`, `decision`, `fact`, `note`, `skill`)
+  2. Lifecycle/store (session, semantic, episodic, procedural)
+- Add direct links to `session`, `compact`, and `openclaw memory` docs.
+
+### 3) Concepts docs (high priority)
+
+Add new concept page:
+
+- `docs/concepts/memory-segmentation` (name can vary, keep short)
+- Include:
+  - architecture diagram
+  - trigger table (count/time/event)
+  - “what gets written where” matrix
+  - anti-patterns (don’t dump full transcript into semantic memory)
+
+### 4) SDK + MCP docs (medium priority)
+
+Update:
+
+- Add one “lifecycle-aware integration” block:
+  - pass `sessionId`, budget/turn hints to context calls
+  - mention compaction checkpoint behavior
+- Add quick examples for session snapshot/compaction-related calls.
+
+### 5) OpenClaw integration page (medium priority)
+
+Update:
+
+- Reframe page around “deterministic segmented memory files”.
+- Show lifecycle sequence:
+  1. bootstrap
+  2. flush before compaction/reset
+  3. snapshot on boundary
+  4. sync
+
+## Launchable Copy Assets
+
+1. New homepage section: “How segmented memory works”
+2. One docs concept page with diagram + command examples
+3. README segment update
+4. One changelog/announcement entry:
+   - “Session + semantic/episodic/procedural lifecycle now first-class”
+
+## Claim Guardrails (avoid overstatement)
+
+Allowed:
+
+- “Compaction-safe checkpoints”
+- “Segmented memory lifecycle”
+- “Deterministic file mode for OpenClaw”
+
+Avoid unless separately validated:
+
+- Quantified success/performance uplift percentages
+- “No context loss ever” absolute claims
+- “Fully autonomous memory management” language
+
+## PR Sequence
+
+### PR-1: Messaging foundation docs
+
+- Add segmentation concept page
+- Update concepts nav/meta
+- Update docs index links
+
+### PR-2: README and docs cross-links
+
+- Add segmentation section to README
+- Add command cross-links (`session`, `compact`, `openclaw memory`)
+- Align terminology with concept page
+
+### PR-3: Homepage conversion copy update
+
+- Hero + feature cards + how-it-works copy refresh
+- Keep current visual system; copy-only changes first
+
+### PR-4: Integration pages refresh
+
+- SDK page lifecycle block
+- MCP page lifecycle hints block
+- OpenClaw page lifecycle sequence block
+
+### PR-5: Release narrative
+
+- Changelog entry + launch snippet for social/email/docs front page
+- Internal sales/demo blurb using same segmentation language
+
+## Acceptance Criteria
+
+1. A new visitor can explain session vs semantic vs episodic vs procedural after first scroll.
+2. README and docs no longer imply only one-dimensional “memory types.”
+3. All top surfaces use the same segmentation vocabulary.
+4. Every segmentation claim has a command/API/doc proof point.
+
+## Suggested Success Metrics (30 days)
+
+1. Higher CTR from homepage to lifecycle docs (`/docs/cli/session`, `/docs/cli/openclaw-memory`, new segmentation page).
+2. Higher completion of lifecycle commands among activated users.
+3. Reduced support questions around “how memory survives reset/compaction.”
+4. Increased conversion on OpenClaw integration page.
+
+## Draft Tagline Options
+
+1. “Segmented memory for agents: session, semantic, episodic, procedural.”
+2. “Stop replaying transcripts. Start using lifecycle memory.”
+3. “Compaction-safe memory continuity for real agent workflows.”


### PR DESCRIPTION
## Summary
- add new Concepts page for memory segmentation (session, semantic, episodic, procedural)
- add lifecycle/compaction trigger guidance with concrete command examples
- link segmentation from existing docs surfaces (Concepts nav, Memory Types, docs home)
- add tracked rollout artifact with phased messaging + PR sequence

## Validation
- pnpm -C packages/web lint

## Notes
- This executes PR-1 from the memory segmentation marketing plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that add new content and navigation links; no runtime code or APIs are modified.
> 
> **Overview**
> Adds a new **Memory Segmentation** concept doc describing the session/semantic/episodic/procedural lifecycle, with compaction triggers and CLI/OpenClaw flow examples.
> 
> Updates docs navigation and existing concept pages to cross-link segmentation vs type, and adds a new section on the docs index highlighting the lifecycle model and linking to related CLI docs. Also includes an internal `reports/memory-segmentation-marketing-plan.md` rollout artifact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9418267e4b636f9e5ddd4d4a5c7a378af01023e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->