### PR TITLE
Fix race conditions in workspace switch, member role updates, and DB provisioning locks

### DIFF
--- a/packages/web/src/app/api/db/provision/__tests__/route.test.ts
+++ b/packages/web/src/app/api/db/provision/__tests__/route.test.ts
@@ -57,6 +57,25 @@ vi.mock("@/lib/env", () => ({
 
 import { POST } from "../route"
 
+function buildProvisionLockTableMock() {
+  return {
+    delete: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        lt: vi.fn().mockResolvedValue({ error: null }),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: { owner_key: "org:org-1" },
+          error: null,
+        }),
+      }),
+    }),
+  }
+}
+
 describe("/api/db/provision", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -119,6 +138,9 @@ describe("/api/db/provision", () => {
     const mockOrgEq = vi.fn().mockResolvedValue({ error: null })
     const mockOrgUpdate = vi.fn().mockReturnValue({ eq: mockOrgEq })
     mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "workspace_db_provision_locks") {
+        return buildProvisionLockTableMock()
+      }
       if (table === "organizations") {
         return { update: mockOrgUpdate }
       }
@@ -169,6 +191,9 @@ describe("/api/db/provision", () => {
     })
 
     mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "workspace_db_provision_locks") {
+        return buildProvisionLockTableMock()
+      }
       if (table === "organizations") {
         return {
           update: vi.fn().mockReturnValue({

--- a/packages/web/src/app/api/db/provision/route.ts
+++ b/packages/web/src/app/api/db/provision/route.ts
@@ -12,6 +12,12 @@ type SaveCredentialsResult =
   | { ok: true; alreadyProvisioned: true; url: string }
   | { ok: false; error: unknown }
 
+type ProvisionLockTarget =
+  | { ownerType: "organization"; ownerKey: string; ownerOrgId: string; ownerUserId: null }
+  | { ownerType: "user"; ownerKey: string; ownerOrgId: null; ownerUserId: string }
+
+const PROVISION_LOCK_STALE_MS = 15 * 60 * 1000
+
 function applyNullFilter(query: {
   is?: (column: string, value: unknown) => unknown
   eq?: (column: string, value: unknown) => unknown
@@ -38,6 +44,127 @@ async function runClaimQuery(claimQuery: unknown): Promise<{ data: unknown; erro
     return { data: null, error: fallback.error }
   }
   return { data: { id: "claimed" }, error: null }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+  if (code === "23505") return true
+
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return message.includes("duplicate key")
+}
+
+function isMissingTableError(error: unknown, tableName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return (
+    message.includes(tableName.toLowerCase()) &&
+    (message.includes("does not exist") || message.includes("could not find the table"))
+  )
+}
+
+function buildProvisionLockTarget(params: {
+  ownerType: "organization" | "user"
+  orgId: string | null
+  userId: string
+}): ProvisionLockTarget {
+  if (params.ownerType === "organization") {
+    if (!params.orgId) {
+      throw new Error("Organization id missing while building provision lock target")
+    }
+    return {
+      ownerType: "organization",
+      ownerKey: `org:${params.orgId}`,
+      ownerOrgId: params.orgId,
+      ownerUserId: null,
+    }
+  }
+
+  return {
+    ownerType: "user",
+    ownerKey: `user:${params.userId}`,
+    ownerOrgId: null,
+    ownerUserId: params.userId,
+  }
+}
+
+async function clearStaleProvisionLock(
+  admin: ReturnType<typeof createAdminClient>,
+  lockTarget: ProvisionLockTarget,
+): Promise<{ error: unknown }> {
+  const staleBeforeIso = new Date(Date.now() - PROVISION_LOCK_STALE_MS).toISOString()
+  const { error } = await admin
+    .from("workspace_db_provision_locks")
+    .delete()
+    .eq("owner_key", lockTarget.ownerKey)
+    .lt("created_at", staleBeforeIso)
+
+  return { error }
+}
+
+async function acquireProvisionLock(params: {
+  admin: ReturnType<typeof createAdminClient>
+  lockTarget: ProvisionLockTarget
+  userId: string
+}): Promise<{ acquired: boolean; error: unknown }> {
+  const { admin, lockTarget, userId } = params
+
+  const staleCleanup = await clearStaleProvisionLock(admin, lockTarget)
+  if (staleCleanup.error) {
+    return { acquired: false, error: staleCleanup.error }
+  }
+
+  const { data, error } = await admin
+    .from("workspace_db_provision_locks")
+    .insert({
+      owner_key: lockTarget.ownerKey,
+      owner_type: lockTarget.ownerType,
+      owner_org_id: lockTarget.ownerOrgId,
+      owner_user_id: lockTarget.ownerUserId,
+      locked_by_user_id: userId,
+    })
+    .select("owner_key")
+    .maybeSingle()
+
+  if (error) {
+    if (isUniqueViolation(error)) {
+      return { acquired: false, error: null }
+    }
+    return { acquired: false, error }
+  }
+
+  return { acquired: Boolean(data), error: null }
+}
+
+async function releaseProvisionLock(params: {
+  admin: ReturnType<typeof createAdminClient>
+  lockTarget: ProvisionLockTarget
+  userId: string
+}): Promise<void> {
+  const { admin, lockTarget, userId } = params
+  const { error } = await admin
+    .from("workspace_db_provision_locks")
+    .delete()
+    .eq("owner_key", lockTarget.ownerKey)
+    .eq("locked_by_user_id", userId)
+
+  if (error && !isMissingTableError(error, "workspace_db_provision_locks")) {
+    console.warn("Failed to release workspace DB provision lock:", {
+      lockOwnerKey: lockTarget.ownerKey,
+      lockedByUserId: userId,
+      error,
+    })
+  }
 }
 
 async function saveProvisionedCredentials(params: {
@@ -187,10 +314,67 @@ export async function POST(request: Request): Promise<Response> {
     )
   }
 
+  const lockTarget = buildProvisionLockTarget({
+    ownerType: context.ownerType,
+    orgId: context.orgId ?? null,
+    userId: auth.userId,
+  })
+  const lockResult = await acquireProvisionLock({
+    admin,
+    lockTarget,
+    userId: auth.userId,
+  })
+
+  if (lockResult.error) {
+    if (isMissingTableError(lockResult.error, "workspace_db_provision_locks")) {
+      return NextResponse.json(
+        { error: "Provisioning locks are not available yet. Run the latest database migration first." },
+        { status: 503 }
+      )
+    }
+    console.error("Failed to acquire workspace provisioning lock:", {
+      error: lockResult.error,
+      ownerType: lockTarget.ownerType,
+      ownerKey: lockTarget.ownerKey,
+      userId: auth.userId,
+    })
+    return NextResponse.json(
+      { error: "Failed to start provisioning" },
+      { status: 500 }
+    )
+  }
+
+  if (!lockResult.acquired) {
+    const latestContext = await resolveWorkspaceContext(admin, auth.userId, {
+      fallbackToUserWithoutOrgCredentials: false,
+    })
+    if (latestContext?.hasDatabase && latestContext.turso_db_url && latestContext.turso_db_token) {
+      return NextResponse.json({
+        url: latestContext.turso_db_url,
+        provisioned: false,
+      })
+    }
+
+    return NextResponse.json(
+      { error: "Provisioning is already in progress for this workspace" },
+      { status: 409 }
+    )
+  }
+
   const tursoOrg = getTursoOrgSlug()
   let createdDbName: string | null = null
 
   try {
+    const latestContext = await resolveWorkspaceContext(admin, auth.userId, {
+      fallbackToUserWithoutOrgCredentials: false,
+    })
+    if (latestContext?.hasDatabase && latestContext.turso_db_url && latestContext.turso_db_token) {
+      return NextResponse.json({
+        url: latestContext.turso_db_url,
+        provisioned: false,
+      })
+    }
+
     // Create a new Turso database
     const db = await createDatabase(tursoOrg)
     createdDbName = db.name
@@ -255,5 +439,11 @@ export async function POST(request: Request): Promise<Response> {
       { error: "Failed to provision database" },
       { status: 500 }
     )
+  } finally {
+    await releaseProvisionLock({
+      admin,
+      lockTarget,
+      userId: auth.userId,
+    })
   }
 }

--- a/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
@@ -4,6 +4,7 @@ const {
   mockGetUser,
   mockSupabaseFrom,
   mockAdminFrom,
+  mockAdminRpc,
   mockAdminListUsers,
   mockAdminGetUserById,
   mockTursoExecute,
@@ -12,6 +13,7 @@ const {
   mockGetUser: vi.fn(),
   mockSupabaseFrom: vi.fn(),
   mockAdminFrom: vi.fn(),
+  mockAdminRpc: vi.fn(),
   mockAdminListUsers: vi.fn(),
   mockAdminGetUserById: vi.fn(),
   mockTursoExecute: vi.fn(),
@@ -30,6 +32,7 @@ vi.mock("@/lib/supabase/server", () => ({
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     from: mockAdminFrom,
+    rpc: mockAdminRpc,
     auth: {
       admin: {
         listUsers: mockAdminListUsers,
@@ -739,25 +742,9 @@ describe("/api/orgs/[orgId]/members PATCH", () => {
   })
 
   it("returns 500 when actor membership lookup fails", async () => {
-    mockSupabaseFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: { message: "DB read failed" },
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {
-        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
-      }
+    mockAdminRpc.mockResolvedValue({
+      data: null,
+      error: { message: "DB read failed" },
     })
 
     const response = await PATCH(
@@ -776,30 +763,9 @@ describe("/api/orgs/[orgId]/members PATCH", () => {
   })
 
   it("returns 500 when target membership lookup fails", async () => {
-    let membershipLookupCount = 0
-
-    mockSupabaseFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockImplementation(async () => {
-                  membershipLookupCount += 1
-                  if (membershipLookupCount === 1) {
-                    return { data: { role: "owner" }, error: null }
-                  }
-                  return { data: null, error: { message: "DB read failed" } }
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {
-        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
-      }
+    mockAdminRpc.mockResolvedValue({
+      data: { status: "target_not_member" },
+      error: null,
     })
 
     const response = await PATCH(
@@ -811,44 +777,16 @@ describe("/api/orgs/[orgId]/members PATCH", () => {
       { params: Promise.resolve({ orgId: "org-1" }) },
     )
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(404)
     await expect(response.json()).resolves.toMatchObject({
-      error: "Failed to update member role",
+      error: "User is not a member",
     })
   })
 
   it("returns 500 when role update fails", async () => {
-    let membershipLookupCount = 0
-
-    mockSupabaseFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockImplementation(async () => {
-                  membershipLookupCount += 1
-                  if (membershipLookupCount === 1) {
-                    return { data: { role: "owner" }, error: null }
-                  }
-                  return { data: { role: "member" }, error: null }
-                }),
-              }),
-            }),
-          })),
-          update: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockResolvedValue({
-                error: { message: "DB write failed" },
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {
-        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
-      }
+    mockAdminRpc.mockResolvedValue({
+      data: { status: "unexpected_state" },
+      error: null,
     })
 
     const response = await PATCH(

--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -73,6 +73,21 @@ function buildGravatarUrl(email: string): string {
   return `https://www.gravatar.com/avatar/${hash}?d=identicon&s=96`
 }
 
+function isMissingFunctionError(error: unknown, functionName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+  const fn = functionName.toLowerCase()
+
+  return (
+    message.includes(fn) &&
+    (message.includes("does not exist") ||
+      message.includes("function") ||
+      message.includes("could not find"))
+  )
+}
+
 function isMissingColumnError(error: unknown, columnName: string): boolean {
   const message =
     typeof error === "object" && error !== null && "message" in error
@@ -495,17 +510,24 @@ export async function PATCH(
   if (!parsed.success) return parsed.response
   const { userId, role } = parsed.data
 
-  // Check current user is owner or admin
-  const { data: currentMembership, error: currentMembershipError } = await supabase
-    .from("org_members")
-    .select("role")
-    .eq("org_id", orgId)
-    .eq("user_id", user.id)
-    .single()
+  const admin = createAdminClient()
+  const { data: roleUpdateResult, error: roleUpdateError } = await admin.rpc("update_org_member_role_atomic", {
+    p_org_id: orgId,
+    p_actor_user_id: user.id,
+    p_target_user_id: userId,
+    p_next_role: role,
+  })
 
-  if (currentMembershipError) {
-    console.error("Failed to verify acting membership before updating org member role:", {
-      error: currentMembershipError,
+  if (roleUpdateError) {
+    if (isMissingFunctionError(roleUpdateError, "update_org_member_role_atomic")) {
+      return NextResponse.json(
+        { error: "Member role updates are not available yet. Run the latest database migration first." },
+        { status: 503 }
+      )
+    }
+
+    console.error("Failed to update org member role atomically:", {
+      error: roleUpdateError,
       orgId,
       actorUserId: user.id,
       targetUserId: userId,
@@ -514,57 +536,45 @@ export async function PATCH(
     return NextResponse.json({ error: "Failed to update member role" }, { status: 500 })
   }
 
-  if (!currentMembership || !["owner", "admin"].includes(currentMembership.role)) {
+  const result =
+    typeof roleUpdateResult === "object" && roleUpdateResult !== null
+      ? (roleUpdateResult as { status?: string; previous_role?: string | null; updated?: boolean })
+      : null
+  const resultStatus = result?.status ?? null
+
+  if (resultStatus === "insufficient_permissions") {
     return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
   }
 
-  // Can't change owner's role
-  const { data: targetMembership, error: targetMembershipError } = await supabase
-    .from("org_members")
-    .select("role")
-    .eq("org_id", orgId)
-    .eq("user_id", userId)
-    .single()
-
-  if (targetMembershipError) {
-    console.error("Failed to verify target membership before updating org member role:", {
-      error: targetMembershipError,
-      orgId,
-      actorUserId: user.id,
-      targetUserId: userId,
-      targetRole: role,
-    })
-    return NextResponse.json({ error: "Failed to update member role" }, { status: 500 })
-  }
-
-  if (!targetMembership) {
+  if (resultStatus === "target_not_member") {
     return NextResponse.json({ error: "User is not a member" }, { status: 404 })
   }
 
-  if (targetMembership.role === "owner") {
+  if (resultStatus === "target_is_owner") {
     return NextResponse.json({ error: "Cannot change owner's role" }, { status: 400 })
   }
 
-  // Only owner can promote to admin
-  if (role === "admin" && currentMembership.role !== "owner") {
+  if (resultStatus === "owner_required") {
     return NextResponse.json({ error: "Only owner can promote to admin" }, { status: 403 })
   }
 
-  const { error } = await supabase
-    .from("org_members")
-    .update({ role })
-    .eq("org_id", orgId)
-    .eq("user_id", userId)
+  if (resultStatus === "invalid_role") {
+    return NextResponse.json({ error: "Invalid role" }, { status: 400 })
+  }
 
-  if (error) {
-    console.error("Failed to update org member role row:", {
-      error,
+  if (resultStatus !== "updated" && resultStatus !== "unchanged") {
+    console.error("Unexpected org member role update result:", {
       orgId,
       actorUserId: user.id,
       targetUserId: userId,
       targetRole: role,
+      result: roleUpdateResult,
     })
     return NextResponse.json({ error: "Failed to update member role" }, { status: 500 })
+  }
+
+  if (resultStatus === "unchanged") {
+    return NextResponse.json({ success: true })
   }
 
   await logOrgAuditEvent({
@@ -576,7 +586,7 @@ export async function PATCH(
     targetId: userId,
     targetLabel: userId,
     metadata: {
-      previousRole: targetMembership.role,
+      previousRole: result?.previous_role ?? null,
       nextRole: role,
     },
   })

--- a/packages/web/src/app/api/user/__tests__/route.test.ts
+++ b/packages/web/src/app/api/user/__tests__/route.test.ts
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
   mockAuthenticateRequest,
   mockAdminFrom,
+  mockAdminRpc,
   mockCheckRateLimit,
   mockCheckPreAuthApiRateLimit,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockAdminFrom: vi.fn(),
+  mockAdminRpc: vi.fn(),
   mockCheckRateLimit: vi.fn(),
   mockCheckPreAuthApiRateLimit: vi.fn(),
 }))
@@ -19,6 +21,7 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     from: mockAdminFrom,
+    rpc: mockAdminRpc,
   })),
 }))
 
@@ -114,20 +117,9 @@ describe("/api/user", () => {
     it("returns 403 when switching to an org the user is not a member of", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
       const mockInsertSwitchEvent = vi.fn().mockResolvedValue({ error: null })
+      mockAdminRpc.mockResolvedValue({ data: "membership_denied", error: null })
 
       mockAdminFrom.mockImplementation((table: string) => {
-        if (table === "org_members") {
-          return {
-            select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-                }),
-              }),
-            }),
-          }
-        }
-
         if (table === "users") {
           return {
             select: vi.fn().mockReturnValue({
@@ -162,26 +154,12 @@ describe("/api/user", () => {
       )
     })
 
-    it("returns 500 when workspace switch membership lookup fails", async () => {
+    it("returns 500 when workspace switch RPC fails", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
       const mockInsertSwitchEvent = vi.fn().mockResolvedValue({ error: null })
+      mockAdminRpc.mockResolvedValue({ data: null, error: { message: "DB read failed" } })
 
       mockAdminFrom.mockImplementation((table: string) => {
-        if (table === "org_members") {
-          return {
-            select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  maybeSingle: vi.fn().mockResolvedValue({
-                    data: null,
-                    error: { message: "DB read failed" },
-                  }),
-                }),
-              }),
-            }),
-          }
-        }
-
         if (table === "users") {
           return {
             select: vi.fn().mockReturnValue({
@@ -214,32 +192,18 @@ describe("/api/user", () => {
           from_org_id: null,
           to_org_id: "org-1",
           success: false,
-          error_code: "membership_lookup_failed",
+          error_code: "switch_rpc_failed",
         }),
       )
     })
 
     it("updates current_org_id when membership is valid", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
-
-      const mockUpdate = vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      })
+      mockAdminRpc.mockResolvedValue({ data: "updated", error: null })
+      const mockUpdate = vi.fn()
       const mockInsertSwitchEvent = vi.fn().mockResolvedValue({ error: null })
 
       mockAdminFrom.mockImplementation((table: string) => {
-        if (table === "org_members") {
-          return {
-            select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  maybeSingle: vi.fn().mockResolvedValue({ data: { id: "membership-1" }, error: null }),
-                }),
-              }),
-            }),
-          }
-        }
-
         if (table === "users") {
           return {
             select: vi.fn().mockReturnValue({
@@ -264,7 +228,7 @@ describe("/api/user", () => {
       expect(response.status).toBe(200)
       expect(body.ok).toBe(true)
       expect(typeof body.workspace_cache_bust_key).toBe("string")
-      expect(mockUpdate).toHaveBeenCalledWith({ current_org_id: "org-1" })
+      expect(mockUpdate).not.toHaveBeenCalled()
       expect(mockInsertSwitchEvent).toHaveBeenCalledTimes(1)
       expect(mockInsertSwitchEvent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -277,10 +241,9 @@ describe("/api/user", () => {
 
     it("allows clearing current_org_id", async () => {
       mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "u@example.com" })
+      mockAdminRpc.mockResolvedValue({ data: "updated", error: null })
 
-      const mockUpdate = vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      })
+      const mockUpdate = vi.fn()
       const mockInsertSwitchEvent = vi.fn().mockResolvedValue({ error: null })
 
       mockAdminFrom.mockImplementation((table: string) => {
@@ -304,7 +267,7 @@ describe("/api/user", () => {
       const body = await response.json()
       expect(response.status).toBe(200)
       expect(typeof body.workspace_cache_bust_key).toBe("string")
-      expect(mockUpdate).toHaveBeenCalledWith({ current_org_id: null })
+      expect(mockUpdate).not.toHaveBeenCalled()
       expect(mockInsertSwitchEvent).toHaveBeenCalledTimes(1)
       expect(mockInsertSwitchEvent).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/web/src/app/api/user/route.ts
+++ b/packages/web/src/app/api/user/route.ts
@@ -61,6 +61,21 @@ function isMissingTableError(error: unknown, tableName: string): boolean {
   )
 }
 
+function isMissingFunctionError(error: unknown, functionName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+  const fn = functionName.toLowerCase()
+
+  return (
+    message.includes(fn) &&
+    (message.includes("does not exist") ||
+      message.includes("function") ||
+      message.includes("could not find"))
+  )
+}
+
 function workspaceCacheBustKey(userId: string): string {
   return `${userId}:${Date.now()}`
 }
@@ -204,70 +219,96 @@ export async function PATCH(request: Request): Promise<Response> {
     ? (parsed.data.current_org_id as string | null)
     : null
 
+  let switchApplied = false
+
   if (switchRequested) {
-    const nextOrgId = parsed.data.current_org_id
+    const { data: switchResult, error: switchError } = await admin.rpc("switch_user_workspace_atomic", {
+      p_user_id: auth.userId,
+      p_next_org_id: switchToOrgId,
+    })
 
-    if (nextOrgId == null) {
-      updates.current_org_id = null
-    } else if (typeof nextOrgId === "string") {
-      const { data: membership, error: membershipError } = await admin
-        .from("org_members")
-        .select("id")
-        .eq("org_id", nextOrgId)
-        .eq("user_id", auth.userId)
-        .maybeSingle()
-
-      if (membershipError) {
-        if (switchStartedAt !== null) {
-          await recordWorkspaceSwitchEvent(admin, {
-            userId: auth.userId,
-            fromOrgId: switchFromOrgId,
-            toOrgId: switchToOrgId,
-            durationMs: Date.now() - switchStartedAt,
-            success: false,
-            errorCode: "membership_lookup_failed",
-          })
-        }
-
-        console.error("Workspace switch membership lookup failed:", {
-          error: membershipError,
-          userId: auth.userId,
-          fromOrgId: switchFromOrgId,
-          toOrgId: switchToOrgId,
-        })
-        return NextResponse.json({ error: "Failed to update user" }, { status: 500 })
-      }
-
-      if (!membership) {
-        if (switchStartedAt !== null) {
-          await recordWorkspaceSwitchEvent(admin, {
-            userId: auth.userId,
-            fromOrgId: switchFromOrgId,
-            toOrgId: switchToOrgId,
-            durationMs: Date.now() - switchStartedAt,
-            success: false,
-            errorCode: "membership_denied",
-          })
-        }
-
+    if (switchError) {
+      if (isMissingFunctionError(switchError, "switch_user_workspace_atomic")) {
         return NextResponse.json(
-          { error: "You are not a member of that organization" },
-          { status: 403 }
+          { error: "Workspace switching is not available yet. Run the latest database migration first." },
+          { status: 503 }
         )
       }
 
-      updates.current_org_id = nextOrgId
+      if (switchStartedAt !== null) {
+        await recordWorkspaceSwitchEvent(admin, {
+          userId: auth.userId,
+          fromOrgId: switchFromOrgId,
+          toOrgId: switchToOrgId,
+          durationMs: Date.now() - switchStartedAt,
+          success: false,
+          errorCode: "switch_rpc_failed",
+        })
+      }
+
+      console.error("Workspace switch RPC failed:", {
+        error: switchError,
+        userId: auth.userId,
+        fromOrgId: switchFromOrgId,
+        toOrgId: switchToOrgId,
+      })
+      return NextResponse.json({ error: "Failed to update user" }, { status: 500 })
     }
+
+    if (switchResult === "membership_denied") {
+      if (switchStartedAt !== null) {
+        await recordWorkspaceSwitchEvent(admin, {
+          userId: auth.userId,
+          fromOrgId: switchFromOrgId,
+          toOrgId: switchToOrgId,
+          durationMs: Date.now() - switchStartedAt,
+          success: false,
+          errorCode: "membership_denied",
+        })
+      }
+
+      return NextResponse.json(
+        { error: "You are not a member of that organization" },
+        { status: 403 }
+      )
+    }
+
+    if (switchResult !== "updated") {
+      if (switchStartedAt !== null) {
+        await recordWorkspaceSwitchEvent(admin, {
+          userId: auth.userId,
+          fromOrgId: switchFromOrgId,
+          toOrgId: switchToOrgId,
+          durationMs: Date.now() - switchStartedAt,
+          success: false,
+          errorCode: "switch_update_failed",
+        })
+      }
+
+      console.error("Workspace switch RPC returned unexpected state:", {
+        userId: auth.userId,
+        fromOrgId: switchFromOrgId,
+        toOrgId: switchToOrgId,
+        result: switchResult,
+      })
+      return NextResponse.json({ error: "Failed to update user" }, { status: 500 })
+    }
+
+    switchApplied = true
   }
 
-  if (Object.keys(updates).length === 0) {
+  if (Object.keys(updates).length === 0 && !switchApplied) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 })
   }
 
-  const { error } = await admin
-    .from("users")
-    .update(updates)
-    .eq("id", auth.userId)
+  let error: unknown = null
+  if (Object.keys(updates).length > 0) {
+    const response = await admin
+      .from("users")
+      .update(updates)
+      .eq("id", auth.userId)
+    error = response.error
+  }
 
   if (error) {
     if (

--- a/supabase/migrations/20260302193000_harden_workspace_switch_member_role_and_provision_lock.sql
+++ b/supabase/migrations/20260302193000_harden_workspace_switch_member_role_and_provision_lock.sql
@@ -1,0 +1,171 @@
+-- Atomic helpers for workspace switching + member role updates,
+-- plus a lock table to avoid duplicate DB provisioning work.
+
+CREATE TABLE IF NOT EXISTS public.workspace_db_provision_locks (
+  owner_key TEXT PRIMARY KEY,
+  owner_type TEXT NOT NULL CHECK (owner_type IN ('user', 'organization')),
+  owner_user_id UUID REFERENCES public.users(id) ON DELETE CASCADE,
+  owner_org_id UUID REFERENCES public.organizations(id) ON DELETE CASCADE,
+  locked_by_user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT workspace_db_provision_locks_owner_check CHECK (
+    (owner_type = 'user' AND owner_user_id IS NOT NULL AND owner_org_id IS NULL)
+    OR
+    (owner_type = 'organization' AND owner_org_id IS NOT NULL AND owner_user_id IS NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_db_provision_locks_created_at
+  ON public.workspace_db_provision_locks (created_at);
+
+ALTER TABLE public.workspace_db_provision_locks ENABLE ROW LEVEL SECURITY;
+
+DO $policy$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'workspace_db_provision_locks'
+      AND policyname = 'Service role full access workspace db provision locks'
+  ) THEN
+    CREATE POLICY "Service role full access workspace db provision locks"
+      ON public.workspace_db_provision_locks FOR ALL
+      USING (auth.role() = 'service_role')
+      WITH CHECK (auth.role() = 'service_role');
+  END IF;
+END
+$policy$;
+
+DO $switch_workspace$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.switch_user_workspace_atomic(
+      p_user_id UUID,
+      p_next_org_id UUID
+    ) RETURNS TEXT
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    DECLARE
+      v_has_membership BOOLEAN := FALSE;
+    BEGIN
+      IF p_next_org_id IS NULL THEN
+        UPDATE public.users
+        SET current_org_id = NULL
+        WHERE id = p_user_id;
+
+        IF NOT FOUND THEN
+          RETURN 'not_found';
+        END IF;
+
+        RETURN 'updated';
+      END IF;
+
+      SELECT TRUE
+      INTO v_has_membership
+      FROM public.org_members
+      WHERE org_id = p_next_org_id
+        AND user_id = p_user_id
+      FOR SHARE;
+
+      IF NOT v_has_membership THEN
+        RETURN 'membership_denied';
+      END IF;
+
+      UPDATE public.users
+      SET current_org_id = p_next_org_id
+      WHERE id = p_user_id;
+
+      IF NOT FOUND THEN
+        RETURN 'not_found';
+      END IF;
+
+      RETURN 'updated';
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.switch_user_workspace_atomic(UUID, UUID) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.switch_user_workspace_atomic(UUID, UUID) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.switch_user_workspace_atomic(UUID, UUID) TO service_role';
+END
+$switch_workspace$;
+
+DO $update_member_role$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.update_org_member_role_atomic(
+      p_org_id UUID,
+      p_actor_user_id UUID,
+      p_target_user_id UUID,
+      p_next_role TEXT
+    ) RETURNS JSONB
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    DECLARE
+      v_actor_role TEXT;
+      v_target_role TEXT;
+    BEGIN
+      IF p_next_role IS NULL OR p_next_role NOT IN ('admin', 'member') THEN
+        RETURN jsonb_build_object('status', 'invalid_role');
+      END IF;
+
+      SELECT role
+      INTO v_actor_role
+      FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_actor_user_id
+      FOR UPDATE;
+
+      IF v_actor_role IS NULL OR v_actor_role NOT IN ('owner', 'admin') THEN
+        RETURN jsonb_build_object('status', 'insufficient_permissions');
+      END IF;
+
+      SELECT role
+      INTO v_target_role
+      FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_target_user_id
+      FOR UPDATE;
+
+      IF v_target_role IS NULL THEN
+        RETURN jsonb_build_object('status', 'target_not_member');
+      END IF;
+
+      IF v_target_role = 'owner' THEN
+        RETURN jsonb_build_object('status', 'target_is_owner');
+      END IF;
+
+      IF p_next_role = 'admin' AND v_actor_role <> 'owner' THEN
+        RETURN jsonb_build_object('status', 'owner_required');
+      END IF;
+
+      IF v_target_role = p_next_role THEN
+        RETURN jsonb_build_object(
+          'status', 'unchanged',
+          'updated', false,
+          'previous_role', v_target_role
+        );
+      END IF;
+
+      UPDATE public.org_members
+      SET role = p_next_role
+      WHERE org_id = p_org_id
+        AND user_id = p_target_user_id;
+
+      RETURN jsonb_build_object(
+        'status', 'updated',
+        'updated', true,
+        'previous_role', v_target_role
+      );
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.update_org_member_role_atomic(UUID, UUID, UUID, TEXT) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.update_org_member_role_atomic(UUID, UUID, UUID, TEXT) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.update_org_member_role_atomic(UUID, UUID, UUID, TEXT) TO service_role';
+END
+$update_member_role$;


### PR DESCRIPTION
## Summary
- switch dashboard workspace changes to atomic DB RPC (`switch_user_workspace_atomic`) to remove check-then-update TOCTOU windows
- update org member role changes to atomic DB RPC (`update_org_member_role_atomic`) with deterministic status handling
- add workspace provisioning lock table + lock acquire/release flow to prevent duplicate Turso DB creation under concurrent requests
- add/update API route tests for the new RPC and lock behavior
- add migration to create lock table + atomic RPC functions (applied via Supabase CLI)

## Validation
- `pnpm --filter @memories.sh/web exec vitest run src/app/api/user/__tests__/route.test.ts 'src/app/api/orgs/[orgId]/members/route.test.ts' src/app/api/db/provision/__tests__/route.test.ts`
- `pnpm --filter @memories.sh/web typecheck`
- `supabase db push --yes`
- `supabase migration list`

Fixes #380
Fixes #381
Fixes #386

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new Supabase migration with SECURITY DEFINER RPCs and a new locking table, and rewires API flows to depend on them; issues in the SQL/permissions or missing migrations can break workspace switching, role changes, or provisioning under concurrency.
> 
> **Overview**
> Fixes several concurrency/TOCTOU paths by moving dashboard workspace switching and org member role changes to **atomic Supabase RPCs** (with explicit status handling), returning `503` when the required DB function isn’t migrated yet.
> 
> Adds a `workspace_db_provision_locks` table and integrates an acquire/release lock around Turso DB provisioning (including stale-lock cleanup and `409` when provisioning is already in progress), with a new migration to create the lock table + RPC functions and updated route tests to mock the new `rpc`/lock behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8eaacd627a89668d8d7cfd690c4073d293b8b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->