### PR TITLE
Fix docs raw path handling and proxy IP edge cases

### DIFF
--- a/packages/web/src/app/api/docs/raw/route.test.ts
+++ b/packages/web/src/app/api/docs/raw/route.test.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from "next/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mockCheckRateLimit, mockGetClientIp, mockReadFile } = vi.hoisted(() => ({
+  mockCheckRateLimit: vi.fn(),
+  mockGetClientIp: vi.fn(),
+  mockReadFile: vi.fn(),
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  publicRateLimit: { limit: vi.fn() },
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: mockGetClientIp,
+}))
+
+vi.mock("fs/promises", () => ({
+  readFile: mockReadFile,
+}))
+
+import { GET } from "./route"
+
+function makeRequest(pathAndQuery: string): NextRequest {
+  return new NextRequest(`https://example.com/api/docs/raw${pathAndQuery}`)
+}
+
+describe("/api/docs/raw GET", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue(null)
+    mockGetClientIp.mockReturnValue("203.0.113.10")
+  })
+
+  it("returns 400 for invalid traversal-style path values", async () => {
+    const response = await GET(makeRequest("?path=../secrets"))
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: "Invalid path parameter" })
+    expect(mockReadFile).not.toHaveBeenCalled()
+  })
+
+  it("reads and returns markdown for valid docs paths", async () => {
+    mockReadFile.mockResolvedValue("# Docs")
+
+    const response = await GET(makeRequest("?path=sdk/client"))
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8")
+    expect(response.headers.get("Cache-Control")).toBe("public, s-maxage=300, stale-while-revalidate=86400")
+    await expect(response.text()).resolves.toBe("# Docs")
+
+    const readPath = String(mockReadFile.mock.calls[0]?.[0] ?? "")
+    expect(readPath).toMatch(/content[\\/]+docs[\\/]+sdk[\\/]+client\.mdx$/)
+  })
+
+  it("returns 404 only when the markdown file is missing", async () => {
+    const notFoundError = Object.assign(new Error("missing"), { code: "ENOENT" })
+    mockReadFile.mockRejectedValue(notFoundError)
+
+    const response = await GET(makeRequest("?path=sdk/missing-doc"))
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: "File not found" })
+  })
+
+  it("returns 500 for filesystem errors other than missing files", async () => {
+    const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" })
+    mockReadFile.mockRejectedValue(permissionError)
+
+    const response = await GET(makeRequest("?path=sdk/client"))
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: "Failed to load document" })
+  })
+})

--- a/packages/web/src/app/api/docs/raw/route.ts
+++ b/packages/web/src/app/api/docs/raw/route.ts
@@ -1,48 +1,81 @@
-import { NextRequest, NextResponse } from "next/server";
-import { readFile } from "fs/promises";
-import { join } from "path";
-import { checkRateLimit, getClientIp, publicRateLimit } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIp, publicRateLimit } from "@/lib/rate-limit"
+import { readFile } from "fs/promises"
+import { NextRequest, NextResponse } from "next/server"
+import { normalize, resolve, sep } from "path"
 
-const CACHE_CONTROL_DOCS = "public, s-maxage=300, stale-while-revalidate=86400";
-const CACHE_CONTROL_NOT_FOUND = "public, s-maxage=60, stale-while-revalidate=300";
+const CACHE_CONTROL_DOCS = "public, s-maxage=300, stale-while-revalidate=86400"
+const CACHE_CONTROL_NOT_FOUND = "public, s-maxage=60, stale-while-revalidate=300"
+const DOCS_ROOT = resolve(process.cwd(), "content", "docs")
+
+function normalizeDocsPath(rawPath: string | null): string | null {
+  if (!rawPath) return null
+
+  const trimmed = rawPath.trim()
+  if (!trimmed || trimmed.includes("\0")) return null
+
+  const normalizedSlashes = trimmed.replace(/\\/g, "/")
+  const withoutMdxExtension = normalizedSlashes.endsWith(".mdx")
+    ? normalizedSlashes.slice(0, -4)
+    : normalizedSlashes
+  const collapsed = normalize(withoutMdxExtension).replace(/\\/g, "/")
+
+  if (!collapsed || collapsed === "." || collapsed === "..") return null
+  if (collapsed.startsWith("/") || collapsed.startsWith("../")) return null
+  if (!/^[a-zA-Z0-9/_-]+$/.test(collapsed)) return null
+
+  return collapsed
+}
+
+function resolveDocsFilePath(rawPath: string | null): string | null {
+  const normalizedPath = normalizeDocsPath(rawPath)
+  if (!normalizedPath) return null
+
+  const candidate = resolve(DOCS_ROOT, `${normalizedPath}.mdx`)
+  const docsRootPrefix = DOCS_ROOT.endsWith(sep) ? DOCS_ROOT : `${DOCS_ROOT}${sep}`
+  if (!candidate.startsWith(docsRootPrefix)) {
+    return null
+  }
+
+  return candidate
+}
+
+function isNotFoundError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === "ENOENT" || code === "ENOTDIR"
+}
 
 export async function GET(request: NextRequest): Promise<Response> {
-  const rateLimited = await checkRateLimit(publicRateLimit, getClientIp(request));
-  if (rateLimited) {
-    return rateLimited;
+  const rateLimited = await checkRateLimit(publicRateLimit, getClientIp(request))
+  if (rateLimited) return rateLimited
+
+  const filePath = resolveDocsFilePath(request.nextUrl.searchParams.get("path"))
+  if (!filePath) {
+    return NextResponse.json({ error: "Invalid path parameter" }, { status: 400 })
   }
 
-  const searchParams = request.nextUrl.searchParams;
-  const path = searchParams.get("path");
-
-  if (!path) {
-    return NextResponse.json({ error: "Missing path parameter" }, { status: 400 });
-  }
-
-  // Sanitize path to prevent directory traversal
-  const sanitizedPath = path.replace(/\.\./g, "").replace(/^\/+/, "");
-  
   try {
-    // Try to read the MDX file from content/docs
-    const filePath = join(process.cwd(), "content", "docs", `${sanitizedPath}.mdx`);
-    const content = await readFile(filePath, "utf-8");
-    
+    const content = await readFile(filePath, "utf-8")
+
     return new NextResponse(content, {
       headers: {
         "Content-Type": "text/markdown; charset=utf-8",
         "Cache-Control": CACHE_CONTROL_DOCS,
       },
-    });
+    })
   } catch (error) {
-    console.error("Failed to read MDX file:", error);
-    return NextResponse.json(
-      { error: "File not found" },
-      {
-        status: 404,
-        headers: {
-          "Cache-Control": CACHE_CONTROL_NOT_FOUND,
-        },
-      }
-    );
+    if (isNotFoundError(error)) {
+      return NextResponse.json(
+        { error: "File not found" },
+        {
+          status: 404,
+          headers: {
+            "Cache-Control": CACHE_CONTROL_NOT_FOUND,
+          },
+        }
+      )
+    }
+
+    console.error("Failed to read MDX file:", error)
+    return NextResponse.json({ error: "Failed to load document" }, { status: 500 })
   }
 }

