### PR TITLE
docs: ship segmented memory launch narrative

### DIFF
--- a/packages/web/content/docs/changelog.mdx
+++ b/packages/web/content/docs/changelog.mdx
@@ -3,6 +3,24 @@ title: Changelog
 description: Product and documentation updates.
 ---
 
+## February 28, 2026
+
+- Launched segmented memory lifecycle messaging across docs and homepage:
+  - Session memory (working context)
+  - Semantic memory (durable truths/preferences)
+  - Episodic memory (daily logs + raw snapshots)
+  - Procedural memory (reusable workflows)
+- Added new Concepts guide: [Memory Segmentation](/docs/concepts/memory-segmentation), including trigger patterns, compaction guidance, and storage routing.
+- Updated homepage copy to foreground lifecycle segmentation, compaction-safe checkpointing, and deterministic OpenClaw memory flow.
+- Updated Getting Started + README guidance with explicit lifecycle commands:
+  - `memories session start|checkpoint|snapshot|end`
+  - `memories compact run`
+  - `memories openclaw memory bootstrap|flush|snapshot|sync`
+- Expanded integration docs with lifecycle-first operational patterns:
+  - SDK: budget/session hints + checkpoint-first flow
+  - MCP: lifecycle sequence for long-running sessions
+  - OpenClaw: deterministic bootstrap → flush → snapshot → sync routine
+
 ## February 26, 2026
 
 - Added memory lifecycle observability endpoint: `GET /api/sdk/v1/management/memory/observability` (lifecycle, compaction, consolidation, contradiction trend metrics + alarms).

--- a/packages/web/content/docs/index.mdx
+++ b/packages/web/content/docs/index.mdx
@@ -13,6 +13,12 @@ Scope model by surface: CLI uses `global` + git project scope. SDK uses `tenantI
 context filter).
 </Callout>
 
+<Callout>
+New: segmented memory lifecycle docs are now live. Start with
+[Memory Segmentation](/docs/concepts/memory-segmentation) and see
+the release summary in [Changelog](/docs/changelog).
+</Callout>
+
 ## Why memories.sh?
 
 If you use multiple AI coding tools, you know the pain:

--- a/reports/memory-segmentation-launch-kit.md
+++ b/reports/memory-segmentation-launch-kit.md
@@ -1,0 +1,41 @@
+# Memory Segmentation Launch Kit
+
+Date: 2026-02-28
+
+## Website/Demo Blurb
+
+memories.sh now uses a segmented memory lifecycle for agents: session memory for active work, semantic memory for durable truths, episodic memory for timeline fidelity, and procedural memory for reusable workflows. This gives teams compaction-safe continuity without replaying entire transcripts.
+
+## Changelog Snippet
+
+Shipped segmented memory lifecycle messaging and docs across the site, including a new Memory Segmentation concept guide, homepage copy refresh, lifecycle command updates in Getting Started/README, and integration runbooks for SDK, MCP, and OpenClaw.
+
+## Social Post Draft
+
+We just shipped segmented agent memory docs + UX at memories.sh.
+
+- Session memory for active context
+- Semantic memory for durable truths
+- Episodic memory for logs + raw snapshots
+- Procedural memory for reusable workflows
+
+Also added lifecycle flows for SDK, MCP, and OpenClaw with compaction-safe checkpoints.
+
+## Email Update Draft
+
+Subject: Segmented memory lifecycle is now live in memories.sh docs
+
+We just rolled out a full lifecycle memory update across memories.sh docs and site copy.
+
+What’s new:
+
+1. A dedicated Memory Segmentation concept guide
+2. Session + compaction commands highlighted in Getting Started and README
+3. Lifecycle-first integration patterns for SDK, MCP, and OpenClaw
+4. Homepage messaging now aligned to session, semantic, episodic, and procedural memory
+
+Start here: /docs/concepts/memory-segmentation
+
+## Sales/Support One-Liner
+
+memories.sh is not just a memory store; it is a segmented lifecycle system that keeps active sessions coherent while preserving durable semantic, episodic, and procedural memory over time.


### PR DESCRIPTION
## Summary
- add February 28 changelog entry summarizing segmented memory lifecycle rollout
- add docs home callout linking to segmentation guide + changelog
- add tracked launch kit with website/demo blurb, social, email, and sales/support snippets

## Validation
- pnpm -C packages/web build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates documentation content and adds a marketing/launch kit markdown file, with no code or runtime behavior changes.
> 
> **Overview**
> Adds a new **Feb 28, 2026** changelog entry summarizing the segmented memory lifecycle rollout, including links to the new [Memory Segmentation](/docs/concepts/memory-segmentation) guide and updated lifecycle command/integration guidance.
> 
> Updates the docs landing page with a callout linking readers to the segmentation guide and `Changelog`, and adds a tracked `reports/memory-segmentation-launch-kit.md` containing prepared website, social, email, and support copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 397d51e9940cd533f06c46661c5659432b4e8c48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->