### PR TITLE
Fix header parsing and rate-limit edge cases

### DIFF
--- a/packages/web/src/app/api/sdk/v1/management/identity.ts
+++ b/packages/web/src/app/api/sdk/v1/management/identity.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { authenticateRequest } from "@/lib/auth"
+import { parseRetryAfterSeconds } from "@/lib/http-headers"
 import { apiError } from "@/lib/memory-service/tools"
 import { apiRateLimit, checkRateLimit, strictRateLimit } from "@/lib/rate-limit"
 import { authenticateApiKey, errorResponse, getApiKey } from "@/lib/sdk-api/runtime"
@@ -28,7 +29,7 @@ interface ResolveManagementIdentityOptions {
 }
 
 function rateLimitEnvelopeResponse(endpoint: string, requestId: string, source: NextResponse): NextResponse {
-  const retryAfter = Number(source.headers.get("Retry-After") ?? String(DEFAULT_RETRY_AFTER_SECONDS))
+  const retryAfter = parseRetryAfterSeconds(source.headers.get("Retry-After"), DEFAULT_RETRY_AFTER_SECONDS)
   const response = errorResponse(
     endpoint,
     requestId,
@@ -39,7 +40,7 @@ function rateLimitEnvelopeResponse(endpoint: string, requestId: string, source: 
       status: 429,
       retryable: true,
       details: {
-        retryAfterSeconds: Number.isFinite(retryAfter) ? retryAfter : DEFAULT_RETRY_AFTER_SECONDS,
+        retryAfterSeconds: retryAfter,
       },
     })
   )

--- a/packages/web/src/lib/__tests__/rate-limit.test.ts
+++ b/packages/web/src/lib/__tests__/rate-limit.test.ts
@@ -166,4 +166,14 @@ describe("getClientIp", () => {
     })
     expect(getClientIp(request)).toBe("unknown")
   })
+
+  it("should normalize IPv4-mapped IPv6 proxy header values", () => {
+    process.env.TRUST_PROXY_HEADERS = "true"
+    const request = new Request("https://example.com", {
+      headers: {
+        "x-forwarded-for": "::ffff:203.0.113.7",
+      },
+    })
+    expect(getClientIp(request)).toBe("203.0.113.7")
+  })
 })

--- a/packages/web/src/lib/http-headers.test.ts
+++ b/packages/web/src/lib/http-headers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { extractBearerToken, parseRetryAfterSeconds } from "./http-headers"
+
+describe("extractBearerToken", () => {
+  it("accepts Authorization bearer scheme in any casing", () => {
+    expect(extractBearerToken("bearer mem_test_key")).toBe("mem_test_key")
+    expect(extractBearerToken("BEARER mem_test_key")).toBe("mem_test_key")
+  })
+
+  it("returns null for invalid or empty bearer headers", () => {
+    expect(extractBearerToken(null)).toBeNull()
+    expect(extractBearerToken("Basic token")).toBeNull()
+    expect(extractBearerToken("Bearer    ")).toBeNull()
+  })
+})
+
+describe("parseRetryAfterSeconds", () => {
+  it("clamps numeric retry-after values to at least one second", () => {
+    expect(parseRetryAfterSeconds("0", 60)).toBe(1)
+    expect(parseRetryAfterSeconds("-5", 60)).toBe(1)
+  })
+
+  it("supports HTTP-date retry-after values", () => {
+    const nowMs = Date.UTC(2026, 0, 1, 0, 0, 0)
+    const httpDate = new Date(nowMs + 90_000).toUTCString()
+    expect(parseRetryAfterSeconds(httpDate, 60, nowMs)).toBe(90)
+  })
+
+  it("falls back to configured default for invalid header values", () => {
+    expect(parseRetryAfterSeconds("not-a-date", 45, Date.UTC(2026, 0, 1, 0, 0, 0))).toBe(45)
+  })
+})