--- a/packages/web/src/lib/__tests__/rate-limit.test.ts
+++ b/packages/web/src/lib/__tests__/rate-limit.test.ts
@@ -176,4 +176,24 @@ describe("getClientIp", () => {
     })
     expect(getClientIp(request)).toBe("203.0.113.7")
   })
+
+  it("should normalize IPv4 proxy values that include a port", () => {
+    process.env.TRUST_PROXY_HEADERS = "true"
+    const request = new Request("https://example.com", {
+      headers: {
+        "x-forwarded-for": "203.0.113.7:12345",
+      },
+    })
+    expect(getClientIp(request)).toBe("203.0.113.7")
+  })
+
+  it("should normalize bracketed IPv6 proxy values that include a port", () => {
+    process.env.TRUST_PROXY_HEADERS = "true"
+    const request = new Request("https://example.com", {
+      headers: {
+        "x-forwarded-for": "[2001:db8::1]:443",
+      },
+    })
+    expect(getClientIp(request)).toBe("2001:db8::1")
+  })
 })

--- a/packages/web/src/lib/rate-limit.ts
+++ b/packages/web/src/lib/rate-limit.ts
@@ -202,11 +202,38 @@ export function getClientIp(request: Request): string {
 
 function normalizeClientIpCandidate(value: string | null | undefined): string | null {
   if (!value) return null
-  const trimmed = value.trim()
+  const trimmed = stripIpPort(value.trim())
   if (!trimmed) return null
   const mappedIpv4 = parseIpv4MappedIpv6(trimmed)
   if (mappedIpv4) return mappedIpv4
   return isValidIpAddress(trimmed) ? trimmed : null
+}
+
+function stripIpPort(value: string): string {
+  if (!value) return value
+
+  if (value.startsWith("[")) {
+    const closingBracket = value.indexOf("]")
+    if (closingBracket === -1) return value
+    const host = value.slice(1, closingBracket)
+    const suffix = value.slice(closingBracket + 1)
+    if (!suffix || /^:\d+$/.test(suffix)) {
+      return host
+    }
+    return value
+  }
+
+  const firstColon = value.indexOf(":")
+  const lastColon = value.lastIndexOf(":")
+  if (firstColon !== -1 && firstColon === lastColon) {
+    const host = value.slice(0, lastColon)
+    const port = value.slice(lastColon + 1)
+    if (/^\d+$/.test(port) && isValidIpv4(host)) {
+      return host
+    }
+  }
+
+  return value
 }
 
 function parseIpv4MappedIpv6(value: string): string | null {


### PR DESCRIPTION
## Summary
- normalize proxy IP header values with ports (IPv4 and bracketed IPv6) before validation/rate-limit keying
- harden `/api/docs/raw` path handling to reject traversal/invalid paths instead of mutating input
- return `500` for internal docs read failures while preserving `404` for true missing files

## Validation
- pnpm -r typecheck
- pnpm -r test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens input validation and error handling on a public docs endpoint and changes how client IPs are parsed for rate limiting, which can alter request behavior (new 400/500 responses and different rate-limit bucketing). Changes are well-scoped and covered by new tests.
> 
> **Overview**
> **Docs raw endpoint hardening:** `/api/docs/raw` now strictly normalizes/validates the `path` query param (no traversal, no absolute paths, limited charset, optional `.mdx` stripping) and resolves the file path under a fixed `DOCS_ROOT` before reading.
> 
> **Error semantics tightened:** missing docs files still return `404`, but other filesystem failures now return `500` instead of being treated as not found; invalid `path` now yields `400`.
> 
> **Rate-limit IP parsing fix:** `getClientIp` now strips `:port` from IPv4 values and bracketed IPv6 values in trusted proxy headers before validation/rate-limit keying. Adds targeted tests for the docs route and the new proxy IP edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 648073682edb6596d30f0d9d76866bce43e32da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->