### PR TITLE
fix(web): resolve queue decision + invite accept race conditions

### DIFF
--- a/packages/web/src/app/api/github/capture/queue/[id]/route.test.ts
+++ b/packages/web/src/app/api/github/capture/queue/[id]/route.test.ts
@@ -113,8 +113,24 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
   it("rejects pending user queue item", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
 
+    const mockRejectMaybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "q-1", status: "rejected" },
+      error: null,
+    })
+    const mockRejectSelect = vi.fn(() => ({
+      maybeSingle: mockRejectMaybeSingle,
+    }))
+    const mockRejectIs = vi.fn(() => ({
+      select: mockRejectSelect,
+    }))
+    const mockRejectEqStatus = vi.fn(() => ({
+      is: mockRejectIs,
+    }))
+    const mockRejectEqId = vi.fn(() => ({
+      eq: mockRejectEqStatus,
+    }))
     const mockUpdate = vi.fn(() => ({
-      eq: vi.fn().mockResolvedValue({ error: null }),
+      eq: mockRejectEqId,
     }))
 
     let githubQueueReadUsed = false
@@ -141,6 +157,8 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
                   title: "Issue",
                   content: "Issue content",
                   source_url: "https://github.com/webrenew/memories/issues/2",
+                  approved_memory_id: null,
+                  reviewed_at: null,
                   metadata: {},
                 },
                 error: null,
@@ -178,15 +196,32 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
         decision_note: "noise",
       })
     )
+    expect(mockRejectEqId).toHaveBeenCalledWith("id", "q-1")
+    expect(mockRejectEqStatus).toHaveBeenCalledWith("status", "pending")
+    expect(mockRejectIs).toHaveBeenCalledWith("approved_memory_id", null)
   })
 
   it("returns 500 with stable error when reject update fails", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
 
+    const mockRejectMaybeSingle = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "db timeout" },
+    })
+    const mockRejectSelect = vi.fn(() => ({
+      maybeSingle: mockRejectMaybeSingle,
+    }))
+    const mockRejectIs = vi.fn(() => ({
+      select: mockRejectSelect,
+    }))
+    const mockRejectEqStatus = vi.fn(() => ({
+      is: mockRejectIs,
+    }))
+    const mockRejectEqId = vi.fn(() => ({
+      eq: mockRejectEqStatus,
+    }))
     const mockUpdate = vi.fn(() => ({
-      eq: vi.fn().mockResolvedValue({
-        error: { message: "db timeout" },
-      }),
+      eq: mockRejectEqId,
     }))
 
     let githubQueueReadUsed = false
@@ -213,6 +248,8 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
                   title: "Issue",
                   content: "Issue content",
                   source_url: "https://github.com/webrenew/memories/issues/2",
+                  approved_memory_id: null,
+                  reviewed_at: null,
                   metadata: {},
                 },
                 error: null,
@@ -250,6 +287,7 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
 
     let githubQueueReadUsed = false
+    let githubQueueUpdateCount = 0
 
     mockFrom.mockImplementation((table: string) => {
       if (table === "github_capture_queue" && !githubQueueReadUsed) {
@@ -273,6 +311,8 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
                   title: "Issue",
                   content: "Issue content",
                   source_url: "https://github.com/webrenew/memories/issues/2",
+                  approved_memory_id: null,
+                  reviewed_at: null,
                   metadata: {},
                 },
                 error: null,
@@ -300,11 +340,40 @@ describe("/api/github/capture/queue/[id] PATCH", () => {
       }
 
       if (table === "github_capture_queue") {
+        githubQueueUpdateCount += 1
+        if (githubQueueUpdateCount === 1) {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  is: vi.fn(() => ({
+                    select: vi.fn(() => ({
+                      maybeSingle: vi.fn().mockResolvedValue({
+                        data: { id: "q-1" },
+                        error: null,
+                      }),
+                    })),
+                  })),
+                })),
+              })),
+            })),
+          }
+        }
+
         return {
           update: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              error: { message: "update failed" },
-            }),
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  select: vi.fn(() => ({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: null,
+                      error: { message: "update failed" },
+                    }),
+                  })),
+                })),
+              })),
+            })),
           })),
         }
       }