--- a/packages/web/src/lib/http-headers.ts
+++ b/packages/web/src/lib/http-headers.ts
@@ -1,0 +1,40 @@
+const BEARER_HEADER_PATTERN = /^Bearer\s+(.+)$/i
+
+export function extractBearerToken(authHeader: string | null | undefined): string | null {
+  if (!authHeader) return null
+
+  const match = BEARER_HEADER_PATTERN.exec(authHeader.trim())
+  if (!match) return null
+
+  const token = match[1]?.trim() ?? ""
+  return token.length > 0 ? token : null
+}
+
+function normalizeFallbackSeconds(value: number): number {
+  if (!Number.isFinite(value)) return 60
+  return Math.max(1, Math.ceil(value))
+}
+
+export function parseRetryAfterSeconds(
+  retryAfterHeader: string | null | undefined,
+  fallbackSeconds = 60,
+  nowMs = Date.now()
+): number {
+  const fallback = normalizeFallbackSeconds(fallbackSeconds)
+  if (!retryAfterHeader) return fallback
+
+  const trimmed = retryAfterHeader.trim()
+  if (!trimmed) return fallback
+
+  const numeric = Number(trimmed)
+  if (Number.isFinite(numeric)) {
+    return Math.max(1, Math.ceil(numeric))
+  }
+
+  const parsedDateMs = Date.parse(trimmed)
+  if (Number.isFinite(parsedDateMs)) {
+    return Math.max(1, Math.ceil((parsedDateMs - nowMs) / 1000))
+  }
+
+  return fallback
+}

--- a/packages/web/src/lib/rate-limit.ts
+++ b/packages/web/src/lib/rate-limit.ts
@@ -204,7 +204,15 @@ function normalizeClientIpCandidate(value: string | null | undefined): string | 
   if (!value) return null
   const trimmed = value.trim()
   if (!trimmed) return null
+  const mappedIpv4 = parseIpv4MappedIpv6(trimmed)
+  if (mappedIpv4) return mappedIpv4
   return isValidIpAddress(trimmed) ? trimmed : null
+}
+
+function parseIpv4MappedIpv6(value: string): string | null {
+  if (!value.toLowerCase().startsWith("::ffff:")) return null
+  const mapped = value.slice("::ffff:".length)
+  return isValidIpv4(mapped) ? mapped : null
 }
 
 function isValidIpAddress(value: string): boolean {

--- a/packages/web/src/lib/sdk-api/runtime.ts
+++ b/packages/web/src/lib/sdk-api/runtime.ts
@@ -1,4 +1,5 @@
 import { resolveActiveMemoryContext } from "@/lib/active-memory-context"
+import { extractBearerToken, parseRetryAfterSeconds } from "@/lib/http-headers"
 import { hashMcpApiKey, isValidMcpApiKey } from "@/lib/mcp-api-key"
 import { resolveApiKeyOwnerByHash } from "@/lib/mcp-api-key-store"
 import { checkRateLimit, mcpRateLimit } from "@/lib/rate-limit"
@@ -94,11 +95,7 @@ export function legacyErrorResponse(
 }
 
 export function getApiKey(request: NextRequest): string | null {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader?.startsWith("Bearer ")) {
-    return null
-  }
-  return authHeader.slice(7)
+  return extractBearerToken(request.headers.get("authorization"))
 }
 
 export async function authenticateApiKey(
@@ -123,7 +120,7 @@ export async function authenticateApiKey(
   const apiKeyHash = hashMcpApiKey(apiKey)
   const rateLimited = await checkRateLimit(mcpRateLimit, apiKeyHash)
   if (rateLimited) {
-    const retryAfter = Number(rateLimited.headers.get("Retry-After") ?? "60")
+    const retryAfter = parseRetryAfterSeconds(rateLimited.headers.get("Retry-After"), 60)
     return errorResponse(
       endpoint,
       requestId,
@@ -134,7 +131,7 @@ export async function authenticateApiKey(
         status: 429,
         retryable: true,
         details: {
-          retryAfterSeconds: Number.isFinite(retryAfter) ? retryAfter : 60,
+          retryAfterSeconds: retryAfter,
         },
       })
     )


### PR DESCRIPTION
## Summary
- accept bearer auth scheme case-insensitively and ignore empty bearer tokens
- parse `Retry-After` as either delta-seconds or HTTP-date, with sane fallback/clamping
- normalize IPv4-mapped IPv6 proxy addresses for stable client IP rate-limit keys

## Validation
- pnpm -r typecheck
- pnpm -r test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth header parsing and rate-limit error metadata, which can affect request authentication and client retry behavior if parsing is wrong. Changes are localized and covered by new unit tests, reducing risk.
> 
> **Overview**
> Improves header parsing by centralizing `Authorization: Bearer` extraction into `extractBearerToken` (case-insensitive and rejects empty tokens), and updates `getApiKey` to use it.
> 
> Adds `parseRetryAfterSeconds` to correctly interpret `Retry-After` as either delta-seconds or HTTP-date with clamping/fallback behavior, and uses it when returning rate-limit errors in both management identity and SDK runtime paths.
> 
> Normalizes IPv4-mapped IPv6 (e.g. `::ffff:1.2.3.4`) in proxy-derived client IPs to keep rate-limit keys stable, with new unit tests covering these edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd1e899b96613a103d6acd41d67b88c7305fc4ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->