### PR TITLE
web: refresh homepage copy around segmented memory lifecycle

### DIFF
--- a/packages/web/src/components/FeaturesGrid.tsx
+++ b/packages/web/src/components/FeaturesGrid.tsx
@@ -40,22 +40,22 @@ const FeatureIcon = ({ index }: { index: number }) => {
 export function FeaturesGrid(): React.JSX.Element {
   const features = [
     {
-      title: "Durable Local State",
-      detail: "Rules and context live in a local SQLite store with embeddings, so agent state persists even offline.",
-      metric: "Always available",
-      docsUrl: "/docs/concepts/memory-types"
+      title: "Segmented Memory Architecture",
+      detail: "Separate session working context from long-term semantic, episodic, and procedural memory so agents stop mixing timelines with durable truths.",
+      metric: "4 memory lanes",
+      docsUrl: "/docs/concepts/memory-segmentation"
     },
     {
-      title: "Semantic Recall",
-      detail: "Search by meaning, not just keywords. Query 'auth issues' and find JWT validation rules, session handling, and OAuth flows.",
-      metric: "768-dim vectors",
+      title: "Compaction-Safe Checkpoints",
+      detail: "Write checkpoints and snapshots before context boundaries so important state survives reset, inactivity, and token pressure.",
+      metric: "Boundary-safe",
+      docsUrl: "/docs/cli/session"
+    },
+    {
+      title: "Session + Long-Term Recall",
+      detail: "Recall merges always-on rules with relevant session and long-term memories, so answers stay consistent across long tasks.",
+      metric: "Layered context",
       docsUrl: "/docs/cli/recall"
-    },
-    {
-      title: "Local Embeddings",
-      detail: "Runs a 100MB embedding model (gte-base) entirely on your CPU via ONNX. No API calls, no data leaves your machine.",
-      metric: "100% private",
-      docsUrl: "/docs/cli/embed"
     },
     {
       title: "Tool-Native Output",
@@ -64,10 +64,10 @@ export function FeaturesGrid(): React.JSX.Element {
       docsUrl: "/docs/cli/generate"
     },
     {
-      title: "Scoped Memory",
-      detail: "CLI uses global + git project scopes with path rules. SDK uses tenantId as the security/database boundary, userId as end-user scope, and projectId as an optional repo filter.",
-      metric: "Right context",
-      docsUrl: "/docs/concepts/scopes"
+      title: "Deterministic OpenClaw File Mode",
+      detail: "Run bootstrap, flush, and snapshot against memory.md, daily logs, and raw snapshots for git-friendly lifecycle continuity.",
+      metric: "bootstrap/flush/snapshot",
+      docsUrl: "/docs/cli/openclaw-memory"
     },
     {
       title: "Portable State",
@@ -100,10 +100,10 @@ export function FeaturesGrid(): React.JSX.Element {
               <span className="font-mono text-[12px] leading-[100%] tracking-[-0.015rem] uppercase text-muted-foreground">Core Features</span>
             </div>
             <h2 className="font-mono font-normal text-2xl sm:text-4xl text-foreground">
-              <ScrambleText text="Built for durable state" delayMs={200} />
+              <ScrambleText text="Built for segmented memory" delayMs={200} />
             </h2>
             <p className="mt-6 text-base sm:text-lg text-muted-foreground max-w-2xl leading-relaxed">
-              Everything you need to make agent context persist—locally by default, synced when you choose.
+              Lifecycle-aware memory for real agent work: session continuity, compaction safety, and long-term retrieval that stays coherent.
             </p>
           </div>
   

--- a/packages/web/src/components/Hero.tsx
+++ b/packages/web/src/components/Hero.tsx
@@ -191,7 +191,7 @@ export function Hero(): React.JSX.Element {
             </motion.h1>
 
             <motion.p variants={itemVariants} className="text-lg md:text-xl text-muted-foreground mb-8 max-w-xl leading-relaxed font-light">
-              Durable state for coding agents and a TypeScript SDK for AI apps. Store rules, recall context, and wire memory into any LLM—local-first, sync when you need it.
+              Segment agent memory by lifecycle: session context, semantic truths, episodic logs, and procedural workflows. Recall what matters and generate native configs for every tool.
             </motion.p>
 
             <CopyCommand />
@@ -241,12 +241,12 @@ export function Hero(): React.JSX.Element {
                     Recent Context
                   </div>
                   {[
-                    "Use Tailwind for all UI components",
-                    "Prefer zod over joi for validation",
-                    "Keep auth logic in /lib/auth.ts",
+                    { text: "Use Tailwind for all UI components", lane: "Semantic" },
+                    { text: "Checkpoint saved before auto compaction", lane: "Episodic" },
+                    { text: "Release checklist skill promoted after successful runs", lane: "Procedural" },
                   ].map((item, index) => (
                     <motion.div 
-                      key={item} 
+                      key={item.text}
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ 
@@ -256,15 +256,15 @@ export function Hero(): React.JSX.Element {
                       }}
                       className="flex items-center justify-between gap-4 rounded-md border border-border bg-foreground/5 px-3 py-2 text-xs text-foreground/80"
                     >
-                      <span>{item}</span>
-                      <span className="text-[10px] uppercase tracking-[0.2em] text-accent-secondary">Stored</span>
+                      <span>{item.text}</span>
+                      <span className="text-[10px] uppercase tracking-[0.2em] text-accent-secondary">{item.lane}</span>
                     </motion.div>
                   ))}
                 </div>
 
                 <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.25em] font-bold text-muted-foreground">
                   <span className="h-1 w-1 rounded-full bg-accent-secondary" />
-                  Recall and generate configs in one command
+                  Segment, recall, and generate in one flow
                 </div>
               </div>
             </motion.div>

--- a/packages/web/src/components/HowItWorks.tsx
+++ b/packages/web/src/components/HowItWorks.tsx
@@ -12,12 +12,12 @@ const cliSteps = [
   {
     cmd: "memories add",
     arg: '"prefer functional components"',
-    note: "Stored to local SQLite database",
+    note: "Stored in local semantic memory",
   },
   {
     cmd: "memories recall",
     arg: '"auth flow"',
-    note: "3 memories matched by semantic similarity",
+    note: "Layered recall: rules + session + long-term matches",
   },
   {
     cmd: "memories generate",
@@ -35,7 +35,7 @@ const mcpSteps = [
   {
     tool: "get_context",
     params: '{ query: "auth flow" }',
-    note: "FTS5-ranked rules + relevant memories",
+    note: "Returns layered context with session and long-term memory",
   },
   {
     tool: "get_rules",
@@ -56,6 +56,21 @@ const sdkCodeLines: SyntaxLine[] = [
   { tokens: [{ text: "// Rules + memories auto-injected into every prompt", style: "comment" }] },
 ];
 
+const memoryLanes = [
+  {
+    title: "Session",
+    detail: "Active working context with checkpoints and boundary snapshots.",
+  },
+  {
+    title: "Long-term",
+    detail: "Semantic truths plus episodic daily logs and raw snapshots.",
+  },
+  {
+    title: "Procedural",
+    detail: "Reusable workflows recalled when task intent matches.",
+  },
+];
+
 // ── Component ───────────────────────────────────────────────────────────────
 
 export function HowItWorks(): React.JSX.Element {
@@ -73,20 +88,20 @@ export function HowItWorks(): React.JSX.Element {
   const tabContent = {
     cli: {
       heading: "Three commands. That's it.",
-      description: "Store context, recall it anywhere, and generate configs for any tool—all from your terminal.",
+      description: "Capture session checkpoints, recall layered context, and generate native configs for every agent tool from one CLI.",
       cardTitle: "Store, recall, generate",
-      cardDescription: "Local SQLite database. Works offline. Syncs when you want it to.",
+      cardDescription: "Session lifecycle + long-term semantic, episodic, and procedural memory in local SQLite.",
     },
     mcp: {
       heading: "MCP when you need it.",
-      description: "For browser-based agents like v0, bolt.new, and Lovable—or any MCP client that can't run the CLI—7 tools with FTS5 search give full access to your memory store.",
+      description: "For browser-based agents like v0, bolt.new, and Lovable—or any MCP client that can't run the CLI—7 tools expose the same segmented memory lifecycle.",
       cardTitle: "Direct agent fallback",
-      cardDescription: "Same 7 tools as CLI. FTS5 search, path-scoped rules, skills, and full field support.",
+      cardDescription: "Same 7 tools as CLI: layered recall, lifecycle sessions, and path-scoped memory operations.",
       endpoint: "https://memories.sh/api/mcp",
     },
     sdk: {
       heading: "Two lines. Memory everywhere.",
-      description: <>Wrap any model with <code className="font-mono text-[0.9em] text-foreground/80 bg-muted px-1.5 py-0.5 rounded">memoriesMiddleware()</code>. Rules and context auto-inject into every prompt—no tool calls, no prompt engineering.</>,
+      description: <>Wrap any model with <code className="font-mono text-[0.9em] text-foreground/80 bg-muted px-1.5 py-0.5 rounded">memoriesMiddleware()</code>. Segmented context auto-injects into prompts—session state, durable truths, and relevant workflows.</>,
       cardTitle: "AI SDK middleware",
       cardDescription: <><code className="font-mono text-[0.9em] text-foreground/80 bg-muted px-1.5 py-0.5 rounded">@memories.sh/ai-sdk</code> — composable middleware for the Vercel AI SDK. Stack with logging, guardrails, caching.</>,
     },
@@ -221,6 +236,25 @@ export function HowItWorks(): React.JSX.Element {
               <p className="text-base sm:text-lg text-muted-foreground max-w-md leading-relaxed">
                 {tabContent[activeTab].description}
               </p>
+
+              <div className="mt-7 w-full max-w-xl rounded-xl border border-border bg-card/40 p-4 sm:p-5">
+                <div className="mb-3 flex items-center gap-2">
+                  <div className="h-1.5 w-1.5 rounded-full bg-primary/80" />
+                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Segmented Lifecycle
+                  </span>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  {memoryLanes.map((lane) => (
+                    <div key={lane.title} className="rounded-lg border border-border bg-background/40 p-3">
+                      <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-foreground mb-1">
+                        {lane.title}
+                      </div>
+                      <p className="text-xs leading-relaxed text-muted-foreground">{lane.detail}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </motion.div>
 
             {/* Spacer to push card down */}


### PR DESCRIPTION
## Summary
- update hero messaging to explicitly describe session/semantic/episodic/procedural segmentation
- refresh feature cards to highlight segmented architecture, compaction-safe checkpoints, layered recall, and OpenClaw lifecycle flow
- add a dedicated "Segmented Lifecycle" explainer block in How It Works
- align CLI/MCP/SDK tab copy and terminal notes with lifecycle vocabulary

## Validation
- pnpm -C packages/web lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to homepage UI copy/content and small presentational data-structure tweaks, with no impact on backend logic or data handling.
> 
> **Overview**
> Updates homepage messaging to center on **segmented, lifecycle-aware memory** (session/semantic/episodic/procedural), replacing prior “durable local state” framing in `Hero` and `FeaturesGrid`.
> 
> Refreshes the feature cards and docs links to highlight segmentation, compaction-safe checkpoints, layered recall, and OpenClaw file-mode; aligns `HowItWorks` CLI/MCP/SDK copy and terminal notes with this vocabulary and adds a new **“Segmented Lifecycle”** explainer block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bec4d3693dc8f37df1a66ae9f76b6aad59628edd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->