### PR TITLE
Fix org authorization TOCTOU races with atomic RPC guards

### DIFF
--- a/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.test.ts
@@ -605,25 +605,9 @@ describe("/api/orgs/[orgId]/members DELETE", () => {
   })
 
   it("returns 500 when actor membership lookup fails", async () => {
-    mockSupabaseFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: { message: "DB read failed" },
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {
-        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
-      }
+    mockAdminRpc.mockResolvedValue({
+      data: null,
+      error: { message: "DB read failed" },
     })
 
     const response = await DELETE(
@@ -637,31 +621,10 @@ describe("/api/orgs/[orgId]/members DELETE", () => {
     })
   })
 
-  it("returns 500 when target membership lookup fails", async () => {
-    let membershipLookupCount = 0
-
-    mockSupabaseFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockImplementation(async () => {
-                  membershipLookupCount += 1
-                  if (membershipLookupCount === 1) {
-                    return { data: { role: "owner" }, error: null }
-                  }
-                  return { data: null, error: { message: "DB read failed" } }
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {
-        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
-      }
+  it("returns 404 when target membership is missing", async () => {
+    mockAdminRpc.mockResolvedValue({
+      data: { status: "target_not_member" },
+      error: null,
     })
 
     const response = await DELETE(
@@ -669,57 +632,16 @@ describe("/api/orgs/[orgId]/members DELETE", () => {
       { params: Promise.resolve({ orgId: "org-1" }) },
     )
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(404)
     await expect(response.json()).resolves.toMatchObject({
-      error: "Failed to remove member",
+      error: "User is not a member",
     })
   })
 
   it("returns 500 when member deletion fails", async () => {
-    let membershipLookupCount = 0
-
-    mockSupabaseFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockImplementation(async () => {
-                  membershipLookupCount += 1
-                  if (membershipLookupCount === 1) {
-                    return { data: { role: "owner" }, error: null }
-                  }
-                  return { data: { role: "member" }, error: null }
-                }),
-              }),
-            }),
-          })),
-          delete: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockResolvedValue({
-                error: { message: "DB write failed" },
-              }),
-            }),
-          })),
-        }
-      }
-
-      if (table === "organizations") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({
-                data: { stripe_subscription_id: null },
-                error: null,
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {
-        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn() })),
-      }
+    mockAdminRpc.mockResolvedValue({
+      data: { status: "unexpected_state" },
+      error: null,
     })
 
     const response = await DELETE(

--- a/packages/web/src/app/api/orgs/[orgId]/members/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/members/route.ts
@@ -362,6 +362,7 @@ export async function DELETE(
   }
 
   const supabase = await createClient()
+  const admin = createAdminClient()
   const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
@@ -371,17 +372,22 @@ export async function DELETE(
   const rateLimited = await checkRateLimit(apiRateLimit, user.id)
   if (rateLimited) return rateLimited
 
-  // Check current user's role
-  const { data: currentMembership, error: currentMembershipError } = await supabase
-    .from("org_members")
-    .select("role")
-    .eq("org_id", orgId)
-    .eq("user_id", user.id)
-    .single()
+  const { data: memberRemoveResult, error: memberRemoveError } = await admin.rpc("remove_org_member_atomic", {
+    p_org_id: orgId,
+    p_actor_user_id: user.id,
+    p_target_user_id: targetUserId,
+  })
 
-  if (currentMembershipError) {
-    console.error("Failed to verify acting membership before removing org member:", {
-      error: currentMembershipError,
+  if (memberRemoveError) {
+    if (isMissingFunctionError(memberRemoveError, "remove_org_member_atomic")) {
+      return NextResponse.json(
+        { error: "Member removal is not available yet. Run the latest database migration first." },
+        { status: 503 }
+      )
+    }
+
+    console.error("Failed to remove org member atomically:", {
+      error: memberRemoveError,
       orgId,
       actorUserId: user.id,
       targetUserId,
@@ -389,69 +395,40 @@ export async function DELETE(
     return NextResponse.json({ error: "Failed to remove member" }, { status: 500 })
   }
 
-  if (!currentMembership) {
+  const memberRemove =
+    typeof memberRemoveResult === "object" && memberRemoveResult !== null
+      ? (memberRemoveResult as { status?: string; removed_role?: string | null; removed_by_self?: boolean })
+      : null
+  const memberRemoveStatus = memberRemove?.status ?? null
+
+  if (memberRemoveStatus === "actor_not_member") {
     return NextResponse.json({ error: "Not a member of this organization" }, { status: 403 })
   }
-
-  // Get target user's membership
-  const { data: targetMembership, error: targetMembershipError } = await supabase
-    .from("org_members")
-    .select("role")
-    .eq("org_id", orgId)
-    .eq("user_id", targetUserId)
-    .single()
-
-  if (targetMembershipError) {
-    console.error("Failed to verify target membership before removing org member:", {
-      error: targetMembershipError,
+  if (memberRemoveStatus === "target_not_member") {
+    return NextResponse.json({ error: "User is not a member" }, { status: 404 })
+  }
+  if (memberRemoveStatus === "target_is_owner") {
+    return NextResponse.json({ error: "Cannot remove the organization owner" }, { status: 400 })
+  }
+  if (memberRemoveStatus === "insufficient_permissions") {
+    return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
+  }
+  if (memberRemoveStatus !== "removed") {
+    console.error("Unexpected org member remove result:", {
       orgId,
       actorUserId: user.id,
       targetUserId,
+      result: memberRemoveResult,
     })
     return NextResponse.json({ error: "Failed to remove member" }, { status: 500 })
   }
 
-  if (!targetMembership) {
-    return NextResponse.json({ error: "User is not a member" }, { status: 404 })
-  }
-
-  // Can't remove the owner
-  if (targetMembership.role === "owner") {
-    return NextResponse.json({ error: "Cannot remove the organization owner" }, { status: 400 })
-  }
-
-  // Users can remove themselves, or admins/owners can remove others
-  const canRemove = 
-    targetUserId === user.id || 
-    ["owner", "admin"].includes(currentMembership.role)
-
-  if (!canRemove) {
-    return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
-  }
-
-  // Get org's subscription to decrement seat
+  // Get org's subscription to decrement seat after successful member removal.
   const { data: org } = await supabase
     .from("organizations")
     .select("stripe_subscription_id")
     .eq("id", orgId)
     .single()
-
-  // Remove the member
-  const { error } = await supabase
-    .from("org_members")
-    .delete()
-    .eq("org_id", orgId)
-    .eq("user_id", targetUserId)
-
-  if (error) {
-    console.error("Failed to delete org member row:", {
-      error,
-      orgId,
-      actorUserId: user.id,
-      targetUserId,
-    })
-    return NextResponse.json({ error: "Failed to remove member" }, { status: 500 })
-  }
 
   await logOrgAuditEvent({
     client: supabase,
@@ -462,8 +439,8 @@ export async function DELETE(
     targetId: targetUserId,
     targetLabel: targetUserId,
     metadata: {
-      targetRole: targetMembership.role,
-      removedBySelf: targetUserId === user.id,
+      targetRole: memberRemove?.removed_role ?? null,
+      removedBySelf: memberRemove?.removed_by_self ?? targetUserId === user.id,
     },
   })
 

--- a/packages/web/src/app/api/orgs/[orgId]/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
   mockGetUser,
   mockFrom,
+  mockAdminRpc,
   mockCheckRateLimit,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
+  mockAdminRpc: vi.fn(),
   mockCheckRateLimit: vi.fn(),
 }))
 
@@ -24,6 +26,12 @@ vi.mock("@/lib/rate-limit", () => ({
   checkRateLimit: mockCheckRateLimit,
 }))
 
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    rpc: mockAdminRpc,
+  })),
+}))
+
 import { DELETE, GET, PATCH } from "./route"
 
 describe("/api/orgs/[orgId] PATCH", () => {
@@ -34,20 +42,7 @@ describe("/api/orgs/[orgId] PATCH", () => {
   })
 
   it("blocks admins from changing domain auto-join settings", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { role: "admin" }, error: null }),
-              }),
-            }),
-          })),
-        }
-      }
-      return {}
-    })
+    mockAdminRpc.mockResolvedValue({ data: "owner_required", error: null })
 
     const response = await PATCH(
       new Request("https://example.com/api/orgs/org-1", {
@@ -64,23 +59,10 @@ describe("/api/orgs/[orgId] PATCH", () => {
     })
   })
 
-  it("returns 500 when membership lookup fails", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: { message: "DB read failed" },
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-      return {}
+  it("returns 500 when settings RPC fails", async () => {
+    mockAdminRpc.mockResolvedValue({
+      data: null,
+      error: { message: "DB write failed" },
     })
 
     const response = await PATCH(
@@ -99,36 +81,7 @@ describe("/api/orgs/[orgId] PATCH", () => {
   })
 
   it("returns 500 when organization update fails", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      if (table === "organizations") {
-        return {
-          update: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              select: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: { message: "DB write failed", code: "XX000" },
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {}
-    })
+    mockAdminRpc.mockResolvedValue({ data: "unexpected_state", error: null })
 
     const response = await PATCH(
       new Request("https://example.com/api/orgs/org-1", {
@@ -146,38 +99,7 @@ describe("/api/orgs/[orgId] PATCH", () => {
   })
 
   it("requires a domain before enabling auto-join", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      if (table === "organizations") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({
-                data: {
-                  plan: "team",
-                  domain_auto_join_enabled: false,
-                  domain_auto_join_domain: null,
-                },
-                error: null,
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {}
-    })
+    mockAdminRpc.mockResolvedValue({ data: "domain_required", error: null })
 
     const response = await PATCH(
       new Request("https://example.com/api/orgs/org-1", {
@@ -195,49 +117,24 @@ describe("/api/orgs/[orgId] PATCH", () => {
   })
 
   it("normalizes the domain when owner updates settings", async () => {
-    const mockUpdate = vi.fn(() => ({
-      eq: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: {
-              id: "org-1",
-              domain_auto_join_enabled: true,
-              domain_auto_join_domain: "webrenew.io",
-            },
-            error: null,
-          }),
-        }),
-      }),
-    }))
+    mockAdminRpc.mockResolvedValue({ data: "updated", error: null })
 
     mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null }),
-              }),
-            }),
-          })),
-        }
-      }
-
       if (table === "organizations") {
         return {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnValue({
               single: vi.fn().mockResolvedValue({
                 data: {
+                  id: "org-1",
                   plan: "team",
-                  domain_auto_join_enabled: false,
-                  domain_auto_join_domain: null,
+                  domain_auto_join_enabled: true,
+                  domain_auto_join_domain: "webrenew.io",
                 },
                 error: null,
               }),
             }),
           })),
