### PR TITLE
fix(web): migrate Sentry client instrumentation for Next 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     },
     "onlyBuiltDependencies": [
       "esbuild",
+      "@sentry/cli",
       "sharp",
       "protobufjs",
       "unrs-resolver"

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -3,10 +3,10 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV || "development",
-  integrations: [
-    Sentry.replayIntegration(),
-  ],
+  integrations: [Sentry.replayIntegration()],
   tracesSampleRate: 0,
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
 });
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,6 @@ ignoredBuiltDependencies:
   - sharp
   - unrs-resolver
 
-onlyBuiltDependencies: esbuild
+onlyBuiltDependencies:
+  - esbuild
+  - "@sentry/cli"


### PR DESCRIPTION
## Summary\n- migrate Sentry client config from  to \n- export  for Next/Sentry client instrumentation support\n- allow  postinstall scripts in pnpm build approval config\n\n## Validation\n- 
> @memories.sh/web@0.1.0 build /Users/tradecraft/dev/memories/packages/web
> next build --webpack

▲ Next.js 16.1.6 (webpack)
- Environments: .env.local
- Experiments (use with caution):
  · clientTraceMetadata
  · optimizePackageImports

  Creating an optimized production build ...
[MDX] generated files in 5.113458000000037ms
✓ Compiled successfully in 16.0s
  Running TypeScript ...
  Collecting page data using 15 workers ...
  Generating static pages using 15 workers (0/165) ...
  Generating static pages using 15 workers (41/165) 
  Generating static pages using 15 workers (82/165) 
  Generating static pages using 15 workers (123/165) 
✓ Generating static pages using 15 workers (165/165) in 952.9ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /api/account
├ ƒ /api/auth/cli
├ ƒ /api/db/credentials
├ ƒ /api/db/limits
├ ƒ /api/db/provision
├ ƒ /api/docs/raw
├ ƒ /api/enterprise/contact
├ ƒ /api/files/config-secrets
├ ƒ /api/github/capture/queue
├ ƒ /api/github/capture/queue/[id]
├ ƒ /api/github/capture/settings
├ ƒ /api/github/webhook
├ ƒ /api/graph/explore
├ ƒ /api/graph/rollout
├ ƒ /api/health
├ ƒ /api/integration/health
├ ƒ /api/invites/accept
├ ƒ /api/mcp
├ ƒ /api/mcp/key
├ ƒ /api/memories
├ ƒ /api/memories/insights/actions
├ ƒ /api/memories/migrate
├ ƒ /api/memories/stats
├ ƒ /api/orgs
├ ƒ /api/orgs/[orgId]
├ ƒ /api/orgs/[orgId]/audit
├ ƒ /api/orgs/[orgId]/github-capture/settings
├ ƒ /api/orgs/[orgId]/invites
├ ƒ /api/orgs/[orgId]/members
├ ƒ /api/sdk/v1/context/get
├ ƒ /api/sdk/v1/embeddings/models
├ ƒ /api/sdk/v1/graph/rollout
├ ƒ /api/sdk/v1/graph/status
├ ƒ /api/sdk/v1/graph/trace
├ ƒ /api/sdk/v1/health
├ ƒ /api/sdk/v1/management/embeddings/backfill
├ ƒ /api/sdk/v1/management/embeddings/observability
├ ƒ /api/sdk/v1/management/embeddings/usage
├ ƒ /api/sdk/v1/management/keys
├ ƒ /api/sdk/v1/management/memory/eval/replay
├ ƒ /api/sdk/v1/management/memory/observability
├ ƒ /api/sdk/v1/management/tenant-overrides
├ ƒ /api/sdk/v1/management/tenant-routing/effective
├ ƒ /api/sdk/v1/memories/add
├ ƒ /api/sdk/v1/memories/bulk-forget
├ ƒ /api/sdk/v1/memories/consolidate
├ ƒ /api/sdk/v1/memories/edit
├ ƒ /api/sdk/v1/memories/forget
├ ƒ /api/sdk/v1/memories/list
├ ƒ /api/sdk/v1/memories/search
├ ƒ /api/sdk/v1/memories/vacuum
├ ƒ /api/sdk/v1/sessions/[sessionId]/snapshot
├ ƒ /api/sdk/v1/sessions/checkpoint
├ ƒ /api/sdk/v1/sessions/end
├ ƒ /api/sdk/v1/sessions/start
├ ƒ /api/sdk/v1/skills/files/delete
├ ƒ /api/sdk/v1/skills/files/list
├ ƒ /api/sdk/v1/skills/files/promote
├ ƒ /api/sdk/v1/skills/files/upsert
├ ƒ /api/search
├ ƒ /api/stripe/checkout
├ ƒ /api/stripe/portal
├ ƒ /api/stripe/webhook
├ ƒ /api/user
├ ƒ /api/workspace
├ ƒ /api/workspace/switch-profile
├ ƒ /app
├ ƒ /app/api-keys
├ ƒ /app/auth/cli
├ ƒ /app/billing
├ ƒ /app/graph-explorer
├ ƒ /app/sdk-projects
├ ƒ /app/settings
├ ƒ /app/stats
├ ƒ /app/team
├ ƒ /app/upgrade
├ ƒ /auth/callback
├ ƒ /auth/signout
├ ● /docs/[[...slug]]
│ ├ /docs/changelog
│ ├ /docs/getting-started
│ ├ /docs
│ └ [+80 more paths]
├ ○ /enterprise
├ ƒ /invite/accept
├ ○ /login
├ ○ /openclaw
├ ○ /openclaw/resources
├ ○ /privacy
├ ○ /robots.txt
├ ○ /sitemap.xml
└ ○ /terms


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand\n- https://memories-gwkvinzhh-webrenew.vercel.app (build passes; deployment still fails at Vercel output deploy with internal error)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Sentry client instrumentation wiring and pnpm build-approval configuration, with minimal impact outside observability/build tooling.
> 
> **Overview**
> Updates the web client Sentry instrumentation to align with newer Next/Sentry expectations by exporting `onRouterTransitionStart` (wired to `Sentry.captureRouterTransitionStart`) and keeping Replay integration enabled.
> 
> Adjusts pnpm build-approval configuration to allow `@sentry/cli` to run its install/build scripts by adding it to `onlyBuiltDependencies` (in both `package.json` and `pnpm-workspace.yaml`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3706408bd4bcdca5b5a2f745124aa32aa0acd37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->