### PR TITLE
feat(web): upsell growth plan after first org creation

### DIFF
--- a/packages/web/src/app/api/orgs/__tests__/route.test.ts
+++ b/packages/web/src/app/api/orgs/__tests__/route.test.ts
@@ -199,6 +199,7 @@ describe("/api/orgs", () => {
       const body = await response.json()
       expect(body.organization.name).toBe("New Team")
       expect(body.organization.slug).toBe("new-team")
+      expect(body.upgradeUrl).toBe("/app/upgrade?plan=growth&source=org-created")
     })
 
     it("should return 500 when slug uniqueness check fails", async () => {

--- a/packages/web/src/app/api/orgs/route.ts
+++ b/packages/web/src/app/api/orgs/route.ts
@@ -162,5 +162,11 @@ export async function POST(request: Request): Promise<Response> {
     },
   })
 
-  return NextResponse.json({ organization: org }, { status: 201 })
+  return NextResponse.json(
+    {
+      organization: org,
+      upgradeUrl: "/app/upgrade?plan=growth&source=org-created",
+    },
+    { status: 201 }
+  )
 }

--- a/packages/web/src/app/app/team/team-content.tsx
+++ b/packages/web/src/app/app/team/team-content.tsx
@@ -412,12 +412,18 @@ export function TeamContent({
         body: JSON.stringify({ name: newOrgName.trim() }),
       })
       
-      const data = await res.json()
+      const data = await res.json().catch(() => ({}))
       
       if (res.ok) {
         setShowCreateOrg(false)
         setNewOrgName("")
-        router.refresh()
+        const upgradeUrl =
+          typeof data?.upgradeUrl === "string" ? data.upgradeUrl : "/app/upgrade?plan=growth&source=org-created"
+        if (organizations.length === 0) {
+          router.push(upgradeUrl)
+        } else {
+          router.refresh()
+        }
       } else {
         console.error("Failed to create organization:", data)
         setCreateError(data.error || "Failed to create organization. Please try again.")


### PR DESCRIPTION
Summary:\n- return explicit upgrade URL in org creation success response\n- redirect to upgrade after successful first org creation in Team dashboard\n- keep refresh behavior for additional org creations\n- add org route test assertion for upgrade URL\n\nValidation:\n- pnpm -C packages/web typecheck\n- pnpm -C packages/web test -- src/app/api/orgs/__tests__/route.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-org-creation navigation flow to redirect on first org creation, which could affect onboarding and routing behavior. Backend response shape changes may impact any consumers expecting only `organization` in the 201 payload.
> 
> **Overview**
> Adds an explicit `upgradeUrl` to the `POST /api/orgs` success response and updates API tests to assert it is returned.
> 
> Updates the Team dashboard org creation flow to **redirect to the upgrade page only when creating the first organization** (falling back to a default URL if missing), while keeping the existing `router.refresh()` behavior for subsequent org creations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f00ed30325f03979afa745cfc0e11089e14fb77a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->