-          update: mockUpdate,
         }
       }
 
@@ -257,58 +154,36 @@ describe("/api/orgs/[orgId] PATCH", () => {
     )
 
     expect(response.status).toBe(200)
-    expect(mockUpdate).toHaveBeenCalledWith(
+    expect(mockAdminRpc).toHaveBeenCalledWith(
+      "update_org_settings_atomic",
       expect.objectContaining({
-        domain_auto_join_enabled: true,
-        domain_auto_join_domain: "webrenew.io",
-      }),
+        p_domain_auto_join_enabled: true,
+        p_set_domain_auto_join_enabled: true,
+        p_domain_auto_join_domain: "webrenew.io",
+        p_set_domain_auto_join_domain: true,
+      })
     )
   })
 
   it("activates auto-join when saving a new domain even if enabled=false was sent", async () => {
-    const mockUpdate = vi.fn(() => ({
-      eq: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: {
-              id: "org-1",
-              domain_auto_join_enabled: true,
-              domain_auto_join_domain: "webrenew.io",
-            },
-            error: null,
-          }),
-        }),
-      }),
-    }))
+    mockAdminRpc.mockResolvedValue({ data: "updated", error: null })
 
     mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null }),
-              }),
-            }),
-          })),
-        }
-      }
-
       if (table === "organizations") {
         return {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnValue({
               single: vi.fn().mockResolvedValue({
                 data: {
+                  id: "org-1",
                   plan: "team",
-                  domain_auto_join_enabled: false,
-                  domain_auto_join_domain: null,
+                  domain_auto_join_enabled: true,
+                  domain_auto_join_domain: "webrenew.io",
                 },
                 error: null,
               }),
             }),
           })),
