### PR TITLE
web: correct MCP capability copy on homepage

### DIFF
--- a/packages/web/src/components/HowItWorks.tsx
+++ b/packages/web/src/components/HowItWorks.tsx
@@ -94,9 +94,9 @@ export function HowItWorks(): React.JSX.Element {
     },
     mcp: {
       heading: "MCP when you need it.",
-      description: "For browser-based agents like v0, bolt.new, and Lovable—or any MCP client that can't run the CLI—7 tools expose the same segmented memory lifecycle.",
+      description: "For browser-based agents like v0, bolt.new, and Lovable—or any MCP client that can't run the CLI—hosted MCP exposes tenant-routed core memory tools with layered recall.",
       cardTitle: "Direct agent fallback",
-      cardDescription: "Same 7 tools as CLI: layered recall, lifecycle sessions, and path-scoped memory operations.",
+      cardDescription: "Hosted endpoint: core memory tools. Local `memories serve`: adds lifecycle, reminder, and streaming tools.",
       endpoint: "https://memories.sh/api/mcp",
     },
     sdk: {

--- a/packages/web/src/components/SDKSection.tsx
+++ b/packages/web/src/components/SDKSection.tsx
@@ -26,7 +26,7 @@ const layers: {
     label: "MCP",
     pkg: "memories serve",
     description:
-      "7 tools, FTS5 search, real-time access for browser-based agents and MCP clients.",
+      "Hosted MCP exposes tenant-routed core memory tools; local memories serve adds lifecycle, reminder, and streaming tools.",
     accent: false,
     href: "/docs/mcp-server",
   },


### PR DESCRIPTION
## Review finding fixed
Homepage copy still claimed "7 tools" and implied hosted MCP included full lifecycle tools.

## What changed
- update How It Works MCP tab copy to distinguish hosted core MCP tools vs local `memories serve` extras
- update SDK section MCP card copy with the same distinction

## Validation
- pnpm -C packages/web lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only changes to homepage components; no behavioral, routing, or data-handling logic is modified.
> 
> **Overview**
> Updates homepage marketing copy to correctly distinguish **hosted MCP** (tenant-routed core memory tools with layered recall) from the **local `memories serve`** server (adds lifecycle, reminder, and streaming tools).
> 
> This clarification is applied in both the `HowItWorks` MCP tab and the `SDKSection` MCP card, removing the outdated “7 tools” implication for hosted MCP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3011e14e27d8dc0fbfb07304fdeb3249f659d515. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->