### PR TITLE
docs: add lifecycle-aware integration flows for sdk, mcp, and openclaw

### DIFF
--- a/packages/web/content/docs/integrations/openclaw.mdx
+++ b/packages/web/content/docs/integrations/openclaw.mdx
@@ -93,18 +93,29 @@ memories reminders add "0 9 * * 1-5" "OpenClaw refresh: run generate + skills co
 memories openclaw memory sync --direction both
 ```
 
-Useful focused operations:
+### Deterministic lifecycle sequence (recommended)
+
+Use this order around session boundaries:
 
 ```bash
-# Read semantic + recent episodic bootstrap context
+# 1) Read semantic + recent episodic bootstrap context
 memories openclaw memory bootstrap
 
-# Flush recent meaningful session events to today's daily log
+# 2) Flush recent meaningful session events to today's daily log
 memories openclaw memory flush <session-id>
 
-# Write a raw snapshot file from session events
+# 3) Write a raw snapshot file from session events
 memories openclaw memory snapshot <session-id> --trigger reset
+
+# 4) Keep DB rows and files aligned
+memories openclaw memory sync --direction both
 ```
+
+Trigger guidance:
+
+- Near compaction or inactivity thresholds: run `flush`
+- On `/new`, `/reset`, or handoff boundaries: run `snapshot --trigger new_session|reset|manual|auto_compaction`
+- Run `sync` after lifecycle writes when multiple devices/workspaces may read the same memory files
 
 ## Important Notes
 

--- a/packages/web/content/docs/mcp-server/index.mdx
+++ b/packages/web/content/docs/mcp-server/index.mdx
@@ -82,3 +82,15 @@ The MCP server exposes:
 - **3 resources** — for accessing rules, recent memories, and project-specific data
 
 See the [Tools Reference](/docs/mcp-server/tools-reference), [Resources Reference](/docs/mcp-server/resources-reference), and [Tenant Routing](/docs/mcp-server/tenant-routing) for complete documentation.
+
+## Lifecycle-Aware MCP Pattern
+
+For long sessions, treat MCP reads/writes as a lifecycle sequence instead of one-off calls:
+
+1. `start_session` (local CLI MCP) to open a tracked session.
+2. `get_context` with `session_id` + compaction hints (`budget_tokens`, `turn_count`, `turn_budget`, inactivity fields).
+3. If compaction is signaled, call `checkpoint_session` before boundary operations.
+4. On reset/handoff boundaries, persist a raw transcript slice via `snapshot_session`.
+5. `end_session` when the task closes.
+
+The hosted MCP endpoint focuses on tenant-routed core memory tools. Local lifecycle tools are exposed when running `memories serve`.

--- a/packages/web/content/docs/sdk/index.mdx
+++ b/packages/web/content/docs/sdk/index.mdx
@@ -126,6 +126,12 @@ const response = await anthropic.messages.create({
 
 `MemoriesClient` already supports budget/session-aware retrieval through `context.get()`. Session lifecycle write endpoints (`/sessions/*`) and consolidation (`/memories/consolidate`) are currently called through SDK HTTP routes.
 
+<Callout>
+When you pass lifecycle hints (`sessionId`, token/turn budgets, inactivity fields), `context.get()`
+can return a `session` block with `compactionRequired` and `triggerHint` so your app can checkpoint
+before context boundaries.
+</Callout>
+
 ```typescript
 import { MemoriesClient } from "@memories.sh/core"
 
@@ -174,12 +180,21 @@ const context = await client.context.get({
   inactivityThresholdMinutes: 45,
 })
 
-await sdkPost("/api/sdk/v1/sessions/checkpoint", {
-  sessionId,
-  content: `Captured ${context.memories.length} relevant memories`,
-  kind: "summary",
-  scope,
-})
+if (context.session?.compactionRequired) {
+  await sdkPost("/api/sdk/v1/sessions/checkpoint", {
+    sessionId,
+    content: `Pre-compaction checkpoint (${context.session.triggerHint ?? "unspecified"} trigger)`,
+    kind: "summary",
+    scope,
+  })
+} else {
+  await sdkPost("/api/sdk/v1/sessions/checkpoint", {
+    sessionId,
+    content: `Captured ${context.memories.length} relevant memories`,
+    kind: "summary",
+    scope,
+  })
+}
 
 await sdkPost("/api/sdk/v1/memories/consolidate", {
   types: ["rule", "decision", "fact"],
@@ -195,6 +210,14 @@ await sdkPost("/api/sdk/v1/sessions/end", {
 ```
 
 If you need explicit raw snapshot creation in the same flow, use local CLI/MCP lifecycle tools (`memories session snapshot` or `snapshot_session`) and then consume `/api/sdk/v1/sessions/{sessionId}/snapshot`.
+
+Recommended lifecycle order:
+
+1. Start session (`/sessions/start`)
+2. Repeated `context.get()` with lifecycle hints
+3. Checkpoint before compaction-boundary turns
+4. Optional raw snapshot on reset/handoff boundary
+5. End session (`/sessions/end`)
 
 ## Management APIs (Copy-Paste)
 


### PR DESCRIPTION
## Summary
- expand SDK docs with lifecycle-aware context hints (`compactionRequired`, `triggerHint`) and checkpoint-first pattern
- add MCP server lifecycle sequence for long-running sessions
- reframe OpenClaw integration around deterministic bootstrap → flush → snapshot → sync flow
- add trigger guidance for compaction/reset/handoff boundaries

## Validation
- pnpm -C packages/web build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify recommended lifecycle sequencing and checkpoint/snapshot triggers without changing runtime behavior.
> 
> **Overview**
> Adds **lifecycle-aware guidance** across docs so integrations follow a consistent session boundary flow (start → context reads with hints → checkpoint before compaction → optional snapshot on reset/handoff → end).
> 
> Updates the SDK guide to show how to use `context.get()` lifecycle hints and conditionally checkpoint when `compactionRequired`/`triggerHint` are returned, and expands the OpenClaw integration with a deterministic `bootstrap` → `flush` → `snapshot` → `sync` sequence plus trigger guidance for when to run each step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d228d7fd7f8d09aaee75efbfe988bb047a3833d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->