### PR TITLE
fix(web): eliminate org + invite + capture-settings race windows

### DIFF
--- a/packages/web/src/app/api/github/capture/settings/route.ts
+++ b/packages/web/src/app/api/github/capture/settings/route.ts
@@ -200,12 +200,12 @@ export async function PATCH(request: Request): Promise<Response> {
         .single()
     : await supabase
         .from("github_capture_settings")
-        .insert({
+        .upsert({
           target_owner_type: "user",
           target_user_id: user.id,
           target_org_id: null,
           ...writePayload,
-        })
+        }, { onConflict: "target_owner_type,target_user_id" })
         .select(SETTINGS_SELECT)
         .single()
 

--- a/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.test.ts
@@ -184,7 +184,7 @@ describe("/api/orgs/[orgId]/github-capture/settings", () => {
         }
 
         return {
-          insert: vi.fn(() => ({
+          upsert: vi.fn(() => ({
             select: vi.fn(() => ({
               single: vi.fn().mockResolvedValue({ data: insertedRow, error: null }),
             })),
@@ -283,7 +283,7 @@ describe("/api/orgs/[orgId]/github-capture/settings", () => {
         }
 
         return {
-          insert: vi.fn(() => ({
+          upsert: vi.fn(() => ({
             select: vi.fn(() => ({
               single: vi.fn().mockResolvedValue({
                 data: null,

--- a/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/github-capture/settings/route.ts
@@ -264,12 +264,12 @@ export async function PATCH(
         .single()
     : await supabase
         .from("github_capture_settings")
-        .insert({
+        .upsert({
           target_owner_type: "organization",
           target_org_id: orgId,
           target_user_id: null,
           ...writePayload,
-        })
+        }, { onConflict: "target_owner_type,target_org_id" })
         .select(SETTINGS_SELECT)
         .single()
 
@@ -287,7 +287,7 @@ export async function PATCH(
       error: response.error,
       orgId,
       userId: user.id,
-      method: existingRow ? "PATCH:update" : "PATCH:insert",
+      method: existingRow ? "PATCH:update" : "PATCH:upsert",
       updatedFields: Object.keys(updates).sort(),
     })
     return NextResponse.json({ error: "Failed to save settings" }, { status: 500 })

--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
@@ -411,6 +411,15 @@ describe("/api/orgs/[orgId]/invites POST", () => {
               }),
             }),
           })),
+          delete: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockReturnValue({
+                  lte: vi.fn().mockResolvedValue({ error: null }),
+                }),
+              }),
+            }),
+          })),
           insert: vi.fn(() => ({
             select: vi.fn(() => ({
               single: vi.fn().mockResolvedValue({

--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -7,6 +7,21 @@ import { parseBody, createInviteSchema } from "@/lib/validations"
 import { getTeamInviteExpiresAt } from "@/lib/team-invites"
 import { getAppUrl, hasResendApiKey } from "@/lib/env"
 
+function isUniqueViolation(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+  if (code === "23505") return true
+
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return message.includes("duplicate key")
+}
+
 // GET /api/orgs/[orgId]/invites - List pending invites
 export async function GET(
   request: Request,
@@ -183,6 +198,25 @@ export async function POST(
     return NextResponse.json({ error: "Invite already pending for this email" }, { status: 400 })
   }
 
+  const nowIso = new Date().toISOString()
+  const { error: cleanupError } = await supabase
+    .from("org_invites")
+    .delete()
+    .eq("org_id", orgId)
+    .eq("email", email.toLowerCase())
+    .is("accepted_at", null)
+    .lte("expires_at", nowIso)
+
+  if (cleanupError) {
+    console.error("Failed to cleanup expired unaccepted invites before create:", {
+      error: cleanupError,
+      orgId,
+      email: email.toLowerCase(),
+      userId: user.id,
+    })
+    return NextResponse.json({ error: "Failed to create invite" }, { status: 500 })
+  }
+
   // Create invite
   const { data: invite, error } = await supabase
     .from("org_invites")
@@ -197,6 +231,32 @@ export async function POST(
     .single()
 
   if (error) {
+    if (isUniqueViolation(error)) {
+      const { data: concurrentInvite, error: concurrentInviteError } = await supabase
+        .from("org_invites")
+        .select("id")
+        .eq("org_id", orgId)
+        .eq("email", email.toLowerCase())
+        .is("accepted_at", null)
+        .gt("expires_at", new Date().toISOString())
+        .maybeSingle()
+
+      if (concurrentInviteError) {
+        console.error("Failed to resolve concurrent invite create conflict:", {
+          error: concurrentInviteError,
+          orgId,
+          userId: user.id,
+          email: email.toLowerCase(),
+          role,
+        })
+        return NextResponse.json({ error: "Failed to create invite" }, { status: 500 })
+      }
+
+      if (concurrentInvite) {
+        return NextResponse.json({ error: "Invite already pending for this email" }, { status: 400 })
+      }
+    }
+
     console.error("Failed to create org invite row:", {
       error,
       orgId,

--- a/packages/web/src/app/api/orgs/__tests__/route.test.ts
+++ b/packages/web/src/app/api/orgs/__tests__/route.test.ts
@@ -137,22 +137,8 @@ describe("/api/orgs", () => {
     it("should create organization with unique slug", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
 
-      let orgCallCount = 0
       mockAdminFrom.mockImplementation((table: string) => {
         if (table === "organizations") {
-          orgCallCount += 1
-          if (orgCallCount === 1) {
-            // Slug uniqueness check
-            return {
-              select: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-                }),
-              }),
-            }
-          }
-
-          // Create org
           return {
             insert: vi.fn().mockReturnValue({
               select: vi.fn().mockReturnValue({
@@ -202,18 +188,58 @@ describe("/api/orgs", () => {
       expect(body.upgradeUrl).toBe("/app/upgrade?plan=growth&source=org-created")
     })
 
-    it("should return 500 when slug uniqueness check fails", async () => {
+    it("should retry slug generation when insert hits duplicate slug", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
+      const insertedSlugs: string[] = []
+
+      let insertCount = 0
 
       mockAdminFrom.mockImplementation((table: string) => {
         if (table === "organizations") {
           return {
-            select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                maybeSingle: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: { message: "DB read failed" },
+            insert: vi.fn((payload: { slug: string }) => {
+              insertedSlugs.push(payload.slug)
+              insertCount += 1
+              if (insertCount === 1) {
+                return {
+                  select: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                      data: null,
+                      error: {
+                        code: "23505",
+                        message: "duplicate key value violates unique constraint",
+                      },
+                    }),
+                  }),
+                }
+              }
+
+              return {
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: { id: "org-new", name: "New Team", slug: payload.slug },
+                    error: null,
+                  }),
                 }),
+              }
+            }),
+            delete: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }
+        }
+
+        if (table === "org_members") {
+          return {
+            insert: vi.fn().mockResolvedValue({ error: null }),
+          }
+        }
+
+        if (table === "users") {
+          return {
+            update: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockResolvedValue({ error: null }),
               }),
             }),
           }
@@ -229,28 +255,17 @@ describe("/api/orgs", () => {
       })
 
       const response = await POST(request)
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(201)
       const body = await response.json()
-      expect(body.error).toBe("Failed to create organization")
+      expect(body.organization.slug).toBe("new-team-1")
+      expect(insertedSlugs).toEqual(["new-team", "new-team-1"])
     })
 
     it("should return 500 when organization insert fails", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
 
-      let orgCallCount = 0
       mockAdminFrom.mockImplementation((table: string) => {
         if (table === "organizations") {
-          orgCallCount += 1
-          if (orgCallCount === 1) {
-            return {
-              select: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-                }),
-              }),
-            }
-          }
-
           return {
             insert: vi.fn().mockReturnValue({
               select: vi.fn().mockReturnValue({
@@ -281,35 +296,17 @@ describe("/api/orgs", () => {
     it("should return 500 when owner membership insert fails", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
 
-      let orgCallCount = 0
       mockAdminFrom.mockImplementation((table: string) => {
         if (table === "organizations") {
-          orgCallCount += 1
-
-          if (orgCallCount === 1) {
-            return {
-              select: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-                }),
-              }),
-            }
-          }
-
-          if (orgCallCount === 2) {
-            return {
-              insert: vi.fn().mockReturnValue({
-                select: vi.fn().mockReturnValue({
-                  single: vi.fn().mockResolvedValue({
-                    data: { id: "org-new", name: "New Team", slug: "new-team" },
-                    error: null,
-                  }),
-                }),
-              }),
-            }
-          }
-
           return {
+            insert: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: "org-new", name: "New Team", slug: "new-team" },
+                  error: null,
+                }),
+              }),
+            }),
             delete: vi.fn().mockReturnValue({
               eq: vi.fn().mockResolvedValue({ error: null }),
             }),

--- a/packages/web/src/app/api/orgs/route.ts
+++ b/packages/web/src/app/api/orgs/route.ts
@@ -5,6 +5,23 @@ import { NextResponse } from "next/server"
 import { apiRateLimit, checkPreAuthApiRateLimit, checkRateLimit } from "@/lib/rate-limit"
 import { parseBody, createOrgSchema } from "@/lib/validations"
 
+const MAX_SLUG_INSERT_RETRIES = 10
+
+function isDuplicateSlugError(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+  if (code === "23505") return true
+
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return message.includes("duplicate key") && message.includes("slug")
+}
+
 // GET /api/orgs - List user's organizations
 export async function GET(request: Request): Promise<Response> {
   const preAuthRateLimited = await checkPreAuthApiRateLimit(request)
@@ -71,46 +88,46 @@ export async function POST(request: Request): Promise<Response> {
 
   // Generate slug from name
   const baseSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
-  let slug = baseSlug
+  let slug = baseSlug || "workspace"
   let counter = 1
 
-  // Check for slug uniqueness
-  while (true) {
-    const { data: existing, error: existingError } = await admin
-      .from("organizations")
-      .select("id")
-      .eq("slug", slug)
-      .maybeSingle()
+  let org: { id: string; name: string; slug: string } | null = null
+  let orgInsertError: unknown = null
 
-    if (existingError) {
-      console.error("Failed to verify organization slug uniqueness:", {
-        error: existingError,
+  for (let attempt = 0; attempt < MAX_SLUG_INSERT_RETRIES; attempt += 1) {
+    const response = await admin
+      .from("organizations")
+      .insert({
+        name,
         slug,
-        userId: auth.userId,
+        owner_id: auth.userId,
       })
-      return NextResponse.json({ error: "Failed to create organization" }, { status: 500 })
+      .select()
+      .single()
+
+    if (!response.error && response.data) {
+      org = response.data as { id: string; name: string; slug: string }
+      orgInsertError = null
+      break
     }
 
-    if (!existing) break
-    slug = `${baseSlug}-${counter++}`
+    if (isDuplicateSlugError(response.error)) {
+      slug = `${baseSlug || "workspace"}-${counter++}`
+      orgInsertError = response.error
+      continue
+    }
+
+    orgInsertError = response.error
+    break
   }
 
-  // Create organization
-  const { data: org, error: orgError } = await admin
-    .from("organizations")
-    .insert({
-      name,
-      slug,
-      owner_id: auth.userId,
-    })
-    .select()
-    .single()
-
-  if (orgError) {
+  if (!org) {
     console.error("Failed to create organization:", {
-      error: orgError,
+      error: orgInsertError,
       userId: auth.userId,
       orgName: name.trim(),
+      slug,
+      retries: MAX_SLUG_INSERT_RETRIES,
     })
     return NextResponse.json({ error: "Failed to create organization" }, { status: 500 })
   }

--- a/supabase/migrations/20260302140607_enable_rls_and_policies_mcp_api_keys.sql
+++ b/supabase/migrations/20260302140607_enable_rls_and_policies_mcp_api_keys.sql
@@ -1,0 +1,39 @@
+
+-- Enable RLS on mcp_api_keys (currently disabled)
+ALTER TABLE public.mcp_api_keys ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access
+CREATE POLICY "Service role full access mcp_api_keys"
+  ON public.mcp_api_keys
+  FOR ALL
+  TO service_role
+  USING (true);
+
+-- Users can view their own API keys
+CREATE POLICY "Users can view own mcp_api_keys"
+  ON public.mcp_api_keys
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Users can create their own API keys
+CREATE POLICY "Users can create own mcp_api_keys"
+  ON public.mcp_api_keys
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+-- Users can update their own API keys (e.g. revoke)
+CREATE POLICY "Users can update own mcp_api_keys"
+  ON public.mcp_api_keys
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Users can delete their own API keys
+CREATE POLICY "Users can delete own mcp_api_keys"
+  ON public.mcp_api_keys
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);
+;

--- a/supabase/migrations/20260302140609_add_rls_policies_sdk_tenant_databases.sql
+++ b/supabase/migrations/20260302140609_add_rls_policies_sdk_tenant_databases.sql
@@ -1,0 +1,9 @@
+
+-- sdk_tenant_databases: service-level table, service_role only access
+-- Matches pattern of sdk_project_meter_events and sdk_embedding_meter_events
+CREATE POLICY "Service role full access sdk_tenant_databases"
+  ON public.sdk_tenant_databases
+  FOR ALL
+  TO service_role
+  USING (true);
+;

--- a/supabase/migrations/20260302140611_add_rls_policies_workspace_switch_events.sql
+++ b/supabase/migrations/20260302140611_add_rls_policies_workspace_switch_events.sql
@@ -1,0 +1,9 @@
+
+-- workspace_switch_events: analytics/telemetry table
+-- Matches pattern of workspace_switch_profile_events (service_role only)
+CREATE POLICY "Service role full access workspace_switch_events"
+  ON public.workspace_switch_events
+  FOR ALL
+  TO service_role
+  USING (true);
+;

--- a/supabase/migrations/20260302141135_fix_rls_initplan_auth_uid_subselect.sql
+++ b/supabase/migrations/20260302141135_fix_rls_initplan_auth_uid_subselect.sql
@@ -1,0 +1,221 @@
+
+-- Fix auth_rls_initplan: wrap auth.uid()/auth.role() in (SELECT ...) for single evaluation
+-- This prevents per-row re-evaluation of these functions
+
+-- 1. github_account_links
+DROP POLICY "Users can upsert own github account link" ON public.github_account_links;
+CREATE POLICY "Users can upsert own github account link"
+  ON public.github_account_links FOR ALL TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY "Users can view own github account link" ON public.github_account_links;
+CREATE POLICY "Users can view own github account link"
+  ON public.github_account_links FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- 2. github_capture_settings
+DROP POLICY "Org admins can manage org github capture settings" ON public.github_capture_settings;
+CREATE POLICY "Org admins can manage org github capture settings"
+  ON public.github_capture_settings FOR ALL TO authenticated
+  USING (
+    target_owner_type = 'organization'
+    AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = github_capture_settings.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    )
+  )
+  WITH CHECK (
+    target_owner_type = 'organization'
+    AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = github_capture_settings.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    )
+  );
+
+DROP POLICY "Users can manage own github capture settings" ON public.github_capture_settings;
+CREATE POLICY "Users can manage own github capture settings"
+  ON public.github_capture_settings FOR ALL TO authenticated
+  USING (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()))
+  WITH CHECK (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()));
+
+-- 3. integration_secret_refs
+DROP POLICY "Org admins can manage org integration secret refs" ON public.integration_secret_refs;
+CREATE POLICY "Org admins can manage org integration secret refs"
+  ON public.integration_secret_refs FOR ALL TO authenticated
+  USING (
+    target_owner_type = 'organization'
+    AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = integration_secret_refs.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    )
+  )
+  WITH CHECK (
+    target_owner_type = 'organization'
+    AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = integration_secret_refs.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    )
+  );
+
+DROP POLICY "Users can manage own integration secret refs" ON public.integration_secret_refs;
+CREATE POLICY "Users can manage own integration secret refs"
+  ON public.integration_secret_refs FOR ALL TO authenticated
+  USING (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()))
+  WITH CHECK (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()));
+
+-- 4. legacy_route_usage_events
+DROP POLICY "Service role full access legacy route usage events" ON public.legacy_route_usage_events;
+CREATE POLICY "Service role full access legacy route usage events"
+  ON public.legacy_route_usage_events FOR ALL TO public
+  USING ((SELECT auth.role()) = 'service_role')
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+-- 5. mcp_api_keys
+DROP POLICY "Users can create own mcp_api_keys" ON public.mcp_api_keys;
+CREATE POLICY "Users can create own mcp_api_keys"
+  ON public.mcp_api_keys FOR INSERT TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY "Users can delete own mcp_api_keys" ON public.mcp_api_keys;
+CREATE POLICY "Users can delete own mcp_api_keys"
+  ON public.mcp_api_keys FOR DELETE TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY "Users can update own mcp_api_keys" ON public.mcp_api_keys;
+CREATE POLICY "Users can update own mcp_api_keys"
+  ON public.mcp_api_keys FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY "Users can view own mcp_api_keys" ON public.mcp_api_keys;
+CREATE POLICY "Users can view own mcp_api_keys"
+  ON public.mcp_api_keys FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- 6. org_audit_logs
+DROP POLICY "Org members can read org audit logs" ON public.org_audit_logs;
+CREATE POLICY "Org members can read org audit logs"
+  ON public.org_audit_logs FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = org_audit_logs.org_id
+        AND m.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- 7. org_invites
+DROP POLICY "Admins can create org invites" ON public.org_invites;
+CREATE POLICY "Admins can create org invites"
+  ON public.org_invites FOR INSERT TO authenticated
+  WITH CHECK (
+    org_id IN (
+      SELECT org_members.org_id FROM org_members
+      WHERE org_members.user_id = (SELECT auth.uid())
+        AND org_members.role = ANY (ARRAY['owner', 'admin'])
+    )
+  );
+
+DROP POLICY "Admins can delete org invites" ON public.org_invites;
+CREATE POLICY "Admins can delete org invites"
+  ON public.org_invites FOR DELETE TO authenticated
+  USING (
+    org_id IN (
+      SELECT org_members.org_id FROM org_members
+      WHERE org_members.user_id = (SELECT auth.uid())
+        AND org_members.role = ANY (ARRAY['owner', 'admin'])
+    )
+  );
+
+DROP POLICY "Admins can view org invites" ON public.org_invites;
+CREATE POLICY "Admins can view org invites"
+  ON public.org_invites FOR SELECT TO authenticated
+  USING (
+    org_id IN (
+      SELECT org_members.org_id FROM org_members
+      WHERE org_members.user_id = (SELECT auth.uid())
+        AND org_members.role = ANY (ARRAY['owner', 'admin'])
+    )
+  );
+
+-- 8. org_members
+DROP POLICY "Admins can manage org members" ON public.org_members;
+CREATE POLICY "Admins can manage org members"
+  ON public.org_members FOR ALL TO authenticated
+  USING (is_org_admin((SELECT auth.uid()), org_id));
+
+DROP POLICY "Users can add themselves as owner to their new orgs" ON public.org_members;
+CREATE POLICY "Users can add themselves as owner to their new orgs"
+  ON public.org_members FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND role = 'owner'
+    AND org_id IN (
+      SELECT organizations.id FROM organizations
+      WHERE organizations.owner_id = (SELECT auth.uid())
+    )
+  );
+
+DROP POLICY "Users can view org members" ON public.org_members;
+CREATE POLICY "Users can view org members"
+  ON public.org_members FOR SELECT TO authenticated
+  USING (org_id IN (SELECT get_user_org_ids((SELECT auth.uid()))));
+
+-- 9. organizations
+DROP POLICY "Owners can update their organizations" ON public.organizations;
+CREATE POLICY "Owners can update their organizations"
+  ON public.organizations FOR UPDATE TO authenticated
+  USING (owner_id = (SELECT auth.uid()));
+
+DROP POLICY "Owners can view their own orgs" ON public.organizations;
+CREATE POLICY "Owners can view their own orgs"
+  ON public.organizations FOR SELECT TO authenticated
+  USING (owner_id = (SELECT auth.uid()));
+
+DROP POLICY "Users can create organizations" ON public.organizations;
+CREATE POLICY "Users can create organizations"
+  ON public.organizations FOR INSERT TO authenticated
+  WITH CHECK (owner_id = (SELECT auth.uid()));
+
+DROP POLICY "Users can view their organizations" ON public.organizations;
+CREATE POLICY "Users can view their organizations"
+  ON public.organizations FOR SELECT TO authenticated
+  USING (id IN (SELECT get_user_org_ids((SELECT auth.uid()))));
+
+-- 10. sdk_embedding_meter_events
+DROP POLICY "Service role full access sdk_embedding_meter_events" ON public.sdk_embedding_meter_events;
+CREATE POLICY "Service role full access sdk_embedding_meter_events"
+  ON public.sdk_embedding_meter_events FOR ALL TO public
+  USING ((SELECT auth.role()) = 'service_role')
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+-- 11. users
+DROP POLICY "Org members can view teammate profiles" ON public.users;
+CREATE POLICY "Org members can view teammate profiles"
+  ON public.users FOR SELECT TO authenticated
+  USING (
+    id IN (
+      SELECT om.user_id FROM org_members om
+      WHERE om.org_id IN (SELECT get_user_org_ids((SELECT auth.uid())))
+    )
+  );
+
+DROP POLICY "Users can read own row" ON public.users;
+CREATE POLICY "Users can read own row"
+  ON public.users FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = id);
+
+DROP POLICY "Users can update own row" ON public.users;
+CREATE POLICY "Users can update own row"
+  ON public.users FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = id)
+  WITH CHECK ((SELECT auth.uid()) = id);
+;

--- a/supabase/migrations/20260302141208_add_missing_foreign_key_indexes.sql
+++ b/supabase/migrations/20260302141208_add_missing_foreign_key_indexes.sql
@@ -1,0 +1,47 @@
+
+-- Add covering indexes for all unindexed foreign keys
+CREATE INDEX IF NOT EXISTS idx_github_capture_queue_reviewed_by
+  ON public.github_capture_queue (reviewed_by);
+
+CREATE INDEX IF NOT EXISTS idx_integration_secret_refs_created_by_user_id
+  ON public.integration_secret_refs (created_by_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_integration_secret_refs_updated_by_user_id
+  ON public.integration_secret_refs (updated_by_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_legacy_route_usage_events_owner_user_id
+  ON public.legacy_route_usage_events (owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_org_invites_invited_by
+  ON public.org_invites (invited_by);
+
+CREATE INDEX IF NOT EXISTS idx_org_members_invited_by
+  ON public.org_members (invited_by);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_embedding_meter_events_owner_org_id
+  ON public.sdk_embedding_meter_events (owner_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_embedding_meter_events_owner_user_id
+  ON public.sdk_embedding_meter_events (owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_project_meter_events_owner_org_id
+  ON public.sdk_project_meter_events (owner_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_project_meter_events_owner_user_id
+  ON public.sdk_project_meter_events (owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_tenant_databases_created_by_user_id
+  ON public.sdk_tenant_databases (created_by_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_switch_events_from_org_id
+  ON public.workspace_switch_events (from_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_switch_events_to_org_id
+  ON public.workspace_switch_events (to_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_switch_profile_events_from_org_id
+  ON public.workspace_switch_profile_events (from_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_switch_profile_events_to_org_id
+  ON public.workspace_switch_profile_events (to_org_id);
+;

--- a/supabase/migrations/20260302141257_drop_unused_indexes.sql
+++ b/supabase/migrations/20260302141257_drop_unused_indexes.sql
@@ -1,0 +1,71 @@
+
+-- Drop 39 unused indexes to reduce write overhead and storage
+
+-- legacy_route_usage_events (3)
+DROP INDEX IF EXISTS public.idx_legacy_route_usage_events_route_created_at;
+DROP INDEX IF EXISTS public.idx_legacy_route_usage_events_created_at;
+DROP INDEX IF EXISTS public.idx_legacy_route_usage_events_success_created_at;
+
+-- org_invites (1)
+DROP INDEX IF EXISTS public.idx_org_invites_email;
+
+-- workspace_switch_events (2)
+DROP INDEX IF EXISTS public.idx_workspace_switch_events_success_created_at;
+DROP INDEX IF EXISTS public.idx_workspace_switch_events_created_at;
+
+-- sdk_tenant_databases (4)
+DROP INDEX IF EXISTS public.idx_sdk_tenant_databases_stripe_customer_id;
+DROP INDEX IF EXISTS public.idx_sdk_tenant_databases_billing_owner_user_id;
+DROP INDEX IF EXISTS public.idx_sdk_tenant_databases_billing_org_id;
+DROP INDEX IF EXISTS public.idx_sdk_tenant_databases_mapping_source;
+
+-- users (5)
+DROP INDEX IF EXISTS public.idx_users_current_org_id;
+DROP INDEX IF EXISTS public.idx_users_stripe_customer_id;
+DROP INDEX IF EXISTS public.idx_users_cli_token;
+DROP INDEX IF EXISTS public.idx_users_cli_auth_code;
+DROP INDEX IF EXISTS public.idx_users_cli_auth_expires_at;
+
+-- github_capture_settings (2)
+DROP INDEX IF EXISTS public.idx_github_capture_settings_target_user;
+DROP INDEX IF EXISTS public.idx_github_capture_settings_target_org;
+
+-- github_capture_queue (3)
+DROP INDEX IF EXISTS public.idx_github_capture_queue_source_event_created_at;
+DROP INDEX IF EXISTS public.idx_github_capture_queue_repo_created_at;
+DROP INDEX IF EXISTS public.idx_github_capture_queue_actor_created_at;
+
+-- organizations (1)
+DROP INDEX IF EXISTS public.idx_organizations_owner;
+
+-- workspace_switch_profile_events (2)
+DROP INDEX IF EXISTS public.idx_workspace_switch_profile_events_org_count_created_at;
+DROP INDEX IF EXISTS public.idx_workspace_switch_profile_events_success_created_at;
+
+-- org_audit_logs (2)
+DROP INDEX IF EXISTS public.idx_org_audit_logs_org_action_created_at;
+DROP INDEX IF EXISTS public.idx_org_audit_logs_actor_created_at;
+
+-- integration_secret_refs (3)
+DROP INDEX IF EXISTS public.idx_integration_secret_refs_user_lookup;
+DROP INDEX IF EXISTS public.idx_integration_secret_refs_org_lookup;
+DROP INDEX IF EXISTS public.idx_integration_secret_refs_vault_secret_id;
+
+-- sdk_project_meter_events (3)
+DROP INDEX IF EXISTS public.idx_sdk_project_meter_events_api_key_hash;
+DROP INDEX IF EXISTS public.idx_sdk_project_meter_events_usage_month;
+DROP INDEX IF EXISTS public.idx_sdk_project_meter_events_stripe_reported_at;
+
+-- sdk_embedding_meter_events (8)
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_owner_scope_month;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_tenant_month;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_project_month;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_model_month;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_stripe_reported;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_api_key_hash;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_token_method_month;
+DROP INDEX IF EXISTS public.idx_sdk_embedding_meter_events_token_delta_month;
+
+-- mcp_api_keys (1)
+DROP INDEX IF EXISTS public.idx_mcp_api_keys_expires_at;
+;

--- a/supabase/migrations/20260302141330_add_remaining_foreign_key_indexes.sql
+++ b/supabase/migrations/20260302141330_add_remaining_foreign_key_indexes.sql
@@ -1,0 +1,29 @@
+
+-- Add indexes for FKs that lost coverage when we dropped unused indexes
+CREATE INDEX IF NOT EXISTS idx_github_capture_settings_target_org_id
+  ON public.github_capture_settings (target_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_github_capture_settings_target_user_id
+  ON public.github_capture_settings (target_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_integration_secret_refs_target_org_id
+  ON public.integration_secret_refs (target_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_integration_secret_refs_target_user_id
+  ON public.integration_secret_refs (target_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_org_audit_logs_actor_user_id
+  ON public.org_audit_logs (actor_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_organizations_owner_id
+  ON public.organizations (owner_id);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_tenant_databases_billing_org_id
+  ON public.sdk_tenant_databases (billing_org_id);
+
+CREATE INDEX IF NOT EXISTS idx_sdk_tenant_databases_billing_owner_user_id
+  ON public.sdk_tenant_databases (billing_owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_users_current_org_id
+  ON public.users (current_org_id);
+;

--- a/supabase/migrations/20260302141352_consolidate_multiple_permissive_policies.sql
+++ b/supabase/migrations/20260302141352_consolidate_multiple_permissive_policies.sql
@@ -1,0 +1,118 @@
+
+-- Consolidate multiple permissive policies into single policies per role+action
+-- This eliminates the multiple_permissive_policies warnings
+
+-- 1. github_account_links: merge SELECT policies
+--    "Users can upsert own github account link" (ALL) already covers SELECT
+--    "Users can view own github account link" (SELECT) is redundant
+DROP POLICY "Users can view own github account link" ON public.github_account_links;
+
+-- 2. github_capture_settings: merge user + org admin policies into one
+DROP POLICY "Org admins can manage org github capture settings" ON public.github_capture_settings;
+DROP POLICY "Users can manage own github capture settings" ON public.github_capture_settings;
+CREATE POLICY "Authenticated users can manage own or org github capture settings"
+  ON public.github_capture_settings FOR ALL TO authenticated
+  USING (
+    (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()))
+    OR
+    (target_owner_type = 'organization' AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = github_capture_settings.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    ))
+  )
+  WITH CHECK (
+    (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()))
+    OR
+    (target_owner_type = 'organization' AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = github_capture_settings.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    ))
+  );
+
+-- 3. integration_secret_refs: merge user + org admin policies into one
+DROP POLICY "Org admins can manage org integration secret refs" ON public.integration_secret_refs;
+DROP POLICY "Users can manage own integration secret refs" ON public.integration_secret_refs;
+CREATE POLICY "Authenticated users can manage own or org integration secret refs"
+  ON public.integration_secret_refs FOR ALL TO authenticated
+  USING (
+    (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()))
+    OR
+    (target_owner_type = 'organization' AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = integration_secret_refs.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    ))
+  )
+  WITH CHECK (
+    (target_owner_type = 'user' AND target_user_id = (SELECT auth.uid()))
+    OR
+    (target_owner_type = 'organization' AND EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = integration_secret_refs.target_org_id
+        AND m.user_id = (SELECT auth.uid())
+        AND m.role = ANY (ARRAY['owner', 'admin'])
+    ))
+  );
+
+-- 4. org_members: merge admin + self-insert policies for INSERT, and admin + view for SELECT
+DROP POLICY "Admins can manage org members" ON public.org_members;
+DROP POLICY "Users can add themselves as owner to their new orgs" ON public.org_members;
+DROP POLICY "Users can view org members" ON public.org_members;
+
+-- Single SELECT policy
+CREATE POLICY "Users can view org members"
+  ON public.org_members FOR SELECT TO authenticated
+  USING (
+    org_id IN (SELECT get_user_org_ids((SELECT auth.uid())))
+    OR is_org_admin((SELECT auth.uid()), org_id)
+  );
+
+-- Single INSERT policy
+CREATE POLICY "Users can insert org members"
+  ON public.org_members FOR INSERT TO authenticated
+  WITH CHECK (
+    is_org_admin((SELECT auth.uid()), org_id)
+    OR (
+      user_id = (SELECT auth.uid())
+      AND role = 'owner'
+      AND org_id IN (SELECT id FROM organizations WHERE owner_id = (SELECT auth.uid()))
+    )
+  );
+
+-- UPDATE/DELETE only for admins
+CREATE POLICY "Admins can update org members"
+  ON public.org_members FOR UPDATE TO authenticated
+  USING (is_org_admin((SELECT auth.uid()), org_id));
+
+CREATE POLICY "Admins can delete org members"
+  ON public.org_members FOR DELETE TO authenticated
+  USING (is_org_admin((SELECT auth.uid()), org_id));
+
+-- 5. organizations: merge two SELECT policies
+DROP POLICY "Owners can view their own orgs" ON public.organizations;
+DROP POLICY "Users can view their organizations" ON public.organizations;
+CREATE POLICY "Users can view their organizations"
+  ON public.organizations FOR SELECT TO authenticated
+  USING (
+    owner_id = (SELECT auth.uid())
+    OR id IN (SELECT get_user_org_ids((SELECT auth.uid())))
+  );
+
+-- 6. users: merge two SELECT policies
+DROP POLICY "Org members can view teammate profiles" ON public.users;
+DROP POLICY "Users can read own row" ON public.users;
+CREATE POLICY "Users can read own or teammate profiles"
+  ON public.users FOR SELECT TO authenticated
+  USING (
+    (SELECT auth.uid()) = id
+    OR id IN (
+      SELECT om.user_id FROM org_members om
+      WHERE om.org_id IN (SELECT get_user_org_ids((SELECT auth.uid())))
+    )
+  );
+;

--- a/supabase/migrations/20260302181000_harden_org_invite_and_slug_uniqueness.sql
+++ b/supabase/migrations/20260302181000_harden_org_invite_and_slug_uniqueness.sql
@@ -1,0 +1,32 @@
+-- Harden invite + organization slug uniqueness guarantees used by API race handling.
+
+-- Normalize invite email casing before applying uniqueness constraints.
+UPDATE public.org_invites
+SET email = lower(trim(email))
+WHERE email IS NOT NULL
+  AND email <> lower(trim(email));
+
+-- Keep only the newest unresolved invite per org/email so the partial unique index can be created safely.
+WITH ranked_unaccepted AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY org_id, lower(email)
+      ORDER BY expires_at DESC, created_at DESC, id DESC
+    ) AS rank
+  FROM public.org_invites
+  WHERE accepted_at IS NULL
+)
+DELETE FROM public.org_invites invites
+USING ranked_unaccepted ranked
+WHERE invites.id = ranked.id
+  AND ranked.rank > 1;
+
+-- At most one unresolved invite per organization/email.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_org_invites_pending_org_email_unique
+  ON public.org_invites (org_id, lower(email))
+  WHERE accepted_at IS NULL;
+
+-- Guarantee stable slug uniqueness for conflict-safe organization creation retries.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_organizations_slug_unique
+  ON public.organizations (slug);


### PR DESCRIPTION
## Summary\n- make org slug creation conflict-safe with insert retry on unique violations\n- harden org invite creation against concurrent duplicates (expired cleanup + conflict-aware insert path)\n- switch user/org GitHub capture settings first-write path from insert to upsert\n- add DB uniqueness migration for pending invites and org slugs\n- sync missing remote migration history files into repo to keep Supabase CLI state consistent\n\n## Supabase CLI\n- supabase migration fetch\n- supabase db push\n- supabase db push --dry-run\n\n## Testing\n- pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/__tests__/route.test.ts' 'src/app/api/orgs/[orgId]/invites/route.test.ts' 'src/app/api/github/capture/settings/route.test.ts' 'src/app/api/orgs/[orgId]/github-capture/settings/route.test.ts'\n- pnpm --filter @memories.sh/web typecheck\n\nCloses #382\nCloses #383\nCloses #384\nCloses #385

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new database RLS/policy changes and multiple index/uniqueness migrations, plus API write-path changes that rely on those constraints; mistakes could block access or cause unexpected 4xx/5xx behavior under concurrency.
> 
> **Overview**
> Hardens several API write paths against concurrent requests by making the *first write* idempotent and conflict-safe: org/user GitHub capture settings now use `upsert` with explicit `onConflict`, org invite creation cleans up expired invites then treats unique-violation insert races as an “invite already pending” response, and org creation retries slug inserts on duplicate-slug errors (with a fallback base slug).
> 
> Adds Supabase migrations to enforce and support these behaviors: a partial unique index for pending invites, a unique index for organization slugs, plus a batch of RLS/policy updates (including enabling RLS for `mcp_api_keys`, service-role-only policies for telemetry/service tables, and policy rewrites to wrap `auth.uid()/auth.role()` in subselects and consolidate permissive policies). It also rebalances database indexing by dropping many unused indexes and adding missing foreign-key covering indexes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce86f1f6421a51f68d2b5bfcccc585da305fbf2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->