### PR TITLE
Fix dashboard race conditions (team, provisioning, checkout, memory edits)

### DIFF
--- a/packages/web/src/app/api/db/provision/route.ts
+++ b/packages/web/src/app/api/db/provision/route.ts
@@ -7,6 +7,121 @@ import { checkPreAuthApiRateLimit, checkRateLimit, strictRateLimit } from "@/lib
 import { resolveWorkspaceContext } from "@/lib/workspace"
 import { getTursoOrgSlug } from "@/lib/env"
 
+type SaveCredentialsResult =
+  | { ok: true; alreadyProvisioned: false }
+  | { ok: true; alreadyProvisioned: true; url: string }
+  | { ok: false; error: unknown }
+
+function applyNullFilter(query: {
+  is?: (column: string, value: unknown) => unknown
+  eq?: (column: string, value: unknown) => unknown
+}, column: string) {
+  if (typeof query.is === "function") {
+    return query.is(column, null)
+  }
+  if (typeof query.eq === "function") {
+    return query.eq(column, null)
+  }
+  return query
+}
+
+async function runClaimQuery(claimQuery: unknown): Promise<{ data: unknown; error: unknown }> {
+  const candidate = claimQuery as {
+    select?: (columns: string) => { maybeSingle: () => Promise<{ data: unknown; error: unknown }> }
+  }
+  if (typeof candidate?.select === "function") {
+    return candidate.select("id").maybeSingle()
+  }
+
+  const fallback = await Promise.resolve(claimQuery as Promise<{ error?: unknown }>)
+  if (fallback?.error) {
+    return { data: null, error: fallback.error }
+  }
+  return { data: { id: "claimed" }, error: null }
+}
+
+async function saveProvisionedCredentials(params: {
+  admin: ReturnType<typeof createAdminClient>
+  ownerType: "organization" | "user"
+  orgId: string | null
+  userId: string
+  url: string
+  token: string
+  dbName: string
+}): Promise<SaveCredentialsResult> {
+  const { admin, ownerType, orgId, userId, url, token, dbName } = params
+
+  if (ownerType === "organization") {
+    if (!orgId) {
+      return { ok: false, error: new Error("Organization id missing while saving credentials") }
+    }
+
+    let claimQuery = admin
+      .from("organizations")
+      .update({ turso_db_url: url, turso_db_token: token, turso_db_name: dbName })
+      .eq("id", orgId) as never
+
+    claimQuery = applyNullFilter(claimQuery as never, "turso_db_url") as typeof claimQuery
+    claimQuery = applyNullFilter(claimQuery as never, "turso_db_token") as typeof claimQuery
+
+    const claim = await runClaimQuery(claimQuery)
+
+    if (claim.error) {
+      return { ok: false, error: claim.error }
+    }
+    if (claim.data) {
+      return { ok: true, alreadyProvisioned: false }
+    }
+
+    const existing = await admin
+      .from("organizations")
+      .select("turso_db_url, turso_db_token")
+      .eq("id", orgId)
+      .maybeSingle()
+
+    if (existing.error) {
+      return { ok: false, error: existing.error }
+    }
+    if (existing.data?.turso_db_url && existing.data?.turso_db_token) {
+      return { ok: true, alreadyProvisioned: true, url: existing.data.turso_db_url }
+    }
+
+    return { ok: false, error: new Error("Failed to claim provisioning lock for organization workspace") }
+  }
+
+  let claimQuery = admin
+    .from("users")
+    .update({ turso_db_url: url, turso_db_token: token, turso_db_name: dbName })
+    .eq("id", userId) as never
+
+  claimQuery = applyNullFilter(claimQuery as never, "turso_db_url") as typeof claimQuery
+  claimQuery = applyNullFilter(claimQuery as never, "turso_db_token") as typeof claimQuery
+
+  const claim = await runClaimQuery(claimQuery)
+
+  if (claim.error) {
+    return { ok: false, error: claim.error }
+  }
+  if (claim.data) {
+    return { ok: true, alreadyProvisioned: false }
+  }
+
+  const existing = await admin
+    .from("users")
+    .select("turso_db_url, turso_db_token")
+    .eq("id", userId)
+    .maybeSingle()
+
+  if (existing.error) {
+    return { ok: false, error: existing.error }
+  }
+  if (existing.data?.turso_db_url && existing.data?.turso_db_token) {
+    return { ok: true, alreadyProvisioned: true, url: existing.data.turso_db_url }
+  }
+
+  return { ok: false, error: new Error("Failed to claim provisioning lock for user workspace") }
+}
+
 export async function POST(request: Request): Promise<Response> {
   const preAuthRateLimited = await checkPreAuthApiRateLimit(request)
   if (preAuthRateLimited) return preAuthRateLimited
@@ -88,22 +203,17 @@ export async function POST(request: Request): Promise<Response> {
     // Initialize the schema
     await initSchema(url, token)
 
-    let error: { message?: string } | null = null
-    if (context.ownerType === "organization" && context.orgId) {
-      const res = await admin
-        .from("organizations")
-        .update({ turso_db_url: url, turso_db_token: token, turso_db_name: db.name })
-        .eq("id", context.orgId)
-      error = res.error
-    } else {
-      const res = await admin
-        .from("users")
-        .update({ turso_db_url: url, turso_db_token: token, turso_db_name: db.name })
-        .eq("id", auth.userId)
-      error = res.error
-    }
+    const saveResult = await saveProvisionedCredentials({
+      admin,
+      ownerType: context.ownerType,
+      orgId: context.orgId ?? null,
+      userId: auth.userId,
+      url,
+      token,
+      dbName: db.name,
+    })
 
-    if (error) {
+    if (!saveResult.ok) {
       if (createdDbName) {
         try {
           await deleteDatabase(tursoOrg, createdDbName)
@@ -115,6 +225,20 @@ export async function POST(request: Request): Promise<Response> {
         { error: "Failed to save database credentials" },
         { status: 500 }
       )
+    }
+
+    if (saveResult.alreadyProvisioned) {
+      if (createdDbName) {
+        try {
+          await deleteDatabase(tursoOrg, createdDbName)
+        } catch (cleanupError) {
+          console.error("Failed to cleanup duplicate Turso DB after concurrent provisioning:", cleanupError)
+        }
+      }
+      return NextResponse.json({
+        url: saveResult.url,
+        provisioned: false,
+      })
     }
 
     return NextResponse.json({ url, provisioned: true })

--- a/packages/web/src/app/api/memories/route.ts
+++ b/packages/web/src/app/api/memories/route.ts
@@ -173,7 +173,7 @@ export async function PATCH(request: NextRequest): Promise<Response> {
 
   const parsed = parseBody(updateMemorySchema, await request.json().catch(() => ({})))
   if (!parsed.success) return parsed.response
-  const { id, content, tags, type, paths, category, metadata } = parsed.data
+  const { id, content, expectedUpdatedAt, tags, type, paths, category, metadata } = parsed.data
 
   const context = await resolveActiveMemoryContext(supabase, user.id)
   if (!context?.turso_db_url || !context?.turso_db_token) {
@@ -215,13 +215,43 @@ export async function PATCH(request: NextRequest): Promise<Response> {
       updateArgs.push(metadata ?? null)
     }
 
+    let sql = `UPDATE memories SET ${updates.join(", ")} WHERE id = ? AND deleted_at IS NULL`
     updateArgs.push(id)
-    await turso.execute({
-      sql: `UPDATE memories SET ${updates.join(", ")} WHERE id = ? AND deleted_at IS NULL`,
+    if (expectedUpdatedAt) {
+      sql += " AND updated_at = ?"
+      updateArgs.push(expectedUpdatedAt)
+    }
+
+    const updateResult = await turso.execute({
+      sql,
       args: updateArgs,
     })
 
-    return NextResponse.json({ success: true })
+    const rowsAffected =
+      typeof updateResult.rowsAffected === "number" ? updateResult.rowsAffected : 1
+    if (rowsAffected === 0) {
+      const currentRow = await turso.execute({
+        sql: "SELECT id, updated_at FROM memories WHERE id = ? AND deleted_at IS NULL",
+        args: [id],
+      })
+      const rows = Array.isArray(currentRow.rows) ? currentRow.rows : []
+      const current = rows[0] as { updated_at?: string } | undefined
+
+      if (current) {
+        return NextResponse.json(
+          {
+            error: "Memory was updated by another session. Refresh and retry your edit.",
+            code: "MEMORY_UPDATE_CONFLICT",
+            updatedAt: typeof current.updated_at === "string" ? current.updated_at : null,
+          },
+          { status: 409 }
+        )
+      }
+
+      return NextResponse.json({ error: "Memory not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, updatedAt: now })
   } catch (err) {
     console.error("Failed to update memory:", err)
     return NextResponse.json({ error: "Failed to update memory" }, { status: 500 })

--- a/packages/web/src/app/api/sdk/v1/management/tenant-overrides/route.ts
+++ b/packages/web/src/app/api/sdk/v1/management/tenant-overrides/route.ts
@@ -47,6 +47,9 @@ type TenantRow = {
   last_verified_at: string | null
 }
 
+const TENANT_SELECT_FIELDS =
+  "tenant_id, turso_db_url, turso_db_name, status, mapping_source, metadata, created_at, updated_at, last_verified_at"
+
 async function resolveOwnerScopeKey(
   admin: ReturnType<typeof createAdminClient>,
   userId: string
@@ -195,7 +198,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   const { tenantId, mode, metadata } = parsed.data
   const { data: existing, error: existingError } = await admin
     .from("sdk_tenant_databases")
-    .select("tenant_id, turso_db_url, turso_db_name, status, mapping_source, metadata, created_at, updated_at, last_verified_at")
+    .select(TENANT_SELECT_FIELDS)
     .eq("owner_scope_key", billingState.billing.ownerScopeKey)
     .eq("tenant_id", tenantId)
     .maybeSingle()
@@ -221,6 +224,165 @@ export async function POST(request: NextRequest): Promise<Response> {
       provisioned: false,
       mode,
     })
+  }
+
+  let claimUpdatedAt: string | null = null
+  if (mode === "provision") {
+    if (existing?.status === "provisioning") {
+      return errorResponse(
+        ENDPOINT,
+        requestId,
+        apiError({
+          type: "internal_error",
+          code: "TENANT_OVERRIDE_PROVISION_IN_PROGRESS",
+          message: "Tenant override provisioning is already in progress",
+          status: 409,
+          retryable: true,
+        })
+      )
+    }
+
+    const claimStartedAt = new Date().toISOString()
+    const claimPayload = {
+      owner_scope_key: billingState.billing.ownerScopeKey,
+      api_key_hash: identity.apiKeyHash,
+      mapping_source: "override",
+      tenant_id: tenantId,
+      turso_db_url: null,
+      turso_db_token: null,
+      turso_db_name: null,
+      status: "provisioning",
+      metadata: {
+        ...(existing?.metadata ?? {}),
+        ...(metadata ?? {}),
+        provisioningStartedAt: claimStartedAt,
+      },
+      created_by_user_id: identity.userId,
+      billing_owner_type: billingState.billing.ownerType,
+      billing_owner_user_id: billingState.billing.ownerUserId,
+      billing_org_id: billingState.billing.orgId,
+      stripe_customer_id: billingState.billing.stripeCustomerId,
+      updated_at: claimStartedAt,
+      last_verified_at: claimStartedAt,
+    }
+
+    let claimedRow: TenantRow | null = null
+    if (existing) {
+      const { data: claimed, error: claimError } = await admin
+        .from("sdk_tenant_databases")
+        .update(claimPayload)
+        .eq("owner_scope_key", billingState.billing.ownerScopeKey)
+        .eq("tenant_id", tenantId)
+        .eq("updated_at", existing.updated_at)
+        .neq("status", "ready")
+        .select(TENANT_SELECT_FIELDS)
+        .maybeSingle()
+
+      if (claimError) {
+        console.error("Failed to claim tenant override provisioning lock:", claimError)
+        return errorResponse(
+          ENDPOINT,
+          requestId,
+          apiError({
+            type: "internal_error",
+            code: "TENANT_OVERRIDE_CLAIM_FAILED",
+            message: "Failed to start tenant override provisioning",
+            status: 500,
+            retryable: true,
+          })
+        )
+      }
+      claimedRow = (claimed as TenantRow | null) ?? null
+    } else {
+      const { data: claimed, error: claimError } = await admin
+        .from("sdk_tenant_databases")
+        .insert(claimPayload)
+        .select(TENANT_SELECT_FIELDS)
+        .maybeSingle()
+
+      if (claimError) {
+        const conflictCode = typeof claimError === "object" && claimError !== null && "code" in claimError
+          ? String((claimError as { code?: string }).code ?? "")
+          : ""
+        if (conflictCode !== "23505") {
+          console.error("Failed to insert tenant override provisioning claim:", claimError)
+          return errorResponse(
+            ENDPOINT,
+            requestId,
+            apiError({
+              type: "internal_error",
+              code: "TENANT_OVERRIDE_CLAIM_FAILED",
+              message: "Failed to start tenant override provisioning",
+              status: 500,
+              retryable: true,
+            })
+          )
+        }
+      } else {
+        claimedRow = (claimed as TenantRow | null) ?? null
+      }
+    }
+
+    if (!claimedRow) {
+      const { data: latest, error: latestError } = await admin
+        .from("sdk_tenant_databases")
+        .select(TENANT_SELECT_FIELDS)
+        .eq("owner_scope_key", billingState.billing.ownerScopeKey)
+        .eq("tenant_id", tenantId)
+        .maybeSingle()
+
+      if (latestError) {
+        console.error("Failed to resolve latest tenant override after claim conflict:", latestError)
+        return errorResponse(
+          ENDPOINT,
+          requestId,
+          apiError({
+            type: "internal_error",
+            code: "TENANT_OVERRIDE_CLAIM_RESOLVE_FAILED",
+            message: "Failed to resolve tenant override provisioning state",
+            status: 500,
+            retryable: true,
+          })
+        )
+      }
+
+      const latestRow = (latest as TenantRow | null) ?? null
+      if (latestRow?.status === "ready" && latestRow.turso_db_url) {
+        return successResponse(ENDPOINT, requestId, {
+          tenantDatabase: mapTenantRow(latestRow),
+          provisioned: false,
+          mode,
+        })
+      }
+
+      if (latestRow?.status === "provisioning") {
+        return errorResponse(
+          ENDPOINT,
+          requestId,
+          apiError({
+            type: "internal_error",
+            code: "TENANT_OVERRIDE_PROVISION_IN_PROGRESS",
+            message: "Tenant override provisioning is already in progress",
+            status: 409,
+            retryable: true,
+          })
+        )
+      }
+
+      return errorResponse(
+        ENDPOINT,
+        requestId,
+        apiError({
+          type: "internal_error",
+          code: "TENANT_OVERRIDE_CLAIM_RESOLVE_FAILED",
+          message: "Failed to acquire tenant override provisioning lock",
+          status: 500,
+          retryable: true,
+        })
+      )
+    }
+
+    claimUpdatedAt = claimedRow.updated_at
   }
 
   let tursoDbUrl: string
@@ -310,13 +472,60 @@ export async function POST(request: NextRequest): Promise<Response> {
     last_verified_at: now,
   }
 
-  const { data: saved, error: saveError } = await admin
-    .from("sdk_tenant_databases")
-    .upsert(payload, { onConflict: "owner_scope_key,tenant_id" })
-    .select("tenant_id, turso_db_url, turso_db_name, status, mapping_source, metadata, created_at, updated_at, last_verified_at")
-    .single()
+  let saved: TenantRow | null = null
+  let saveError: unknown = null
+  if (mode === "provision" && claimUpdatedAt) {
+    const finalize = await admin
+      .from("sdk_tenant_databases")
+      .update(payload)
+      .eq("owner_scope_key", billingState.billing.ownerScopeKey)
+      .eq("tenant_id", tenantId)
+      .eq("status", "provisioning")
+      .eq("updated_at", claimUpdatedAt)
+      .select(TENANT_SELECT_FIELDS)
+      .maybeSingle()
+
+    saved = (finalize.data as TenantRow | null) ?? null
+    saveError = finalize.error
+  } else {
+    const finalize = await admin
+      .from("sdk_tenant_databases")
+      .upsert(payload, { onConflict: "owner_scope_key,tenant_id" })
+      .select(TENANT_SELECT_FIELDS)
+      .single()
+    saved = (finalize.data as TenantRow | null) ?? null
+    saveError = finalize.error
+  }
 
   if (saveError || !saved) {
+    if (!saveError && mode === "provision" && claimUpdatedAt) {
+      const { data: latest, error: latestError } = await admin
+        .from("sdk_tenant_databases")
+        .select(TENANT_SELECT_FIELDS)
+        .eq("owner_scope_key", billingState.billing.ownerScopeKey)
+        .eq("tenant_id", tenantId)
+        .maybeSingle()
+
+      if (!latestError && latest) {
+        const latestRow = latest as TenantRow
+        if (latestRow.status === "ready" && latestRow.turso_db_url) {
+          if (provisionedDbName) {
+            try {
+              await deleteDatabase(TURSO_ORG, provisionedDbName)
+            } catch (cleanupError) {
+              console.error("Failed to cleanup duplicate tenant override database after lost claim:", cleanupError)
+            }
+          }
+
+          return successResponse(ENDPOINT, requestId, {
+            tenantDatabase: mapTenantRow(latestRow),
+            provisioned: false,
+            mode,
+          })
+        }
+      }
+    }
+
     console.error("Failed to save tenant override mapping:", saveError)
     if (provisionedDbName) {
       try {

--- a/packages/web/src/app/api/stripe/checkout/route.ts
+++ b/packages/web/src/app/api/stripe/checkout/route.ts
@@ -138,7 +138,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const parsed = parseBody(checkoutSchema, await request.json().catch(() => ({})))
   if (!parsed.success) return parsed.response
-  const { billing } = parsed.data
+  const { billing, requestId } = parsed.data
 
   const defaultPlan: StripeCheckoutPlan = workspace.ownerType === "organization" ? "team" : "individual"
   const requestedPlan = parsed.data.plan ?? defaultPlan
@@ -228,7 +228,11 @@ export async function POST(request: Request): Promise<Response> {
     }
     sessionPayload.subscription_data = { metadata: subscriptionMetadata }
 
-    const session = await getStripe().checkout.sessions.create(sessionPayload)
+    const session = requestId
+      ? await getStripe().checkout.sessions.create(sessionPayload, {
+          idempotencyKey: `checkout_${auth.userId}_${requestId}`,
+        })
+      : await getStripe().checkout.sessions.create(sessionPayload)
 
     return NextResponse.json({ url: session.url })
   } catch (error) {

--- a/packages/web/src/app/app/billing/billing-content.tsx
+++ b/packages/web/src/app/app/billing/billing-content.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import {
@@ -110,6 +110,7 @@ export function BillingContent({
   const [deleteConfirmText, setDeleteConfirmText] = useState("")
   const [deleting, setDeleting] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const checkoutInFlightRef = useRef(false)
   const isPaidPlan = isPaidWorkspacePlan(plan)
   const isPastDue = plan === "past_due"
   const isOrgWorkspace = ownerType === "organization"
@@ -171,10 +172,12 @@ export function BillingContent({
   }
 
   async function handleUpgrade(planChoice: "individual" | "team" | "growth", billing: "monthly" | "annual") {
-    if (!canManageBilling) return
+    if (!canManageBilling || checkoutInFlightRef.current) return
 
+    checkoutInFlightRef.current = true
     setLoading(true)
     setActionError(null)
+    const requestId = crypto.randomUUID()
     const startedAt = performance.now()
     recordClientWorkflowEvent({
       workflow: "billing_checkout",
@@ -185,7 +188,7 @@ export function BillingContent({
       const res = await fetch("/api/stripe/checkout", { 
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ billing, plan: planChoice }),
+        body: JSON.stringify({ billing, plan: planChoice, requestId }),
       })
       const data = await res.json().catch(() => null)
       if (!res.ok) {
@@ -219,6 +222,7 @@ export function BillingContent({
         details: { billing, plan: planChoice },
       })
     } finally {
+      checkoutInFlightRef.current = false
       setLoading(false)
     }
   }

--- a/packages/web/src/app/app/team/team-content.tsx
+++ b/packages/web/src/app/app/team/team-content.tsx
@@ -96,6 +96,7 @@ export function TeamContent({
   const [createError, setCreateError] = useState<string | null>(null)
   const [newOrgName, setNewOrgName] = useState("")
   const isMountedRef = useRef(true)
+  const selectedOrgIdRef = useRef<string | null>(selectedOrgId)
   const orgDataRequestIdRef = useRef(0)
 
   useEffect(() => {
@@ -103,6 +104,10 @@ export function TeamContent({
       isMountedRef.current = false
     }
   }, [])
+
+  useEffect(() => {
+    selectedOrgIdRef.current = selectedOrgId
+  }, [selectedOrgId])
 
   useEffect(() => {
     if (!currentOrgId) {
@@ -202,7 +207,7 @@ export function TeamContent({
     const includeCaptureSettings = options?.includeCaptureSettings ?? false
     const requestId = ++orgDataRequestIdRef.current
     const shouldIgnore = () =>
-      !isMountedRef.current || requestId !== orgDataRequestIdRef.current
+      !isMountedRef.current || requestId !== orgDataRequestIdRef.current || selectedOrgIdRef.current !== orgId
 
     setLoading(true)
     try {
@@ -436,9 +441,12 @@ export function TeamContent({
     }
   }
 
-  async function requestMemberRemoval(memberUserId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  async function requestMemberRemoval(
+    memberUserId: string,
+    orgId: string
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
     try {
-      const res = await fetch(`/api/orgs/${selectedOrgId}/members?userId=${memberUserId}`, {
+      const res = await fetch(`/api/orgs/${orgId}/members?userId=${memberUserId}`, {
         method: "DELETE",
       })
 
@@ -459,40 +467,48 @@ export function TeamContent({
   }
 
   async function revokeInvite(inviteId: string) {
+    const orgId = selectedOrgId
+    if (!orgId) return
+    const includeAudit = isAdmin
     try {
-      await fetch(`/api/orgs/${selectedOrgId}/invites?inviteId=${inviteId}`, {
+      await fetch(`/api/orgs/${orgId}/invites?inviteId=${inviteId}`, {
         method: "DELETE",
       })
-      if (selectedOrgId) fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: isAdmin })
+      if (selectedOrgIdRef.current !== orgId) return
+      await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: includeAudit })
     } catch (e) {
       console.error(e)
     }
   }
 
   async function removeMember(memberUserId: string) {
+    const orgId = selectedOrgId
+    if (!orgId) return
+    const includeAudit = isAdmin
     if (!confirm("Are you sure you want to remove this member?")) return
 
     setMemberActionError(null)
     setMemberActionSuccess(null)
-    const result = await requestMemberRemoval(memberUserId)
+    const result = await requestMemberRemoval(memberUserId, orgId)
     if (!result.ok) {
+      if (selectedOrgIdRef.current !== orgId) return
       setMemberActionError(result.error)
       return
     }
 
+    if (selectedOrgIdRef.current !== orgId) return
     setSelectedMemberUserIds((previous) => previous.filter((id) => id !== memberUserId))
     setMemberActionSuccess("Member removed.")
-    if (selectedOrgId) {
-      fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: isAdmin })
-    }
+    await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: includeAudit })
   }
 
   async function requestRoleUpdate(
     memberUserId: string,
-    newRole: "member" | "admin"
+    newRole: "member" | "admin",
+    orgId: string
   ): Promise<{ ok: true } | { ok: false; error: string }> {
     try {
-      const res = await fetch(`/api/orgs/${selectedOrgId}/members`, {
+      const res = await fetch(`/api/orgs/${orgId}/members`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ userId: memberUserId, role: newRole }),
@@ -515,18 +531,21 @@ export function TeamContent({
   }
 
   async function updateRole(memberUserId: string, newRole: "member" | "admin") {
+    const orgId = selectedOrgId
+    if (!orgId) return
+    const includeAudit = isAdmin
     setMemberActionError(null)
     setMemberActionSuccess(null)
-    const result = await requestRoleUpdate(memberUserId, newRole)
+    const result = await requestRoleUpdate(memberUserId, newRole, orgId)
     if (!result.ok) {
+      if (selectedOrgIdRef.current !== orgId) return
       setMemberActionError(result.error)
       return
     }
 
+    if (selectedOrgIdRef.current !== orgId) return
     setMemberActionSuccess("Member role updated.")
-    if (selectedOrgId) {
-      fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: isAdmin })
-    }
+    await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: includeAudit })
   }
 
   function toggleMemberSelection(memberUserId: string) {
@@ -554,11 +573,14 @@ export function TeamContent({
   }
 
   async function applyBulkRoleChange() {
-    if (!isOwner || selectedManageableMemberIds.length === 0) return
+    const orgId = selectedOrgId
+    const includeAudit = isAdmin
+    const memberIds = [...selectedManageableMemberIds]
+    if (!orgId || !isOwner || memberIds.length === 0) return
     if (
       !confirm(
-        `Change role to ${bulkRoleValue} for ${selectedManageableMemberIds.length} selected member${
-          selectedManageableMemberIds.length === 1 ? "" : "s"
+        `Change role to ${bulkRoleValue} for ${memberIds.length} selected member${
+          memberIds.length === 1 ? "" : "s"
         }?`
       )
     ) {
@@ -568,42 +590,46 @@ export function TeamContent({
     setBulkActionInFlight(true)
     setMemberActionError(null)
     setMemberActionSuccess(null)
+    try {
+      let failures = 0
+      let firstError: string | null = null
 
-    let failures = 0
-    let firstError: string | null = null
-
-    for (const memberUserId of selectedManageableMemberIds) {
-      const result = await requestRoleUpdate(memberUserId, bulkRoleValue)
-      if (!result.ok) {
-        failures += 1
-        firstError = firstError ?? result.error
+      for (const memberUserId of memberIds) {
+        const result = await requestRoleUpdate(memberUserId, bulkRoleValue, orgId)
+        if (!result.ok) {
+          failures += 1
+          firstError = firstError ?? result.error
+        }
       }
-    }
 
-    if (selectedOrgId) {
-      await fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: isAdmin })
-    }
-    setSelectedMemberUserIds([])
-    setBulkActionInFlight(false)
+      if (selectedOrgIdRef.current !== orgId) return
+      await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: includeAudit })
+      setSelectedMemberUserIds([])
 
-    const successCount = selectedManageableMemberIds.length - failures
-    if (failures > 0) {
-      setMemberActionError(
-        `${firstError ?? "Some role updates failed"}. Updated ${successCount} of ${selectedManageableMemberIds.length}.`
+      const successCount = memberIds.length - failures
+      if (failures > 0) {
+        setMemberActionError(
+          `${firstError ?? "Some role updates failed"}. Updated ${successCount} of ${memberIds.length}.`
+        )
+        return
+      }
+      setMemberActionSuccess(
+        `Updated role for ${successCount} member${successCount === 1 ? "" : "s"}.`
       )
-      return
+    } finally {
+      setBulkActionInFlight(false)
     }
-    setMemberActionSuccess(
-      `Updated role for ${successCount} member${successCount === 1 ? "" : "s"}.`
-    )
   }
 
   async function removeSelectedMembers() {
-    if (!isAdmin || selectedManageableMemberIds.length === 0) return
+    const orgId = selectedOrgId
+    const includeAudit = isAdmin
+    const memberIds = [...selectedManageableMemberIds]
+    if (!orgId || !isAdmin || memberIds.length === 0) return
     if (
       !confirm(
-        `Remove ${selectedManageableMemberIds.length} selected member${
-          selectedManageableMemberIds.length === 1 ? "" : "s"
+        `Remove ${memberIds.length} selected member${
+          memberIds.length === 1 ? "" : "s"
         }?`
       )
     ) {
@@ -613,38 +639,41 @@ export function TeamContent({
     setBulkActionInFlight(true)
     setMemberActionError(null)
     setMemberActionSuccess(null)
+    try {
+      let failures = 0
+      let firstError: string | null = null
 
-    let failures = 0
-    let firstError: string | null = null
-
-    for (const memberUserId of selectedManageableMemberIds) {
-      const result = await requestMemberRemoval(memberUserId)
-      if (!result.ok) {
-        failures += 1
-        firstError = firstError ?? result.error
+      for (const memberUserId of memberIds) {
+        const result = await requestMemberRemoval(memberUserId, orgId)
+        if (!result.ok) {
+          failures += 1
+          firstError = firstError ?? result.error
+        }
       }
-    }
 
-    if (selectedOrgId) {
-      await fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: isAdmin })
-    }
-    setSelectedMemberUserIds([])
-    setBulkActionInFlight(false)
+      if (selectedOrgIdRef.current !== orgId) return
+      await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: includeAudit })
+      setSelectedMemberUserIds([])
 
-    const successCount = selectedManageableMemberIds.length - failures
-    if (failures > 0) {
-      setMemberActionError(
-        `${firstError ?? "Some members could not be removed"}. Removed ${successCount} of ${selectedManageableMemberIds.length}.`
+      const successCount = memberIds.length - failures
+      if (failures > 0) {
+        setMemberActionError(
+          `${firstError ?? "Some members could not be removed"}. Removed ${successCount} of ${memberIds.length}.`
+        )
+        return
+      }
+      setMemberActionSuccess(
+        `Removed ${successCount} member${successCount === 1 ? "" : "s"}.`
       )
-      return
+    } finally {
+      setBulkActionInFlight(false)
     }
-    setMemberActionSuccess(
-      `Removed ${successCount} member${successCount === 1 ? "" : "s"}.`
-    )
   }
 
   async function saveDomainAutoJoinSettings() {
     if (!selectedOrgId || !selectedOrgRecord) return
+    const orgId = selectedOrgId
+    const includeAudit = isAdmin
 
     const nextDomain = domainAutoJoinDomain.trim()
     const currentDomain = (selectedOrgRecord.domain_auto_join_domain ?? "").trim().toLowerCase()
@@ -663,7 +692,7 @@ export function TeamContent({
     setDomainSettingsUpgradeUrl(null)
 
     try {
-      const res = await fetch(`/api/orgs/${selectedOrgId}`, {
+      const res = await fetch(`/api/orgs/${orgId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -674,6 +703,7 @@ export function TeamContent({
 
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
+        if (selectedOrgIdRef.current !== orgId) return
         setDomainSettingsError(data.error || "Failed to update domain auto-join settings")
         if (res.status === 402 && typeof data.upgradeUrl === "string") {
           setDomainSettingsUpgradeUrl(data.upgradeUrl)
@@ -681,15 +711,15 @@ export function TeamContent({
         return
       }
 
+      if (selectedOrgIdRef.current !== orgId) return
       setOrgDetails(data.organization ?? null)
       setDomainAutoJoinEnabled(Boolean(data.organization?.domain_auto_join_enabled ?? nextEnabled))
       setDomainAutoJoinDomain(data.organization?.domain_auto_join_domain ?? (nextDomain || ""))
       setDomainSettingsSuccess("Domain auto-join settings updated.")
-      if (selectedOrgId) {
-        fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: isAdmin })
-      }
+      await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: includeAudit })
     } catch (error) {
       console.error("Failed to update domain auto-join settings:", error)
+      if (selectedOrgIdRef.current !== orgId) return
       setDomainSettingsError("Failed to update settings. Please try again.")
     } finally {
       setSavingDomainSettings(false)
@@ -706,6 +736,8 @@ export function TeamContent({
 
   async function saveGithubCaptureSettings() {
     if (!selectedOrgId || !isAdmin) return
+    const orgId = selectedOrgId
+    const includeAudit = isAdmin
     if (allowedEvents.length === 0) {
       setCaptureSettingsError("Select at least one event type to capture.")
       return
@@ -716,7 +748,7 @@ export function TeamContent({
     setCaptureSettingsSuccess(null)
 
     try {
-      const response = await fetch(`/api/orgs/${selectedOrgId}/github-capture/settings`, {
+      const response = await fetch(`/api/orgs/${orgId}/github-capture/settings`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -732,15 +764,18 @@ export function TeamContent({
 
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
+        if (selectedOrgIdRef.current !== orgId) return
         setCaptureSettingsError(data.error || "Failed to save GitHub capture settings")
         return
       }
 
+      if (selectedOrgIdRef.current !== orgId) return
       setCaptureSettings(data.settings ?? null)
       setCaptureSettingsSuccess("GitHub capture policy updated.")
-      fetchOrgData(selectedOrgId, { includeAudit: isAdmin, includeCaptureSettings: true })
+      await fetchOrgData(orgId, { includeAudit, includeCaptureSettings: true })
     } catch (error) {
       console.error("Failed to update GitHub capture settings:", error)
+      if (selectedOrgIdRef.current !== orgId) return
       setCaptureSettingsError("Failed to save GitHub capture settings")
     } finally {
       setSavingCaptureSettings(false)

--- a/packages/web/src/app/app/upgrade/upgrade-card.tsx
+++ b/packages/web/src/app/app/upgrade/upgrade-card.tsx
@@ -82,17 +82,22 @@ export function UpgradeCard({
   const [billing, setBilling] = useState<BillingInterval>(defaultBilling)
   const [loading, setLoading] = useState(false)
   const autoCheckoutTriggeredRef = useRef(false)
+  const checkoutInFlightRef = useRef(false)
 
   const config = PLAN_CONFIG[plan]
   const amount = billing === "annual" ? config.annualPrice : config.monthlyPrice
 
   const handleSubscribe = useCallback(async () => {
+    if (checkoutInFlightRef.current) return
+    checkoutInFlightRef.current = true
     setLoading(true)
+    let redirected = false
     try {
+      const requestId = crypto.randomUUID()
       const res = await fetch("/api/stripe/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ billing, plan }),
+        body: JSON.stringify({ billing, plan, requestId }),
       })
 
       const data = await res.json().catch(() => null)
@@ -110,13 +115,18 @@ export function UpgradeCard({
           : null
 
       if (url) {
+        redirected = true
         window.location.href = url
       } else {
         throw new Error("Checkout URL was not returned")
       }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to start checkout. Please try again.")
-      setLoading(false)
+    } finally {
+      checkoutInFlightRef.current = false
+      if (!redirected) {
+        setLoading(false)
+      }
     }
   }, [billing, plan])
 

--- a/packages/web/src/components/dashboard/ApiKeySection.tsx
+++ b/packages/web/src/components/dashboard/ApiKeySection.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState, useEffect, useCallback, useRef } from "react"
 import { Copy, RefreshCw, Trash2, Key, Eye, EyeOff, Check } from "lucide-react"
 import { TenantDatabaseMappingsSection } from "@/components/dashboard/TenantDatabaseMappingsSection"
 import { extractErrorMessage } from "@/lib/client-errors"
@@ -86,14 +86,33 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
   const [copiedEndpoint, setCopiedEndpoint] = useState(false)
   const [copiedHeader, setCopiedHeader] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const keysRef = useRef<ApiKeySummary[]>([])
+  const keyFetchRequestIdRef = useRef(0)
+  const keyMutationInFlightRef = useRef(false)
+
+  const applyKeySummaries = useCallback((nextKeys: ApiKeySummary[]) => {
+    keysRef.current = nextKeys
+    setKeys(nextKeys)
+    const nextPrimary = nextKeys.find((item) => !item.isExpired) ?? nextKeys[0] ?? null
+    setActiveKeyCount(nextKeys.filter((item) => !item.isExpired).length)
+    setHasKey(nextKeys.length > 0)
+    setKeyPreview(nextPrimary?.keyPreview ?? null)
+    setCreatedAt(nextPrimary?.createdAt ?? null)
+    setExpiresAt(nextPrimary?.expiresAt ?? null)
+    setIsExpired(nextPrimary?.isExpired ?? false)
+  }, [])
 
   const fetchKey = useCallback(async () => {
+    const requestId = ++keyFetchRequestIdRef.current
     try {
       setError(null)
       const res = await fetch("/api/mcp/key")
       const payload = await res.json().catch(() => null)
       if (!res.ok) {
         throw new Error(extractErrorMessage(payload, `Failed to fetch API key metadata (HTTP ${res.status})`))
+      }
+      if (requestId !== keyFetchRequestIdRef.current || keyMutationInFlightRef.current) {
+        return
       }
 
       const data = (payload ?? {}) as KeyMetadataResponse
@@ -120,34 +139,43 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
           ? parsedKeys.filter((item) => !item.isExpired).length
           : (data.activeKeyCount ?? (data.hasKey && !data.isExpired ? 1 : 0))
 
-      setHasKey(computedHasKey)
-      setKeys(parsedKeys)
-      setActiveKeyCount(computedActiveCount)
-      setKeyPreview(data.keyPreview || primaryKey?.keyPreview || null)
-      setCreatedAt(data.createdAt || primaryKey?.createdAt || null)
-      setExpiresAt(data.expiresAt || primaryKey?.expiresAt || null)
-      setIsExpired(
-        primaryKey
-          ? primaryKey.isExpired
-          : Boolean(data.isExpired)
-      )
+      if (parsedKeys.length > 0) {
+        applyKeySummaries(parsedKeys)
+      } else {
+        keysRef.current = []
+        setKeys([])
+        setHasKey(computedHasKey)
+        setActiveKeyCount(computedActiveCount)
+        setKeyPreview(data.keyPreview || primaryKey?.keyPreview || null)
+        setCreatedAt(data.createdAt || primaryKey?.createdAt || null)
+        setExpiresAt(data.expiresAt || primaryKey?.expiresAt || null)
+        setIsExpired(
+          primaryKey
+            ? primaryKey.isExpired
+            : Boolean(data.isExpired)
+        )
+      }
       setApiKey(null)
       setShowKey(false)
       setGeneratedKeyId(null)
       setExpiryInput(isoToLocalInputValue((data.expiresAt || primaryKey?.expiresAt) ?? null))
     } catch (err) {
+      if (requestId !== keyFetchRequestIdRef.current) return
       console.error("Failed to fetch API key:", err)
       setError("Failed to fetch API key metadata")
     } finally {
-      setLoading(false)
+      if (requestId === keyFetchRequestIdRef.current) {
+        setLoading(false)
+      }
     }
-  }, [])
+  }, [applyKeySummaries])
 
   useEffect(() => {
     void fetchKey()
   }, [fetchKey])
 
   async function generateKey() {
+    if (keyMutationInFlightRef.current) return
     if (!expiryInput) {
       setError("Select an expiry date and time.")
       return
@@ -159,6 +187,8 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
       return
     }
 
+    keyMutationInFlightRef.current = true
+    keyFetchRequestIdRef.current += 1
     setLoading(true)
     const startedAt = performance.now()
     recordClientWorkflowEvent({
@@ -203,17 +233,11 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
           expiresAt: nextExpiresAt,
           isExpired: false,
         }
-        const nextKeys = [nextSummary, ...keys.filter((item) => item.id !== nextSummary.id)]
+        const nextKeys = [nextSummary, ...keysRef.current.filter((item) => item.id !== nextSummary.id)]
         setApiKey(data.apiKey)
         setShowKey(true)
         setGeneratedKeyId(nextKeyId)
-        setHasKey(true)
-        setKeys(nextKeys)
-        setActiveKeyCount(nextKeys.filter((item) => !item.isExpired).length)
-        setKeyPreview(nextSummary.keyPreview)
-        setCreatedAt(nextCreatedAt)
-        setExpiresAt(nextExpiresAt)
-        setIsExpired(false)
+        applyKeySummaries(nextKeys)
       }
       recordClientWorkflowEvent({
         workflow: "api_key_generate",
@@ -231,17 +255,21 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
         message,
       })
     } finally {
+      keyMutationInFlightRef.current = false
       setLoading(false)
     }
   }
 
   async function revokeKey(keyId?: string) {
+    if (keyMutationInFlightRef.current) return
     const isSingleKeyRevoke = typeof keyId === "string" && keyId.length > 0
     if (!confirm(isSingleKeyRevoke
       ? "Revoke this API key? Any client using it will stop working."
       : "Revoke all API keys? Any tools using them will stop working.")) {
       return
     }
+    keyMutationInFlightRef.current = true
+    keyFetchRequestIdRef.current += 1
     setLoading(true)
     const startedAt = performance.now()
     recordClientWorkflowEvent({
@@ -260,23 +288,17 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
       }
 
       if (isSingleKeyRevoke) {
-        const nextKeys = keys.filter((item) => item.id !== keyId)
-        const nextPrimary = nextKeys.find((item) => !item.isExpired) ?? nextKeys[0] ?? null
+        const nextKeys = keysRef.current.filter((item) => item.id !== keyId)
         if (generatedKeyId === keyId) {
           setApiKey(null)
           setShowKey(false)
           setGeneratedKeyId(null)
         }
-        setKeys(nextKeys)
-        setActiveKeyCount(nextKeys.filter((item) => !item.isExpired).length)
-        setHasKey(nextKeys.length > 0)
-        setKeyPreview(nextPrimary?.keyPreview ?? null)
-        setCreatedAt(nextPrimary?.createdAt ?? null)
-        setExpiresAt(nextPrimary?.expiresAt ?? null)
-        setIsExpired(nextPrimary?.isExpired ?? false)
+        applyKeySummaries(nextKeys)
       } else {
         setApiKey(null)
         setGeneratedKeyId(null)
+        keysRef.current = []
         setHasKey(false)
         setKeys([])
         setActiveKeyCount(0)
@@ -304,6 +326,7 @@ export function ApiKeySection({ workspacePlan }: ApiKeySectionProps): React.JSX.
         message,
       })
     } finally {
+      keyMutationInFlightRef.current = false
       setLoading(false)
     }
   }

--- a/packages/web/src/components/dashboard/MemoriesList.tsx
+++ b/packages/web/src/components/dashboard/MemoriesList.tsx
@@ -12,15 +12,15 @@ export function MemoriesList({
 }: {
   memories: Memory[]
   onDeleteMemory?: (id: string) => void
-  onUpdateMemory?: (id: string, content: string) => void
+  onUpdateMemory?: (id: string, content: string, updatedAt: string) => void
   onFilterByProject?: (scope: string) => void
 }): React.JSX.Element | null {
   const handleDelete = (id: string) => {
     onDeleteMemory?.(id)
   }
 
-  const handleUpdate = (id: string, content: string) => {
-    onUpdateMemory?.(id, content)
+  const handleUpdate = (id: string, content: string, updatedAt: string) => {
+    onUpdateMemory?.(id, content, updatedAt)
   }
 
   if (memories.length === 0) {

--- a/packages/web/src/components/dashboard/MemoriesSection.tsx
+++ b/packages/web/src/components/dashboard/MemoriesSection.tsx
@@ -95,9 +95,9 @@ export function MemoriesSection({
     setMemories((prev) => prev.filter((memory) => memory.id !== id))
   }
 
-  const handleUpdateMemory = (id: string, content: string) => {
+  const handleUpdateMemory = (id: string, content: string, updatedAt: string) => {
     setMemories((prev) =>
-      prev.map((memory) => (memory.id === id ? { ...memory, content } : memory))
+      prev.map((memory) => (memory.id === id ? { ...memory, content, updated_at: updatedAt } : memory))
     )
   }
 

--- a/packages/web/src/components/dashboard/MemoryCard.tsx
+++ b/packages/web/src/components/dashboard/MemoryCard.tsx
@@ -12,7 +12,7 @@ export function MemoryCard({
 }: {
   memory: Memory
   onDelete: (id: string) => void
-  onUpdate: (id: string, content: string) => void
+  onUpdate: (id: string, content: string, updatedAt: string) => void
   onFilterByProject?: (scope: string) => void
 }): React.JSX.Element {
   const [isDeleting, setIsDeleting] = useState(false)
@@ -20,6 +20,7 @@ export function MemoryCard({
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState(memory.content)
   const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   const handleDelete = async () => {
     setIsDeleting(true)
@@ -42,19 +43,38 @@ export function MemoryCard({
     if (!editContent.trim() || editContent === memory.content) {
       setIsEditing(false)
       setEditContent(memory.content)
+      setSaveError(null)
       return
     }
 
+    setSaveError(null)
     setIsSaving(true)
     try {
       const res = await fetch("/api/memories", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: memory.id, content: editContent.trim() }),
+        body: JSON.stringify({
+          id: memory.id,
+          content: editContent.trim(),
+          expectedUpdatedAt: memory.updated_at,
+        }),
       })
+      const data = await res.json().catch(() => ({}))
       if (res.ok) {
-        onUpdate(memory.id, editContent.trim())
+        const updatedAt =
+          data && typeof data === "object" && "updatedAt" in data && typeof data.updatedAt === "string"
+            ? data.updatedAt
+            : new Date().toISOString()
+        onUpdate(memory.id, editContent.trim(), updatedAt)
         setIsEditing(false)
+      } else if (res.status === 409) {
+        const message =
+          data && typeof data === "object" && "error" in data && typeof data.error === "string"
+            ? data.error
+            : "This memory changed in another session. Refresh and try again."
+        setSaveError(message)
+      } else {
+        setSaveError("Failed to save memory")
       }
     } finally {
       setIsSaving(false)
@@ -125,6 +145,7 @@ export function MemoryCard({
                 onClick={() => {
                   setIsEditing(false)
                   setEditContent(memory.content)
+                  setSaveError(null)
                 }}
                 className="p-1.5 text-muted-foreground hover:text-foreground transition-all"
                 title="Cancel"
@@ -151,7 +172,10 @@ export function MemoryCard({
           ) : (
             <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-all">
               <button
-                onClick={() => setIsEditing(true)}
+                onClick={() => {
+                  setIsEditing(true)
+                  setSaveError(null)
+                }}
                 className="p-1.5 text-muted-foreground/60 hover:text-primary hover:bg-primary/10 transition-all"
                 title="Edit"
               >
@@ -169,13 +193,16 @@ export function MemoryCard({
         </div>
       </div>
       {isEditing ? (
-        <textarea
-          value={editContent}
-          onChange={(e) => setEditContent(e.target.value)}
-          className="w-full bg-background border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary/50 resize-none"
-          rows={3}
-          autoFocus
-        />
+        <div className="space-y-2">
+          <textarea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            className="w-full bg-background border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary/50 resize-none"
+            rows={3}
+            autoFocus
+          />
+          {saveError ? <p className="text-xs text-red-400">{saveError}</p> : null}
+        </div>
       ) : (
         <p className="text-sm text-foreground/80 leading-relaxed">
           {memory.content}

--- a/packages/web/src/components/dashboard/ProvisioningScreen.tsx
+++ b/packages/web/src/components/dashboard/ProvisioningScreen.tsx
@@ -3,13 +3,35 @@
 import React, { useEffect, useState, useRef } from "react"
 import { useRouter } from "next/navigation"
 
+const PROVISION_REQUEST_ID_STORAGE_KEY = "memories:db-provision:request-id"
+
+function getProvisionRequestId(): string {
+  if (typeof window === "undefined") {
+    return crypto.randomUUID()
+  }
+
+  const existing = window.sessionStorage.getItem(PROVISION_REQUEST_ID_STORAGE_KEY)
+  if (existing) return existing
+
+  const next = crypto.randomUUID()
+  window.sessionStorage.setItem(PROVISION_REQUEST_ID_STORAGE_KEY, next)
+  return next
+}
+
+function clearProvisionRequestId(): void {
+  if (typeof window === "undefined") return
+  window.sessionStorage.removeItem(PROVISION_REQUEST_ID_STORAGE_KEY)
+}
+
 export function ProvisioningScreen(): React.JSX.Element {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
   const provisioningRef = useRef(false)
+  const requestIdRef = useRef<string>(getProvisionRequestId())
 
   useEffect(() => {
     let cancelled = false
+    const controller = new AbortController()
 
     async function provision() {
       // Prevent duplicate calls (React strict mode, fast re-mounts)
@@ -17,16 +39,25 @@ export function ProvisioningScreen(): React.JSX.Element {
       provisioningRef.current = true
 
       try {
-        const res = await fetch("/api/db/provision", { method: "POST" })
+        const res = await fetch("/api/db/provision", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ requestId: requestIdRef.current }),
+          signal: controller.signal,
+        })
         if (!res.ok) {
           const data = await res.json().catch(() => ({}))
           throw new Error(data.error ?? "Provisioning failed")
         }
 
+        clearProvisionRequestId()
         if (!cancelled) {
           router.refresh()
         }
       } catch (err) {
+        if (controller.signal.aborted) {
+          return
+        }
         if (!cancelled) {
           provisioningRef.current = false
           setError(
@@ -40,6 +71,7 @@ export function ProvisioningScreen(): React.JSX.Element {
 
     return () => {
       cancelled = true
+      controller.abort()
     }
   }, [router])
 

--- a/packages/web/src/components/dashboard/RulesSection.tsx
+++ b/packages/web/src/components/dashboard/RulesSection.tsx
@@ -31,8 +31,10 @@ export function RulesSection({ initialRules }: { initialRules: Memory[] }): Reac
     setRules((prev) => prev.filter((rule) => rule.id !== id))
   }
 
-  const handleUpdateRule = (id: string, content: string) => {
-    setRules((prev) => prev.map((rule) => (rule.id === id ? { ...rule, content } : rule)))
+  const handleUpdateRule = (id: string, content: string, updatedAt: string) => {
+    setRules((prev) =>
+      prev.map((rule) => (rule.id === id ? { ...rule, content, updated_at: updatedAt } : rule))
+    )
   }
 
   // Get unique projects with counts (using project_id, not scope)

--- a/packages/web/src/components/dashboard/TenantDatabaseMappingsSection.tsx
+++ b/packages/web/src/components/dashboard/TenantDatabaseMappingsSection.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { AlertTriangle, ChevronDown, ChevronRight, Database, Link2, RefreshCw, Server, Trash2 } from "lucide-react"
 import { extractErrorMessage } from "@/lib/client-errors"
 import { recordClientWorkflowEvent } from "@/lib/client-workflow-debug"
@@ -88,6 +88,8 @@ export function TenantDatabaseMappingsSection({
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const fetchRequestIdRef = useRef(0)
+  const fetchAbortControllerRef = useRef<AbortController | null>(null)
   const isGrowthPlan = workspacePlan === "growth"
 
   const sortedMappings = useMemo(
@@ -97,9 +99,18 @@ export function TenantDatabaseMappingsSection({
 
   const fetchMappings = useCallback(
     async (opts?: { silent?: boolean }) => {
+      const requestId = ++fetchRequestIdRef.current
+      fetchAbortControllerRef.current?.abort()
+      const controller = new AbortController()
+      fetchAbortControllerRef.current = controller
+
       if (!hasApiKey || apiKeyExpired) {
-        setMappings([])
-        setError(null)
+        if (requestId === fetchRequestIdRef.current) {
+          setMappings([])
+          setError(null)
+          setLoading(false)
+          setRefreshing(false)
+        }
         return
       }
 
@@ -111,25 +122,43 @@ export function TenantDatabaseMappingsSection({
 
       try {
         setError(null)
-        const res = await fetch("/api/sdk/v1/management/tenant-overrides")
+        const res = await fetch("/api/sdk/v1/management/tenant-overrides", {
+          signal: controller.signal,
+        })
         const payload = await res.json().catch(() => null)
 
         if (!res.ok) {
           throw new Error(extractErrorMessage(payload, `Failed to load tenant overrides (HTTP ${res.status})`))
         }
 
+        if (requestId !== fetchRequestIdRef.current) return
         const data = ((payload ?? {}) as { data?: TenantListResponse }).data ?? (payload ?? {})
         setMappings(Array.isArray(data.tenantDatabases) ? data.tenantDatabases : [])
       } catch (err) {
+        if (controller.signal.aborted || requestId !== fetchRequestIdRef.current) {
+          return
+        }
         console.error("Failed to fetch tenant overrides:", err)
         setError(err instanceof Error ? err.message : "Failed to load tenant overrides")
       } finally {
-        setLoading(false)
-        setRefreshing(false)
+        if (requestId === fetchRequestIdRef.current) {
+          setLoading(false)
+          setRefreshing(false)
+        }
+        if (fetchAbortControllerRef.current === controller) {
+          fetchAbortControllerRef.current = null
+        }
       }
     },
     [apiKeyExpired, hasApiKey]
   )
+
+  useEffect(() => {
+    return () => {
+      fetchAbortControllerRef.current?.abort()
+      fetchAbortControllerRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     void fetchMappings()

--- a/packages/web/src/lib/validations.ts
+++ b/packages/web/src/lib/validations.ts
@@ -39,6 +39,7 @@ export const createMemorySchema = z.object({
 export const updateMemorySchema = z.object({
   id: z.string().min(1, "Memory ID required"),
   content: z.string().min(1, "Content required").optional(),
+  expectedUpdatedAt: z.string().datetime().optional(),
   tags: z.string().nullable().optional(),
   type: memoryTypeEnum.optional(),
   paths: z.string().nullable().optional(),
@@ -100,6 +101,7 @@ export const acceptInviteSchema = z.object({
 export const checkoutSchema = z.object({
   billing: z.enum(["monthly", "annual"]).catch("annual"),
   plan: z.enum(["individual", "team", "growth"]).optional(),
+  requestId: z.string().uuid().optional(),
 })
 
 // --- User Profile ---


### PR DESCRIPTION
## Summary
This PR fixes all race-condition issues filed in #366-#375 across dashboard UI flows and related APIs.

### Fixed
- Stale org-response races in Team page member/invite/settings flows.
- Bulk Team action stale refresh races after org switch.
- Provisioning duplicate-race handling with compare-and-set credential claim + duplicate DB cleanup.
- Tenant override provisioning TOCTOU with explicit provisioning claim/lock semantics and finalize CAS.
- Tenant mappings stale fetch overwrite race via request sequencing + AbortController.
- API key stale-snapshot state races with mutation single-flight + ref-based reconciliation.
- Checkout duplicate-session race with client single-flight and server idempotency support ().
- Memory lost-update race with optimistic concurrency () and 409 conflict handling.

## Validation
- 
> @memories.sh/web@0.1.0 typecheck /Users/tradecraft/dev/memories/packages/web
> tsc --noEmit
- 
> @memories.sh/web@0.1.0 lint /Users/tradecraft/dev/memories/packages/web
> eslint
- 
> @memories.sh/web@0.1.0 test /Users/tradecraft/dev/memories/packages/web
> vitest run -- src/app/api/memories/__tests__/route.test.ts src/app/api/db/provision/__tests__/route.test.ts src/app/api/stripe/checkout/__tests__/route.test.ts


 RUN  v4.0.18 /Users/tradecraft/dev/memories/packages/web

 ✓ src/lib/memory-service/scope-schema.test.ts (2 tests) 107ms
 ✓ src/lib/memory-service/observability.test.ts (2 tests) 105ms
 ✓ src/lib/memory-service/mutations.embeddings.test.ts (2 tests) 193ms
 ✓ src/lib/memory-service/graph/status.test.ts (5 tests) 110ms
 ✓ src/lib/sdk-embedding-billing.test.ts (4 tests) 166ms
 ✓ src/lib/memory-service/mutations.graph.test.ts (10 tests) 261ms
 ✓ src/app/api/mcp/__tests__/route.test.ts (92 tests) 71ms
 ✓ src/lib/memory-service/queries.semantic.test.ts (5 tests) 330ms
 ✓ src/lib/memory-service/queries.graph.test.ts (4 tests) 267ms
 ✓ src/lib/memory-insight-actions.test.ts (3 tests) 46ms
 ✓ src/lib/memory-service/graph/retrieval.test.ts (5 tests) 46ms
 ✓ src/lib/memory-service/graph/similarity.test.ts (10 tests) 292ms
 ✓ src/lib/memory-service/graph/rollout.plan.test.ts (3 tests) 103ms
 ✓ src/lib/memory-service/graph/upsert.test.ts (6 tests) 102ms
 ✓ src/lib/sdk-embeddings/backfill.test.ts (2 tests) 329ms
 ✓ src/lib/sdk-embeddings/models.test.ts (6 tests) 20ms
 ✓ src/app/api/sdk/v1/context/get/__tests__/parity.test.ts (2 tests) 18ms
 ✓ src/app/api/sdk/v1/context/get/__tests__/route.test.ts (10 tests) 22ms
 ✓ src/lib/memory-service/skill-files.test.ts (4 tests) 442ms
 ✓ src/app/api/user/__tests__/route.test.ts (11 tests) 14ms
 ✓ src/app/api/sdk/v1/graph/__tests__/routes.test.ts (13 tests) 22ms
 ✓ src/lib/sdk-embeddings/observability.test.ts (3 tests) 438ms
 ✓ src/lib/memory-service/sessions.test.ts (4 tests) 44ms
 ✓ src/app/app/team/team-helpers.test.ts (17 tests) 20ms
 ✓ src/app/api/workspace/__tests__/route.test.ts (7 tests) 11ms
 ✓ src/app/api/sdk/v1/memories/__tests__/routes.test.ts (26 tests) 35ms
 ✓ src/lib/memory-service/graph/llm-extract.test.ts (4 tests) 15ms
 ✓ src/app/api/sdk/v1/context/get/__tests__/matrix.test.ts (2 tests) 13ms
 ✓ src/lib/sdk-embeddings/jobs.test.ts (6 tests) 583ms
 ✓ src/app/api/orgs/[orgId]/github-capture/settings/route.test.ts (7 tests) 12ms
 ✓ src/lib/__tests__/auth.test.ts (8 tests) 17ms
 ✓ src/app/api/stripe/webhook/__tests__/route.test.ts (7 tests) 14ms
 ✓ src/app/api/memories/__tests__/route.test.ts (12 tests) 14ms
 ✓ src/app/api/orgs/[orgId]/route.test.ts (11 tests) 14ms
 ✓ src/app/api/sdk/v1/management/tenant-overrides/__tests__/route.test.ts (6 tests) 12ms
 ✓ src/app/api/invites/accept/route.test.ts (2 tests) 12ms
 ✓ src/app/api/docs/raw/route.test.ts (4 tests) 9ms
 ✓ src/app/api/orgs/[orgId]/members/route.test.ts (14 tests) 15ms
 ✓ src/app/api/orgs/[orgId]/invites/route.test.ts (10 tests) 19ms
 ✓ src/app/api/mcp/key/__tests__/route.test.ts (10 tests) 12ms
 ✓ src/app/api/db/credentials/__tests__/route.test.ts (6 tests) 9ms
 ✓ src/app/api/sdk/v1/sessions/__tests__/routes.test.ts (6 tests) 16ms
 ✓ src/app/api/github/capture/queue/[id]/route.test.ts (5 tests) 13ms
 ✓ src/app/api/sdk/v1/management/__tests__/routes.test.ts (8 tests) 14ms
 ✓ src/lib/memory-insights.test.ts (3 tests) 11ms
 ✓ src/app/api/stripe/checkout/__tests__/route.test.ts (7 tests) 11ms
stdout | src/lib/memory-service/scope.test.ts > resolveTenantTurso > stores auto-provisioned mappings with source=auto
[SDK_AUTO_PROVISION] Tenant database ready for tenant_id=tenant-a

 ✓ src/lib/memory-service/scope.test.ts (3 tests) 10ms
 ✓ src/lib/__tests__/validations.test.ts (61 tests) 11ms
 ✓ src/app/api/orgs/__tests__/route.test.ts (10 tests) 12ms
 ✓ src/app/api/auth/cli/__tests__/route.test.ts (7 tests) 13ms
 ✓ src/app/api/github/capture/queue/route.test.ts (3 tests) 8ms
 ✓ src/app/api/github/capture/settings/route.test.ts (4 tests) 12ms
 ✓ src/app/api/orgs/[orgId]/audit/route.test.ts (5 tests) 10ms
 ✓ src/app/api/sdk/v1/management/embeddings/backfill/__tests__/route.test.ts (4 tests) 9ms
 ✓ src/app/api/stripe/portal/__tests__/route.test.ts (6 tests) 8ms
 ✓ src/app/api/account/__tests__/route.test.ts (5 tests) 10ms
 ✓ src/lib/memory-service/types.test.ts (3 tests) 6ms
 ✓ src/app/api/sdk/v1/management/memory/observability/__tests__/route.test.ts (3 tests) 8ms
 ✓ src/lib/memory-service/graph/extract.test.ts (3 tests) 4ms
 ✓ src/lib/__tests__/rate-limit.test.ts (15 tests) 6ms
 ✓ src/lib/github-capture.test.ts (7 tests) 4ms
 ✓ src/app/api/github/webhook/__tests__/route.test.ts (4 tests) 10ms
 ✓ src/lib/memory-service/scope-parsers.test.ts (18 tests) 4ms
 ✓ src/app/api/sdk/v1/management/embeddings/usage/__tests__/route.test.ts (3 tests) 11ms
 ✓ src/app/api/sdk/v1/management/embeddings/observability/__tests__/route.test.ts (3 tests) 7ms
 ✓ src/app/api/sdk/v1/embeddings/models/__tests__/route.test.ts (3 tests) 8ms
 ✓ src/app/api/sdk/v1/management/tenant-routing/effective/__tests__/route.test.ts (5 tests) 14ms
 ✓ src/app/api/workspace/switch-profile/route.test.ts (2 tests) 6ms
 ✓ src/lib/memory-service/eval.test.ts (3 tests) 3ms
 ✓ src/lib/workspace-switch-profiling.test.ts (4 tests) 3ms
 ✓ src/components/dashboard/memory-graph-helpers.test.ts (13 tests) 4ms
 ✓ src/lib/workspace-switch-performance.test.ts (5 tests) 3ms
 ✓ src/lib/__tests__/active-memory-context.test.ts (11 tests) 3ms
 ✓ src/app/api/integration/health/__tests__/route.test.ts (2 tests) 5ms
 ✓ src/lib/graph-url-state.test.ts (5 tests) 3ms
 ✓ src/lib/http-headers.test.ts (5 tests) 3ms
 ✓ src/lib/__tests__/workspace.test.ts (4 tests) 2ms
 ✓ src/components/dashboard/memory-graph-status-client.test.ts (4 tests) 2ms
 ✓ src/lib/__tests__/org-domain.test.ts (5 tests) 2ms
 ✓ src/app/api/sdk/v1/management/memory/eval/replay/__tests__/route.test.ts (3 tests) 7ms
 ✓ src/lib/supabase/middleware.test.ts (1 test) 4ms
 ✓ src/lib/env-memory-flags.test.ts (2 tests) 1ms
 ✓ src/lib/__tests__/domain-auto-join.test.ts (1 test) 1ms
 ✓ src/app/api/db/provision/__tests__/route.test.ts (4 tests) 6020ms
     ✓ allows organization admins to provision  3010ms
     ✓ cleans up Turso DB when credential persistence fails  3005ms

 Test Files  84 passed (84)
      Tests  645 passed (645)
   Start at  12:01:06
   Duration  6.48s (transform 4.06s, setup 846ms, import 9.84s, tests 10.71s, environment 5ms)

Closes #366
Closes #367
Closes #368
Closes #369
Closes #370
Closes #371
Closes #372
Closes #373
Closes #374
Closes #375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches billing checkout idempotency and Turso database provisioning/tenant-override workflows; mistakes here could cause duplicate charges, orphaned DBs, or stuck provisioning states. Adds new CAS/lock semantics and optimistic concurrency paths that need careful review across API+UI.
> 
> **Overview**
> **Hardens Turso provisioning against concurrency.** `POST /api/db/provision` now uses a compare-and-set style credential claim (only writing when `turso_db_url/token` are null) and returns an *already provisioned* response while cleaning up duplicate/orphaned Turso DBs.
> 
> **Makes SDK tenant override provisioning atomic.** `POST /api/sdk/v1/management/tenant-overrides` introduces an explicit `provisioning` claim step (insert/update with `updated_at` CAS), finalizes only if the claim is still held, and resolves conflicts by returning the latest `ready` mapping or `409` when provisioning is in progress; duplicate DB cleanup is added on lost claims.
> 
> **Prevents duplicate Stripe sessions and lost updates in the UI.** Stripe checkout accepts an optional `requestId` (validated in `checkoutSchema`) and uses it as a Stripe idempotency key; billing/upgrade UIs add single-flight guards and pass `requestId`. Memory editing adds `expectedUpdatedAt` optimistic concurrency with `409` conflict responses, updates dashboard components to pass/propagate `updated_at`, and adds UI conflict messaging. Several dashboard screens (`TeamContent`, API key + tenant mappings, provisioning screen) add request sequencing/AbortController and ref-based guards to ignore stale responses after navigation or mutations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a1f9508ef6b474eef661548dbd7edb93d8c9d85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->