--- a/packages/web/src/app/api/github/capture/queue/[id]/route.ts
+++ b/packages/web/src/app/api/github/capture/queue/[id]/route.ts
@@ -7,6 +7,9 @@ import { parseBody, githubCaptureDecisionSchema } from "@/lib/validations"
 import { addMemoryPayload } from "@/lib/memory-service/mutations"
 import { ensureMemoryUserIdSchema } from "@/lib/memory-service/tools"
 
+const APPROVAL_LOCK_PREFIX = "__approval_lock__:"
+const APPROVAL_LOCK_STALE_MS = 10 * 60 * 1000
+
 interface QueueItemRow {
   id: string
   target_owner_type: "user" | "organization"
@@ -22,6 +25,8 @@ interface QueueItemRow {
   title: string | null
   content: string
   source_url: string | null
+  approved_memory_id: string | null
+  reviewed_at: string | null
   metadata: Record<string, unknown> | null
 }
 
@@ -46,6 +51,21 @@ function memoryTypeForEvent(event: QueueItemRow["source_event"]): "rule" | "deci
   return "note"
 }
 
+function buildApprovalLockToken(userId: string): string {
+  return `${APPROVAL_LOCK_PREFIX}${userId}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 10)}`
+}
+
+function isApprovalLockToken(value: string | null): value is string {
+  return typeof value === "string" && value.startsWith(APPROVAL_LOCK_PREFIX)
+}
+
+function isStaleApprovalLock(reviewedAt: string | null): boolean {
+  if (!reviewedAt) return false
+  const reviewedAtMs = Date.parse(reviewedAt)
+  if (!Number.isFinite(reviewedAtMs)) return true
+  return reviewedAtMs <= Date.now() - APPROVAL_LOCK_STALE_MS
+}
+
 async function fetchQueueItem(
   admin: ReturnType<typeof createAdminClient>,
   queueId: string
@@ -53,7 +73,7 @@ async function fetchQueueItem(
   const { data, error } = await admin
     .from("github_capture_queue")
     .select(
-      "id, target_owner_type, target_user_id, target_org_id, status, source_event, source_action, repo_full_name, project_id, actor_login, source_id, title, content, source_url, metadata"
+      "id, target_owner_type, target_user_id, target_org_id, status, source_event, source_action, repo_full_name, project_id, actor_login, source_id, title, content, source_url, approved_memory_id, reviewed_at, metadata"
     )
     .eq("id", queueId)
     .single()
@@ -160,7 +180,7 @@ export async function PATCH(
   const nowIso = new Date().toISOString()
 
   if (parsed.data.action === "reject") {
-    const { error } = await admin
+    const rejectResponse = await admin
       .from("github_capture_queue")
       .update({
         status: "rejected",
@@ -169,14 +189,41 @@ export async function PATCH(
         decision_note: parsed.data.note ?? null,
       })
       .eq("id", id)
+      .eq("status", "pending")
+      .is("approved_memory_id", null)
+      .select("id, status")
+      .maybeSingle()
 
-    if (error) {
+    if (rejectResponse.error) {
       console.error("Failed to reject capture queue item:", {
         queueId: id,
         reviewerUserId: user.id,
-        error,
+        error: rejectResponse.error,
       })
       return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+    }
+
+    if (!rejectResponse.data) {
+      const { item: latestItem, error: latestError } = await fetchQueueItem(admin, id)
+      if (latestError) {
+        console.error("Failed to read latest capture queue item after reject conflict:", {
+          queueId: id,
+          reviewerUserId: user.id,
+          error: latestError,
+        })
+        return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+      }
+
+      if (!latestItem) {
+        return NextResponse.json({ error: "Capture queue item not found" }, { status: 404 })
+      }
+
+      return NextResponse.json(
+        {
+          error: `Capture queue item is already ${latestItem.status}`,
+        },
+        { status: 409 }
+      )
     }
 
     return NextResponse.json({ ok: true, status: "rejected" })
@@ -191,8 +238,100 @@ export async function PATCH(
     )
   }
 
+  if (isApprovalLockToken(item.approved_memory_id) && !isStaleApprovalLock(item.reviewed_at)) {
+    return NextResponse.json(
+      {
+        error: "Capture queue item is currently being approved",
+      },
+      { status: 409 }
+    )
+  }
+
+  if (isApprovalLockToken(item.approved_memory_id) && isStaleApprovalLock(item.reviewed_at)) {
+    const staleLockRelease = await admin
+      .from("github_capture_queue")
+      .update({
+        reviewed_by: null,
+        reviewed_at: null,
+        decision_note: null,
+        approved_memory_id: null,
+      })
+      .eq("id", id)
+      .eq("status", "pending")
+      .eq("approved_memory_id", item.approved_memory_id)
+
+    if (staleLockRelease.error) {
+      console.error("Failed to release stale approval lock for capture queue item:", {
+        queueId: id,
+        reviewerUserId: user.id,
+        lockToken: item.approved_memory_id,
+        error: staleLockRelease.error,
+      })
+      return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+    }
+  }
+
+  const approvalLockToken = buildApprovalLockToken(user.id)
+  const claimResponse = await admin
+    .from("github_capture_queue")
+    .update({
+      reviewed_by: user.id,
+      reviewed_at: nowIso,
+      decision_note: parsed.data.note ?? null,
+      approved_memory_id: approvalLockToken,
+    })
+    .eq("id", id)
+    .eq("status", "pending")
+    .is("approved_memory_id", null)
+    .select("id")
+    .maybeSingle()
+
+  if (claimResponse.error) {
+    console.error("Failed to claim capture queue item for approval:", {
+      queueId: id,
+      reviewerUserId: user.id,
+      error: claimResponse.error,
+    })
+    return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+  }
+
+  if (!claimResponse.data) {
+    const { item: latestItem, error: latestError } = await fetchQueueItem(admin, id)
+    if (latestError) {
+      console.error("Failed to read latest capture queue item after approval claim conflict:", {
+        queueId: id,
+        reviewerUserId: user.id,
+        error: latestError,
+      })
+      return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+    }
+
+    if (!latestItem) {
+      return NextResponse.json({ error: "Capture queue item not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(
+      {
+        error: `Capture queue item is already ${latestItem.status}`,
+      },
+      { status: 409 }
+    )
+  }
+
   const creds = await resolveWorkspaceCredentials(admin, item)
   if (!creds?.turso_db_url || !creds?.turso_db_token) {
+    await admin
+      .from("github_capture_queue")
+      .update({
+        reviewed_by: null,
+        reviewed_at: null,
+        decision_note: null,
+        approved_memory_id: null,
+      })
+      .eq("id", id)
+      .eq("status", "pending")
+      .eq("approved_memory_id", approvalLockToken)
+
     return NextResponse.json({ error: "Workspace database is not configured" }, { status: 409 })
   }
 
@@ -210,31 +349,53 @@ export async function PATCH(
     tags.push(`action:${item.source_action}`)
   }
 
-  const payload = await addMemoryPayload({
-    turso,
-    args: {
-      content: item.content,
-      type: memoryTypeForEvent(item.source_event),
-      tags,
-      category: "github",
-      metadata: {
-        source: "github_capture_queue",
-        queue_id: item.id,
-        source_event: item.source_event,
-        source_action: item.source_action,
-        source_id: item.source_id,
-        source_url: item.source_url,
-        actor_login: item.actor_login,
-        repo_full_name: item.repo_full_name,
-        payload: item.metadata ?? {},
+  let payload: Awaited<ReturnType<typeof addMemoryPayload>>
+  try {
+    payload = await addMemoryPayload({
+      turso,
+      args: {
+        content: item.content,
+        type: memoryTypeForEvent(item.source_event),
+        tags,
+        category: "github",
+        metadata: {
+          source: "github_capture_queue",
+          queue_id: item.id,
+          source_event: item.source_event,
+          source_action: item.source_action,
+          source_id: item.source_id,
+          source_url: item.source_url,
+          actor_login: item.actor_login,
+          repo_full_name: item.repo_full_name,
+          payload: item.metadata ?? {},
+        },
       },
-    },
-    projectId: item.project_id,
-    userId: item.target_owner_type === "user" ? item.target_user_id : null,
-    nowIso,
-  })
+      projectId: item.project_id,
+      userId: item.target_owner_type === "user" ? item.target_user_id : null,
+      nowIso,
+    })
+  } catch (memoryError) {
+    await admin
+      .from("github_capture_queue")
+      .update({
+        reviewed_by: null,
+        reviewed_at: null,
+        decision_note: null,
+        approved_memory_id: null,
+      })
+      .eq("id", id)
+      .eq("status", "pending")
+      .eq("approved_memory_id", approvalLockToken)
 
-  const { error: updateError } = await admin
+    console.error("Failed to insert memory while approving capture queue item:", {
+      queueId: id,
+      reviewerUserId: user.id,
+      error: memoryError,
+    })
+    return NextResponse.json({ error: "Failed to insert approved memory" }, { status: 500 })
+  }
+
+  const finalizeResponse = await admin
     .from("github_capture_queue")
     .update({
       status: "approved",
@@ -244,13 +405,47 @@ export async function PATCH(
       approved_memory_id: payload.data.id,
     })
     .eq("id", id)
+    .eq("status", "pending")
+    .eq("approved_memory_id", approvalLockToken)
+    .select("id")
+    .maybeSingle()
 
-  if (updateError) {
+  if (finalizeResponse.error) {
     console.error("Failed to approve capture queue item:", {
       queueId: id,
       reviewerUserId: user.id,
       approvedMemoryId: payload.data.id,
-      error: updateError,
+      error: finalizeResponse.error,
+    })
+    return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+  }
+
+  if (!finalizeResponse.data) {
+    const { item: latestItem, error: latestError } = await fetchQueueItem(admin, id)
+    if (latestError) {
+      console.error("Failed to read latest capture queue item after approval finalize conflict:", {
+        queueId: id,
+        reviewerUserId: user.id,
+        approvedMemoryId: payload.data.id,
+        error: latestError,
+      })
+      return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
+    }
+
+    if (latestItem?.status === "approved" && latestItem.approved_memory_id === payload.data.id) {
+      return NextResponse.json({
+        ok: true,
+        status: "approved",
+        memory_id: payload.data.id,
+      })
+    }
+
+    console.error("Approval finalize claim lost for capture queue item:", {
+      queueId: id,
+      reviewerUserId: user.id,
+      approvedMemoryId: payload.data.id,
+      latestStatus: latestItem?.status ?? null,
+      latestApprovedMemoryId: latestItem?.approved_memory_id ?? null,
     })
     return NextResponse.json({ error: "Failed to update capture queue item" }, { status: 500 })
   }

--- a/packages/web/src/app/api/invites/accept/route.test.ts
+++ b/packages/web/src/app/api/invites/accept/route.test.ts
@@ -59,7 +59,7 @@ describe("/api/invites/accept", () => {
     mockLogOrgAuditEvent.mockResolvedValue(undefined)
   })
 
-  it("returns 500 with stable error when member insert fails", async () => {
+  it("treats duplicate member insert as idempotent invite acceptance", async () => {
     mockGetUser.mockResolvedValue({
       data: {
         user: {
@@ -102,7 +102,14 @@ describe("/api/invites/accept", () => {
           })),
           update: vi.fn(() => ({
             eq: vi.fn().mockReturnValue({
-              is: vi.fn().mockResolvedValue({ error: null }),
+              is: vi.fn().mockReturnValue({
+                select: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: { id: "invite-1" },
+                    error: null,
+                  }),
+                })),
+              }),
             }),
           })),
         }
@@ -113,7 +120,7 @@ describe("/api/invites/accept", () => {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnValue({
               eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: null, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
               }),
             }),
           })),
@@ -122,6 +129,16 @@ describe("/api/invites/accept", () => {
               message: "duplicate key value violates unique constraint",
             },
           }),
+        }
+      }
+
+      if (table === "users") {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              is: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          })),
         }
       }
 
@@ -143,11 +160,16 @@ describe("/api/invites/accept", () => {
       }),
     )
 
