### PR TITLE
CI: mitigate nondeterministic install flakes and rollout push failures

### DIFF
--- a/.github/scripts/pnpm-install-with-retry.sh
+++ b/.github/scripts/pnpm-install-with-retry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-4}"
+BASE_SLEEP_SECONDS="${BASE_SLEEP_SECONDS:-5}"
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [[ "$MAX_ATTEMPTS" -lt 1 ]]; then
+  echo "MAX_ATTEMPTS must be a positive integer (got: $MAX_ATTEMPTS)" >&2
+  exit 2
+fi
+
+if ! [[ "$BASE_SLEEP_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "BASE_SLEEP_SECONDS must be a non-negative integer (got: $BASE_SLEEP_SECONDS)" >&2
+  exit 2
+fi
+
+attempt=1
+while true; do
+  echo "pnpm install attempt $attempt/$MAX_ATTEMPTS"
+  if pnpm install --frozen-lockfile; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -ge "$MAX_ATTEMPTS" ]]; then
+    echo "pnpm install failed after $MAX_ATTEMPTS attempts" >&2
+    exit 1
+  fi
+
+  sleep_seconds=$(( BASE_SLEEP_SECONDS * attempt ))
+  echo "pnpm install failed; retrying in ${sleep_seconds}s..." >&2
+  sleep "$sleep_seconds"
+  attempt=$(( attempt + 1 ))
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient network failures)
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Lint
         run: pnpm lint
@@ -55,7 +56,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient network failures)
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Typecheck
         run: pnpm typecheck
@@ -75,7 +77,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient network failures)
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Run tests
         run: pnpm test
@@ -95,7 +98,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient network failures)
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Enforce workspace-switch p50/p95 budgets
         run: pnpm --filter @memories.sh/web test src/lib/workspace-switch-performance.test.ts
@@ -115,7 +119,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient network failures)
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Run SDK contract snapshot tests
         run: pnpm --filter @memories.sh/web test:sdk-contracts
@@ -139,7 +144,8 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient network failures)
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/graph-rollout-baseline-report.yml
+++ b/.github/workflows/graph-rollout-baseline-report.yml
@@ -64,7 +64,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add reports/graph-rollout
           git commit -m "chore(graph): refresh rollout baseline report [skip ci]"
-          git push origin HEAD:main
+          if git push origin HEAD:main; then
+            echo "Report updates pushed to main."
+          else
+            echo "::warning::Unable to push report updates to main (likely blocked by branch protection)."
+            echo "::warning::Report artifacts were uploaded; create a PR to persist report history."
+          fi
 
       - name: Fail when report generation detects regression or errors
         if: steps.generate.outputs.exit_code != '0'

--- a/.github/workflows/local-onboarding-smoke.yml
+++ b/.github/workflows/local-onboarding-smoke.yml
@@ -40,7 +40,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Run minimal-local clean machine smoke
         run: bash .github/scripts/local-onboarding-smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: bash .github/scripts/pnpm-install-with-retry.sh
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary
- add a shared retry wrapper for `pnpm install --frozen-lockfile` to reduce transient `sharp`/network flake failures in CI
- use the retry wrapper in CI, release, and local onboarding smoke workflows
- make graph rollout baseline report commit step resilient to protected-branch push rejections (warn instead of failing the run)

## Why
Recent CI failures were nondeterministic install failures during `sharp@0.32.6` postinstall (`socket hang up` + fallback native build failure). This patch hardens install steps against transient network errors and prevents unrelated GH013 branch-protection push failures from failing scheduled report runs.

## Validation
- bash -n .github/scripts/pnpm-install-with-retry.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to GitHub Actions scripts/workflows and only affect CI reliability, with no product/runtime code changes. Main risk is longer CI times or masking persistent dependency install issues due to retries.
> 
> **Overview**
> Adds a shared `.github/scripts/pnpm-install-with-retry.sh` wrapper to retry `pnpm install --frozen-lockfile` with configurable backoff, and updates CI, release, and local onboarding workflows to use it instead of a single install attempt.
> 
> Hardens the graph rollout baseline report workflow by treating `git push` failures (e.g., branch protection) as warnings after committing, while still uploading report artifacts and failing only when report generation signals regressions/errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1049ab274849e35871858a3f7e8cb12dbebcd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->