### PR TITLE
docs: update README and quickstart for segmented memory lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ memories generate
 
 - **One store, every tool** — add a memory once, generate native configs for 8+ tools
 - **Local-first** — SQLite at `~/.config/memories/local.db`, works fully offline
+- **Segmented lifecycle memory** — separate session, semantic, episodic, and procedural memory for stronger continuity
 - **Path-scoped rules** — `--paths "src/api/**"` becomes `paths:` in Claude, `globs:` in Cursor
 - **Skills** — define reusable agent workflows following the [Agent Skills](https://agentskills.io) standard
 - **`.agents/` canonical directory** — tool-agnostic intermediate format, checked into git
@@ -105,6 +106,36 @@ memories add --fact "Deploy target is Vercel with Edge Functions"   # Concrete p
 memories add "Legacy API deprecated Q3 2026"                       # General notes (default)
 memories add --type skill "..." --category deploy                  # Reusable agent workflows
 ```
+
+## Memory Segmentation Lifecycle
+
+memories.sh uses two complementary axes:
+
+1. **Type**: `rule`, `decision`, `fact`, `note`, `skill` (what kind of memory it is)
+2. **Lifecycle segment**: session, semantic, episodic, procedural (where memory lives over time)
+
+Session and lifecycle commands:
+
+```bash
+# Explicit session lifecycle
+memories session start --title "Checkout refactor"
+memories session checkpoint <session-id> "Pre-compaction checkpoint"
+memories session snapshot <session-id> --trigger auto_compaction
+
+# Inactivity compaction worker
+memories compact run --inactivity-minutes 60
+
+# OpenClaw file-mode lifecycle (semantic + daily + snapshots)
+memories openclaw memory bootstrap
+memories openclaw memory flush <session-id>
+memories openclaw memory snapshot <session-id> --trigger reset
+```
+
+Learn more:
+- [Memory Segmentation](https://memories.sh/docs/concepts/memory-segmentation)
+- [memories session](https://memories.sh/docs/cli/session)
+- [memories compact](https://memories.sh/docs/cli/compact)
+- [openclaw memory](https://memories.sh/docs/cli/openclaw-memory)
 
 ## Generation Pipeline
 
@@ -184,6 +215,9 @@ Use `global: true` for user-wide memories (do not send both `global` and `projec
 | `memories search <query>` | Full-text search (`--semantic` for embeddings) |
 | `memories list` | List memories with optional filters |
 | `memories recall` | Get context-aware memories for the current project |
+| `memories session <subcommand>` | Manage explicit session lifecycle (`start`, `checkpoint`, `status`, `end`, `snapshot`) |
+| `memories compact run` | Run inactivity compaction worker for active sessions |
+| `memories openclaw memory <subcommand>` | Read/write OpenClaw semantic, daily, and snapshot files |
 | `memories generate [target]` | Generate native config files |
 | `memories ingest [source]` | Import from existing rule files |
 | `memories diff` | Compare generated output against existing files |

--- a/packages/web/content/docs/cli/index.mdx
+++ b/packages/web/content/docs/cli/index.mdx
@@ -5,6 +5,12 @@ description: Complete reference for all memories.sh CLI commands.
 
 The `memories` CLI is the primary interface for managing your AI agent memory store. All commands operate on a local SQLite database at `~/.config/memories/local.db`.
 
+<Callout>
+Command references on this page map to a segmented lifecycle model:
+session working memory + long-term semantic/episodic/procedural stores.
+See [Memory Segmentation](/docs/concepts/memory-segmentation).
+</Callout>
+
 ## Quick Reference
 
 ```bash

--- a/packages/web/content/docs/getting-started.mdx
+++ b/packages/web/content/docs/getting-started.mdx
@@ -195,6 +195,27 @@ To generate embeddings for existing memories:
 memories embed
 ```
 
+## Session Lifecycle + Compaction
+
+For longer-running agent tasks, use explicit sessions and compaction-aware checkpoints:
+
+```bash
+memories session start --title "Auth migration" --client codex
+memories session checkpoint <session-id> "Migration plan approved"
+memories session snapshot <session-id> --trigger auto_compaction
+memories compact run --inactivity-minutes 60
+```
+
+If you use OpenClaw file mode, pair session lifecycle with deterministic files:
+
+```bash
+memories openclaw memory bootstrap
+memories openclaw memory flush <session-id>
+memories openclaw memory snapshot <session-id> --trigger reset
+```
+
+See [Memory Segmentation](/docs/concepts/memory-segmentation) for the full model (`session`, `semantic`, `episodic`, `procedural`).
+
 ## MCP Server (Fallback)
 
 The primary workflow is `memories generate` — it writes native config files that each tool reads natively. For browser-based agents (v0, bolt.new, Lovable) or any MCP client where the CLI can't run, the built-in MCP server provides real-time access.
@@ -256,6 +277,7 @@ Queue API supports richer review filters:
 - [Starter Apps Quickstart](/docs/starter-apps-quickstart) — Next.js, Express, and Python templates
 - [CLI Reference](/docs/cli) — Complete command documentation
 - [Memory Types and Scopes](/docs/concepts/memory-types) — Understanding the type system
+- [Memory Segmentation](/docs/concepts/memory-segmentation) — Session + long-term lifecycle model
 - [MCP Server](/docs/mcp-server) — Fallback for real-time agent access
 - [Files Sync](/docs/cli/files) — Sync config files across machines
 - [Cloud Sync](/docs/cloud-sync) — Multi-device sync with Pro


### PR DESCRIPTION
## Summary
- add a dedicated README section for memory segmentation lifecycle
- add session/compaction/OpenClaw lifecycle command examples and docs links
- add lifecycle command rows in README CLI reference table
- add Getting Started lifecycle + compaction section with command examples
- add CLI reference callout linking command model to memory segmentation concepts

## Validation
- pnpm -C packages/web lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Adds documentation for the **segmented memory lifecycle** model (session + semantic/episodic/procedural) across the README and web docs.
> 
> The README now includes a dedicated lifecycle section with `memories session`, `compact run`, and `openclaw memory` example flows, plus links to the new/related docs, and the CLI table lists these lifecycle commands.
> 
> Web docs add a CLI reference callout tying command semantics to memory segmentation, and the Getting Started guide adds a session/compaction section and links to the segmentation concept page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0060eb5f19363b67fbbb7da7cd0741767d0e1de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->