-    expect(response.status).toBe(500)
-    await expect(response.json()).resolves.toEqual({
-      error: "Failed to accept invite",
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      organization: {
+        id: "org-1",
+        slug: "acme",
+      },
     })
     expect(mockLogOrgAuditEvent).not.toHaveBeenCalled()
+    expect(mockAddTeamSeat).not.toHaveBeenCalled()
   })
 
   it("returns 500 with stable error when invite lookup fails", async () => {

--- a/packages/web/src/app/api/invites/accept/route.ts
+++ b/packages/web/src/app/api/invites/accept/route.ts
@@ -8,6 +8,21 @@ import { parseBody, acceptInviteSchema } from "@/lib/validations"
 import { getInviteTokenCandidates } from "@/lib/team-invites"
 import { hasServiceRoleKey } from "@/lib/env"
 
+function isDuplicateMembershipError(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+  if (code === "23505") return true
+
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return message.includes("duplicate key")
+}
+
 // POST /api/invites/accept - Accept an invite
 export async function POST(request: Request): Promise<Response> {
   const supabase = await createClient()
@@ -78,12 +93,22 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // Check if already a member
-  const { data: existingMember } = await supabase
+  const { data: existingMember, error: existingMemberError } = await supabase
     .from("org_members")
     .select("id")
     .eq("org_id", invite.org_id)
     .eq("user_id", user.id)
-    .single()
+    .maybeSingle()
+
+  if (existingMemberError) {
+    console.error("Failed to verify existing org membership during invite accept:", {
+      inviteId: invite.id,
+      orgId: invite.org_id,
+      userId: user.id,
+      error: existingMemberError,
+    })
+    return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
+  }
 
   if (existingMember) {
     return NextResponse.json({ error: "You are already a member of this organization" }, { status: 400 })
@@ -99,55 +124,85 @@ export async function POST(request: Request): Promise<Response> {
 
   // Mark invite as accepted FIRST to prevent race conditions
   const writeClient = adminSupabase ?? supabase
-  const { error: acceptError } = await writeClient
+  const acceptedAt = new Date().toISOString()
+  const acceptResponse = await writeClient
     .from("org_invites")
-    .update({ accepted_at: new Date().toISOString() })
+    .update({ accepted_at: acceptedAt })
     .eq("id", invite.id)
     .is("accepted_at", null) // Only update if not already accepted
+    .select("id")
+    .maybeSingle()
 
-  if (acceptError) {
-    console.error("Failed to mark invite as accepted:", acceptError)
+  if (acceptResponse.error) {
+    console.error("Failed to mark invite as accepted:", acceptResponse.error)
     return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
   }
 
-  // Add as member
-  const { error: memberError } = await writeClient
-    .from("org_members")
-    .insert({
-      org_id: invite.org_id,
-      user_id: user.id,
-      role: invite.role,
-      invited_by: invite.invited_by,
-    })
+  const inviteAcceptedByThisRequest = Boolean(acceptResponse.data)
+  let membershipInserted = false
 
-  if (memberError) {
-    console.error("Failed to insert org member during invite accept:", {
-      inviteId: invite.id,
+  if (inviteAcceptedByThisRequest) {
+    // Add as member
+    const { error: memberError } = await writeClient
+      .from("org_members")
+      .insert({
+        org_id: invite.org_id,
+        user_id: user.id,
+        role: invite.role,
+        invited_by: invite.invited_by,
+      })
+
+    if (memberError && !isDuplicateMembershipError(memberError)) {
+      console.error("Failed to insert org member during invite accept:", {
+        inviteId: invite.id,
+        orgId: invite.org_id,
+        userId: user.id,
+        error: memberError,
+      })
+      return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
+    }
+
+    membershipInserted = !memberError
+  } else {
+    // Another request likely consumed this invite concurrently. Treat as idempotent
+    // success only when membership now exists.
+    const { data: memberAfterConsume, error: memberAfterConsumeError } = await writeClient
+      .from("org_members")
+      .select("id")
+      .eq("org_id", invite.org_id)
+      .eq("user_id", user.id)
+      .maybeSingle()
+
+    if (memberAfterConsumeError) {
+      console.error("Failed to verify membership after concurrent invite consume:", {
+        inviteId: invite.id,
+        orgId: invite.org_id,
+        userId: user.id,
+        error: memberAfterConsumeError,
+      })
+      return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
+    }
+
+    if (!memberAfterConsume) {
+      return NextResponse.json({ error: "Invite has already been accepted" }, { status: 409 })
+    }
+  }
+
+  if (membershipInserted) {
+    await logOrgAuditEvent({
+      client: writeClient,
       orgId: invite.org_id,
-      userId: user.id,
-      error: memberError,
+      actorUserId: user.id,
+      action: "org_invite_accepted",
+      targetType: "user",
+      targetId: user.id,
+      targetLabel: invite.email,
+      metadata: {
+        inviteId: invite.id,
+        role: invite.role,
+      },
     })
-    // Rollback invite acceptance if member insert fails
-    await writeClient
-      .from("org_invites")
-      .update({ accepted_at: null })
-      .eq("id", invite.id)
-    return NextResponse.json({ error: "Failed to accept invite" }, { status: 500 })
   }
-
-  await logOrgAuditEvent({
-    client: writeClient,
-    orgId: invite.org_id,
-    actorUserId: user.id,
-    action: "org_invite_accepted",
-    targetType: "user",
-    targetId: user.id,
-    targetLabel: invite.email,
-    metadata: {
-      inviteId: invite.id,
-      role: invite.role,
-    },
-  })
 
   // Set as user's current org if they don't have one
   const { error: orgError } = await writeClient
@@ -163,23 +218,25 @@ export async function POST(request: Request): Promise<Response> {
 
   // Add seat to org subscription after membership is committed.
   // This avoids charging seats for failed invite acceptance flows.
-  try {
-    const result = await addTeamSeat({
-      orgId: org.id,
-      stripeCustomerId: org.stripe_customer_id,
-      stripeSubscriptionId: org.stripe_subscription_id,
-      billing: billing as "monthly" | "annual",
-    })
+  if (membershipInserted) {
+    try {
+      const result = await addTeamSeat({
+        orgId: org.id,
+        stripeCustomerId: org.stripe_customer_id,
+        stripeSubscriptionId: org.stripe_subscription_id,
+        billing: billing as "monthly" | "annual",
+      })
 
-    if (result.action === "created") {
-      await writeClient
-        .from("organizations")
-        .update({ stripe_subscription_id: result.subscriptionId })
-        .eq("id", org.id)
+      if (result.action === "created") {
+        await writeClient
+          .from("organizations")
+          .update({ stripe_subscription_id: result.subscriptionId })
+          .eq("id", org.id)
+      }
+    } catch (e) {
+      console.error("Failed to add team seat after invite acceptance:", e)
+      // Non-blocking: billing can reconcile from org membership.
     }
-  } catch (e) {
-    console.error("Failed to add team seat after invite acceptance:", e)
-    // Non-blocking: billing can reconcile from org membership.
   }
 
   return NextResponse.json({ 


### PR DESCRIPTION
## Summary\n- prevent stale reject overwrites by requiring pending + unlocked rows\n- add optimistic approval lock claim/finalize flow to avoid duplicate memory insertion on concurrent approve\n- add stale lock recovery for abandoned approval attempts\n- make invite acceptance idempotent for concurrent duplicate requests\n- remove invite acceptance rollback that could reopen consumed invites\n\n## Testing\n- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/invites/accept/route.test.ts' 'src/app/api/github/capture/queue/[id]/route.test.ts'\n- pnpm --filter @memories.sh/web typecheck\n\nCloses #377\nCloses #378\nCloses #379

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches two write-heavy API routes to add optimistic concurrency controls and idempotency, which can change edge-case HTTP responses and DB update behavior under contention. Risk is moderated by added checks and expanded tests but still impacts approval/membership flows.
> 
> **Overview**
> **Prevents race-condition overwrites in GitHub capture queue decisions.** `PATCH /api/github/capture/queue/[id]` now guards reject/approve updates with `status = pending` and an unlocked `approved_memory_id`, returning a **409** when the item was already processed.
> 
> **Adds an optimistic approval lock + stale-lock recovery for approvals.** Approvals now (1) claim a per-request lock token in `approved_memory_id`, (2) insert the memory, then (3) finalize only if the lock is still held; stale locks are cleared after ~10 minutes, and failures during approval release the lock and return stable errors.
> 
> **Makes invite acceptance idempotent under concurrency.** `POST /api/invites/accept` uses `maybeSingle`, treats duplicate `org_members` inserts as success, avoids rolling back `accepted_at`, and only triggers audit logging and Stripe seat changes when this request actually created the membership; concurrent consumes now resolve to success (if membership exists) or **409**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55d636c4eb310095f697378f9007ea72eec87ebc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->