-          update: mockUpdate,
         }
       }
 
@@ -328,47 +203,19 @@ describe("/api/orgs/[orgId] PATCH", () => {
     )
 
     expect(response.status).toBe(200)
-    expect(mockUpdate).toHaveBeenCalledWith(
+    expect(mockAdminRpc).toHaveBeenCalledWith(
+      "update_org_settings_atomic",
       expect.objectContaining({
-        domain_auto_join_enabled: true,
-        domain_auto_join_domain: "webrenew.io",
-      }),
+        p_domain_auto_join_enabled: false,
+        p_set_domain_auto_join_enabled: true,
+        p_domain_auto_join_domain: "webrenew.io",
+        p_set_domain_auto_join_domain: true,
+      })
     )
   })
 
   it("returns upgrade-required when enabling domain auto-join on free plan", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({ data: { role: "owner" }, error: null }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      if (table === "organizations") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({
-                data: {
-                  plan: "free",
-                  domain_auto_join_enabled: false,
-                  domain_auto_join_domain: null,
-                },
-                error: null,
-              }),
-            }),
-          })),
-        }
-      }
-
-      return {}
-    })
+    mockAdminRpc.mockResolvedValue({ data: "team_plan_required", error: null })
 
     const response = await PATCH(
       new Request("https://example.com/api/orgs/org-1", {
@@ -477,23 +324,10 @@ describe("/api/orgs/[orgId] DELETE", () => {
     mockCheckRateLimit.mockResolvedValue(null)
   })
 
-  it("returns 500 when ownership lookup fails", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: { message: "DB read failed" },
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-      return {}
+  it("returns 500 when delete RPC fails", async () => {
+    mockAdminRpc.mockResolvedValue({
+      data: null,
+      error: { message: "DB read failed" },
     })
 
     const response = await DELETE(
@@ -508,34 +342,7 @@ describe("/api/orgs/[orgId] DELETE", () => {
   })
 
   it("returns 500 when organization deletion fails", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "org_members") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                single: vi.fn().mockResolvedValue({
-                  data: { role: "owner" },
-                  error: null,
-                }),
-              }),
-            }),
-          })),
-        }
-      }
-
-      if (table === "organizations") {
-        return {
-          delete: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              error: { message: "DB write failed" },
-            }),
-          })),
-        }
-      }
-
-      return {}
-    })
+    mockAdminRpc.mockResolvedValue({ data: "unexpected_state", error: null })
 
     const response = await DELETE(
       new Request("https://example.com/api/orgs/org-1", { method: "DELETE" }),

--- a/packages/web/src/app/api/orgs/[orgId]/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/route.ts
@@ -1,15 +1,10 @@
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
 import { logOrgAuditEvent } from "@/lib/org-audit"
 import { NextResponse } from "next/server"
 import { apiRateLimit, checkRateLimit } from "@/lib/rate-limit"
 import { parseBody, updateOrgSchema } from "@/lib/validations"
 import { normalizeOrgJoinDomain } from "@/lib/org-domain"
-import {
-  isPaidWorkspacePlan,
-  normalizeActiveOrganizationPlan,
-  normalizeWorkspacePlan,
-  type WorkspacePlan,
-} from "@/lib/workspace"
 
 function isMissingColumnError(error: unknown, columnName: string): boolean {
   const message =
@@ -24,30 +19,19 @@ function isMissingColumnError(error: unknown, columnName: string): boolean {
   )
 }
 
-type OrgSubscriptionStatus = "active" | "past_due" | "cancelled" | null
+function isMissingFunctionError(error: unknown, functionName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+  const fn = functionName.toLowerCase()
 
-interface OrganizationDomainAutoJoinPlanRow {
-  plan: string | null
-  subscription_status: OrgSubscriptionStatus
-  stripe_subscription_id: string | null
-}
-
-function resolveOrganizationDomainAutoJoinPlan(
-  org: OrganizationDomainAutoJoinPlanRow
-): WorkspacePlan {
-  if (org.subscription_status === "past_due") return "past_due"
-  if (org.subscription_status === "cancelled") return "free"
-
-  if (org.subscription_status === "active") {
-    if (org.plan) return normalizeActiveOrganizationPlan(org.plan)
-    if (org.stripe_subscription_id) return "team"
-  }
-
-  return normalizeWorkspacePlan(org.plan)
-}
-
-function supportsDomainAutoJoinPlan(org: OrganizationDomainAutoJoinPlanRow): boolean {
-  return isPaidWorkspacePlan(resolveOrganizationDomainAutoJoinPlan(org))
+  return (
+    message.includes(fn) &&
+    (message.includes("does not exist") ||
+      message.includes("function") ||
+      message.includes("could not find"))
+  )
 }
 
 // GET /api/orgs/[orgId] - Get organization details
@@ -125,27 +109,6 @@ export async function PATCH(
   const rateLimited = await checkRateLimit(apiRateLimit, user.id)
   if (rateLimited) return rateLimited
 
-  // Check user is admin or owner
-  const { data: membership, error: membershipError } = await supabase
-    .from("org_members")
-    .select("role")
-    .eq("org_id", orgId)
-    .eq("user_id", user.id)
-    .single()
-
-  if (membershipError) {
-    console.error("Failed to verify organization membership for update:", {
-      error: membershipError,
-      orgId,
-      userId: user.id,
-    })
-    return NextResponse.json({ error: "Failed to update organization" }, { status: 500 })
-  }
-
-  if (!membership || !["owner", "admin"].includes(membership.role)) {
-    return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
-  }
-
   const parsed = parseBody(updateOrgSchema, await request.json().catch(() => ({})))
   if (!parsed.success) return parsed.response
 
@@ -158,10 +121,6 @@ export async function PATCH(
   const updatesDomainSettings =
     parsed.data.domain_auto_join_enabled !== undefined ||
     parsed.data.domain_auto_join_domain !== undefined
-
-  if (updatesDomainSettings && membership.role !== "owner") {
-    return NextResponse.json({ error: "Only the owner can manage domain auto-join" }, { status: 403 })
-  }
 
   if (parsed.data.domain_auto_join_domain !== undefined) {
     if (parsed.data.domain_auto_join_domain === null) {
@@ -179,109 +138,109 @@ export async function PATCH(
     updates.domain_auto_join_enabled = parsed.data.domain_auto_join_enabled
   }
 
-  if (updatesDomainSettings) {
-    const { data: currentOrg, error: currentOrgError } = await supabase
-      .from("organizations")
-      .select(
-        "plan, subscription_status, stripe_subscription_id, domain_auto_join_enabled, domain_auto_join_domain"
-      )
-      .eq("id", orgId)
-      .single()
-
-    if (
-      currentOrgError &&
-      (isMissingColumnError(currentOrgError, "domain_auto_join_enabled") ||
-        isMissingColumnError(currentOrgError, "domain_auto_join_domain"))
-    ) {
-      return NextResponse.json(
-        { error: "Domain auto-join is not available yet. Run the latest database migration first." },
-        { status: 503 },
-      )
-    }
-
-    if (currentOrgError || !currentOrg) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 404 })
-    }
-
-    const currentDomain = typeof currentOrg.domain_auto_join_domain === "string"
-      ? currentOrg.domain_auto_join_domain.trim().toLowerCase() || null
-      : null
-    const requestedDomain =
-      typeof updates.domain_auto_join_domain === "string"
-        ? updates.domain_auto_join_domain.trim().toLowerCase() || null
-        : updates.domain_auto_join_domain === null
-          ? null
-          : currentDomain
-    const domainChanged = requestedDomain !== currentDomain
-
-    // Saving a domain should activate auto-join in the same action.
-    if (domainChanged && typeof requestedDomain === "string" && requestedDomain.length > 0) {
-      updates.domain_auto_join_enabled = true
-    }
-    if (domainChanged && requestedDomain === null) {
-      updates.domain_auto_join_enabled = false
-    }
-
-    const finalEnabled =
-      typeof updates.domain_auto_join_enabled === "boolean"
-        ? updates.domain_auto_join_enabled
-        : Boolean(currentOrg.domain_auto_join_enabled)
-    const finalDomain =
-      typeof updates.domain_auto_join_domain === "string" || updates.domain_auto_join_domain === null
-        ? updates.domain_auto_join_domain
-        : currentOrg.domain_auto_join_domain
-
-    if (finalEnabled && (!finalDomain || String(finalDomain).trim().length === 0)) {
-      return NextResponse.json(
-        { error: "Set a domain before enabling domain auto-join" },
-        { status: 400 },
-      )
-    }
-
-    if (finalEnabled && !supportsDomainAutoJoinPlan(currentOrg)) {
-      return NextResponse.json(
-        {
-          error: "Domain auto-join requires the Team plan. Upgrade to continue.",
-          code: "TEAM_PLAN_REQUIRED",
-          upgradeUrl: "/app/upgrade?plan=team",
-        },
-        { status: 402 },
-      )
-    }
-  }
-
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 })
   }
 
-  const { data: org, error } = await supabase
-    .from("organizations")
-    .update({ ...updates, updated_at: new Date().toISOString() })
-    .eq("id", orgId)
-    .select()
-    .single()
+  const updatedFields = Object.keys(updates).sort()
+  const admin = createAdminClient()
+  const { data: updateResult, error: updateError } = await admin.rpc("update_org_settings_atomic", {
+    p_org_id: orgId,
+    p_actor_user_id: user.id,
+    p_name: updates.name ?? null,
+    p_set_name: updates.name !== undefined,
+    p_domain_auto_join_enabled:
+      typeof updates.domain_auto_join_enabled === "boolean"
+        ? updates.domain_auto_join_enabled
+        : null,
+    p_set_domain_auto_join_enabled: updates.domain_auto_join_enabled !== undefined,
+    p_domain_auto_join_domain:
+      typeof updates.domain_auto_join_domain === "string" || updates.domain_auto_join_domain === null
+        ? updates.domain_auto_join_domain
+        : null,
+    p_set_domain_auto_join_domain: updates.domain_auto_join_domain !== undefined,
+  })
 
-  if (error) {
+  if (updateError) {
+    if (isMissingFunctionError(updateError, "update_org_settings_atomic")) {
+      return NextResponse.json(
+        { error: "Domain auto-join is not available yet. Run the latest database migration first." },
+        { status: 503 },
+      )
+    }
     if (
-      isMissingColumnError(error, "domain_auto_join_enabled") ||
-      isMissingColumnError(error, "domain_auto_join_domain")
+      isMissingColumnError(updateError, "domain_auto_join_enabled") ||
+      isMissingColumnError(updateError, "domain_auto_join_domain")
     ) {
       return NextResponse.json(
         { error: "Domain auto-join is not available yet. Run the latest database migration first." },
         { status: 503 },
       )
     }
-    if (error.code === "23505") {
+    const errorCode =
+      typeof updateError === "object" && updateError !== null && "code" in updateError
+        ? String((updateError as { code?: unknown }).code ?? "")
+        : ""
+    if (errorCode === "23505") {
       return NextResponse.json(
         { error: "That domain is already configured by another organization" },
         { status: 409 },
       )
     }
-    console.error("Failed to update organization row:", {
-      error,
+    console.error("Failed to update organization atomically:", {
+      error: updateError,
       orgId,
       userId: user.id,
-      updatedFields: Object.keys(updates).sort(),
+      updatedFields,
+    })
+    return NextResponse.json({ error: "Failed to update organization" }, { status: 500 })
+  }
+
+  const updateStatus = typeof updateResult === "string" ? updateResult : null
+  if (updateStatus === "insufficient_permissions") {
+    return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
+  }
+  if (updateStatus === "owner_required") {
+    return NextResponse.json({ error: "Only the owner can manage domain auto-join" }, { status: 403 })
+  }
+  if (updateStatus === "domain_required") {
+    return NextResponse.json({ error: "Set a domain before enabling domain auto-join" }, { status: 400 })
+  }
+  if (updateStatus === "team_plan_required") {
+    return NextResponse.json(
+      {
+        error: "Domain auto-join requires the Team plan. Upgrade to continue.",
+        code: "TEAM_PLAN_REQUIRED",
+        upgradeUrl: "/app/upgrade?plan=team",
+      },
+      { status: 402 },
+    )
+  }
+  if (updateStatus === "org_not_found") {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 })
+  }
+  if (updateStatus !== "updated") {
+    console.error("Unexpected update_org_settings_atomic result:", {
+      orgId,
+      actorUserId: user.id,
+      result: updateResult,
+      updatedFields,
+    })
+    return NextResponse.json({ error: "Failed to update organization" }, { status: 500 })
+  }
+
+  const { data: org, error: orgError } = await supabase
+    .from("organizations")
+    .select("*")
+    .eq("id", orgId)
+    .single()
+
+  if (orgError || !org) {
+    console.error("Failed to load updated organization row:", {
+      error: orgError,
+      orgId,
+      userId: user.id,
+      updatedFields,
     })
     return NextResponse.json({ error: "Failed to update organization" }, { status: 500 })
   }
@@ -295,7 +254,7 @@ export async function PATCH(
     targetId: orgId,
     targetLabel: org?.name ?? null,
     metadata: {
-      updatedFields: Object.keys(updates).sort(),
+      updatedFields,
       domain_auto_join_enabled: org?.domain_auto_join_enabled ?? null,
       domain_auto_join_domain: org?.domain_auto_join_domain ?? null,
     },
@@ -320,37 +279,40 @@ export async function DELETE(
   const rateLimited = await checkRateLimit(apiRateLimit, user.id)
   if (rateLimited) return rateLimited
 
-  // Only users with owner role can delete.
-  const { data: membership, error: membershipError } = await supabase
-    .from("org_members")
-    .select("role")
-    .eq("org_id", orgId)
-    .eq("user_id", user.id)
-    .single()
+  const admin = createAdminClient()
+  const { data: deleteResult, error: deleteError } = await admin.rpc("delete_organization_atomic", {
+    p_org_id: orgId,
+    p_actor_user_id: user.id,
+  })
 
-  if (membershipError) {
-    console.error("Failed to verify organization ownership for delete:", {
-      error: membershipError,
+  if (deleteError) {
+    if (isMissingFunctionError(deleteError, "delete_organization_atomic")) {
+      return NextResponse.json(
+        { error: "Organization deletion is not available yet. Run the latest database migration first." },
+        { status: 503 }
+      )
+    }
+
+    console.error("Failed to delete organization atomically:", {
+      error: deleteError,
       orgId,
       userId: user.id,
     })
     return NextResponse.json({ error: "Failed to delete organization" }, { status: 500 })
   }
 
-  if (!membership || membership.role !== "owner") {
+  const deleteStatus = typeof deleteResult === "string" ? deleteResult : null
+  if (deleteStatus === "actor_not_member" || deleteStatus === "owner_required") {
     return NextResponse.json({ error: "Only the owner can delete this organization" }, { status: 403 })
   }
-
-  const { error } = await supabase
-    .from("organizations")
-    .delete()
-    .eq("id", orgId)
-
-  if (error) {
-    console.error("Failed to delete organization row:", {
-      error,
+  if (deleteStatus === "org_not_found") {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 })
+  }
+  if (deleteStatus !== "deleted") {
+    console.error("Unexpected delete_organization_atomic result:", {
       orgId,
-      userId: user.id,
+      actorUserId: user.id,
+      result: deleteResult,
     })
     return NextResponse.json({ error: "Failed to delete organization" }, { status: 500 })
   }

--- a/supabase/migrations/20260302194500_add_atomic_org_member_delete_and_org_settings_delete.sql
+++ b/supabase/migrations/20260302194500_add_atomic_org_member_delete_and_org_settings_delete.sql
@@ -1,0 +1,234 @@
+-- Atomic helpers for org member removal, org settings updates, and org deletion.
+
+DO $remove_member$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.remove_org_member_atomic(
+      p_org_id UUID,
+      p_actor_user_id UUID,
+      p_target_user_id UUID
+    ) RETURNS JSONB
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    DECLARE
+      v_actor_role TEXT;
+      v_target_role TEXT;
+      v_removed_by_self BOOLEAN;
+    BEGIN
+      SELECT role
+      INTO v_actor_role
+      FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_actor_user_id
+      FOR UPDATE;
+
+      IF v_actor_role IS NULL THEN
+        RETURN jsonb_build_object('status', 'actor_not_member');
+      END IF;
+
+      SELECT role
+      INTO v_target_role
+      FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_target_user_id
+      FOR UPDATE;
+
+      IF v_target_role IS NULL THEN
+        RETURN jsonb_build_object('status', 'target_not_member');
+      END IF;
+
+      IF v_target_role = 'owner' THEN
+        RETURN jsonb_build_object('status', 'target_is_owner');
+      END IF;
+
+      v_removed_by_self := p_target_user_id = p_actor_user_id;
+      IF NOT v_removed_by_self AND v_actor_role NOT IN ('owner', 'admin') THEN
+        RETURN jsonb_build_object('status', 'insufficient_permissions');
+      END IF;
+
+      DELETE FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_target_user_id;
+
+      IF NOT FOUND THEN
+        RETURN jsonb_build_object('status', 'target_not_member');
+      END IF;
+
+      RETURN jsonb_build_object(
+        'status', 'removed',
+        'removed_role', v_target_role,
+        'removed_by_self', v_removed_by_self
+      );
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.remove_org_member_atomic(UUID, UUID, UUID) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.remove_org_member_atomic(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.remove_org_member_atomic(UUID, UUID, UUID) TO service_role';
+END
+$remove_member$;
+
+DO $update_org_settings$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.update_org_settings_atomic(
+      p_org_id UUID,
+      p_actor_user_id UUID,
+      p_name TEXT,
+      p_set_name BOOLEAN,
+      p_domain_auto_join_enabled BOOLEAN,
+      p_set_domain_auto_join_enabled BOOLEAN,
+      p_domain_auto_join_domain TEXT,
+      p_set_domain_auto_join_domain BOOLEAN
+    ) RETURNS TEXT
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    DECLARE
+      v_actor_role TEXT;
+      v_org public.organizations%ROWTYPE;
+      v_next_name TEXT;
+      v_next_domain_auto_join_enabled BOOLEAN;
+      v_next_domain_auto_join_domain TEXT;
+      v_domain_changed BOOLEAN;
+      v_supports_domain_auto_join BOOLEAN;
+    BEGIN
+      SELECT role
+      INTO v_actor_role
+      FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_actor_user_id
+      FOR UPDATE;
+
+      IF v_actor_role IS NULL OR v_actor_role NOT IN ('owner', 'admin') THEN
+        RETURN 'insufficient_permissions';
+      END IF;
+
+      IF (p_set_domain_auto_join_enabled OR p_set_domain_auto_join_domain) AND v_actor_role <> 'owner' THEN
+        RETURN 'owner_required';
+      END IF;
+
+      SELECT *
+      INTO v_org
+      FROM public.organizations
+      WHERE id = p_org_id
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        RETURN 'org_not_found';
+      END IF;
+
+      v_next_name := v_org.name;
+      v_next_domain_auto_join_enabled := COALESCE(v_org.domain_auto_join_enabled, FALSE);
+      v_next_domain_auto_join_domain := v_org.domain_auto_join_domain;
+
+      IF p_set_name THEN
+        v_next_name := p_name;
+      END IF;
+
+      IF p_set_domain_auto_join_domain THEN
+        v_next_domain_auto_join_domain := p_domain_auto_join_domain;
+      END IF;
+
+      IF p_set_domain_auto_join_enabled THEN
+        v_next_domain_auto_join_enabled := p_domain_auto_join_enabled;
+      END IF;
+
+      v_domain_changed := COALESCE(v_next_domain_auto_join_domain, '') <> COALESCE(v_org.domain_auto_join_domain, '');
+      IF v_domain_changed AND v_next_domain_auto_join_domain IS NOT NULL AND char_length(trim(v_next_domain_auto_join_domain)) > 0 THEN
+        v_next_domain_auto_join_enabled := TRUE;
+      END IF;
+      IF v_domain_changed AND v_next_domain_auto_join_domain IS NULL THEN
+        v_next_domain_auto_join_enabled := FALSE;
+      END IF;
+
+      IF v_next_domain_auto_join_enabled AND (v_next_domain_auto_join_domain IS NULL OR char_length(trim(v_next_domain_auto_join_domain)) = 0) THEN
+        RETURN 'domain_required';
+      END IF;
+
+      IF v_next_domain_auto_join_enabled THEN
+        v_supports_domain_auto_join := FALSE;
+
+        IF v_org.subscription_status = 'active' THEN
+          IF v_org.plan IN ('team', 'growth') THEN
+            v_supports_domain_auto_join := TRUE;
+          ELSIF v_org.plan IS NULL AND v_org.stripe_subscription_id IS NOT NULL THEN
+            v_supports_domain_auto_join := TRUE;
+          END IF;
+        ELSIF v_org.subscription_status IS NULL THEN
+          IF v_org.plan IN ('team', 'growth') THEN
+            v_supports_domain_auto_join := TRUE;
+          END IF;
+        END IF;
+
+        IF NOT v_supports_domain_auto_join THEN
+          RETURN 'team_plan_required';
+        END IF;
+      END IF;
+
+      UPDATE public.organizations
+      SET
+        name = v_next_name,
+        domain_auto_join_enabled = v_next_domain_auto_join_enabled,
+        domain_auto_join_domain = v_next_domain_auto_join_domain,
+        updated_at = now()
+      WHERE id = p_org_id;
+
+      RETURN 'updated';
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.update_org_settings_atomic(UUID, UUID, TEXT, BOOLEAN, BOOLEAN, BOOLEAN, TEXT, BOOLEAN) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.update_org_settings_atomic(UUID, UUID, TEXT, BOOLEAN, BOOLEAN, BOOLEAN, TEXT, BOOLEAN) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.update_org_settings_atomic(UUID, UUID, TEXT, BOOLEAN, BOOLEAN, BOOLEAN, TEXT, BOOLEAN) TO service_role';
+END
+$update_org_settings$;
+
+DO $delete_org$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.delete_organization_atomic(
+      p_org_id UUID,
+      p_actor_user_id UUID
+    ) RETURNS TEXT
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    DECLARE
+      v_actor_role TEXT;
+    BEGIN
+      SELECT role
+      INTO v_actor_role
+      FROM public.org_members
+      WHERE org_id = p_org_id
+        AND user_id = p_actor_user_id
+      FOR UPDATE;
+
+      IF v_actor_role IS NULL THEN
+        RETURN 'actor_not_member';
+      END IF;
+
+      IF v_actor_role <> 'owner' THEN
+        RETURN 'owner_required';
+      END IF;
+
+      DELETE FROM public.organizations
+      WHERE id = p_org_id;
+
+      IF NOT FOUND THEN
+        RETURN 'org_not_found';
+      END IF;
+
+      RETURN 'deleted';
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.delete_organization_atomic(UUID, UUID) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.delete_organization_atomic(UUID, UUID) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.delete_organization_atomic(UUID, UUID) TO service_role';
+END
+$delete_org$;


### PR DESCRIPTION
## Summary
- add atomic DB functions for member removal, org settings updates, and org deletion
- switch `DELETE /api/orgs/[orgId]/members` to RPC-backed atomic permission + target-role enforcement
- switch `PATCH /api/orgs/[orgId]` to RPC-backed atomic authorization + domain auto-join eligibility enforcement
- switch `DELETE /api/orgs/[orgId]` to RPC-backed atomic owner validation + delete
- update route tests for the new RPC status flows
- apply Supabase migration for new functions

## Validation
- `pnpm --filter @memories.sh/web exec vitest run 'src/app/api/orgs/[orgId]/route.test.ts' 'src/app/api/orgs/[orgId]/members/route.test.ts'`
- `pnpm --filter @memories.sh/web typecheck`
- `supabase db push --yes`
- `supabase migration list`

Fixes #390
Fixes #391
Fixes #392
Fixes #393

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 7a207fe5848e241bcd0b6e14a532ad75a454cb28. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->