### PR TITLE
Fix Stripe customer, CLI approve, and invite revoke race conditions

### DIFF
--- a/packages/web/src/app/api/auth/cli/__tests__/route.test.ts
+++ b/packages/web/src/app/api/auth/cli/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockGetUser = vi.fn()
 const mockAdminFrom = vi.fn()
+const mockAdminRpc = vi.fn()
 const mockAdminGetUserById = vi.fn()
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -13,6 +14,7 @@ vi.mock("@/lib/supabase/server", () => ({
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     from: mockAdminFrom,
+    rpc: mockAdminRpc,
     auth: { admin: { getUserById: mockAdminGetUserById } },
   })),
 }))
@@ -178,16 +180,19 @@ describe("POST /api/auth/cli", () => {
 
     it("stores auth code and expiry for authenticated user", async () => {
       mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
-      const eq = vi.fn().mockResolvedValue({ error: null })
-      const update = vi.fn().mockReturnValue({ eq })
-      mockAdminFrom.mockReturnValue({ update })
+      mockAdminRpc.mockResolvedValue({ data: "updated", error: null })
 
       const response = await POST(makeRequest({ action: "approve", code: VALID_CODE }))
       expect(response.status).toBe(200)
-
-      const payload = update.mock.calls[0]?.[0]
-      expect(payload.cli_auth_code).toBe(VALID_CODE)
-      expect(typeof payload.cli_auth_expires_at).toBe("string")
+      expect(mockAdminRpc).toHaveBeenCalledWith(
+        "approve_cli_auth_code_atomic",
+        expect.objectContaining({
+          p_user_id: "user-1",
+          p_code: VALID_CODE,
+        })
+      )
+      const approvePayload = mockAdminRpc.mock.calls[0]?.[1]
+      expect(typeof approvePayload?.p_expires_at).toBe("string")
     })
   })
 })

--- a/packages/web/src/app/api/auth/cli/route.ts
+++ b/packages/web/src/app/api/auth/cli/route.ts
@@ -5,6 +5,21 @@ import { checkRateLimit, getClientIp, publicRateLimit } from "@/lib/rate-limit"
 import { parseBody, cliAuthPollSchema, cliAuthApproveSchema } from "@/lib/validations"
 import { CLI_AUTH_CODE_TTL_MS, generateCliToken, hashCliToken } from "@/lib/cli-token"
 
+function isMissingFunctionError(error: unknown, functionName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+  const fn = functionName.toLowerCase()
+
+  return (
+    message.includes(fn) &&
+    (message.includes("does not exist") ||
+      message.includes("function") ||
+      message.includes("could not find"))
+  )
+}
+
 export async function POST(request: Request): Promise<Response> {
   const rateLimited = await checkRateLimit(publicRateLimit, getClientIp(request))
   if (rateLimited) return rateLimited
@@ -102,14 +117,34 @@ export async function POST(request: Request): Promise<Response> {
 
     const expiresAt = new Date(Date.now() + CLI_AUTH_CODE_TTL_MS).toISOString()
 
-    // Save auth code and expiry to user's row.
     const admin = createAdminClient()
-    const { error } = await admin
-      .from("users")
-      .update({ cli_auth_code: parsed.data.code, cli_auth_expires_at: expiresAt })
-      .eq("id", user.id)
+    const { data: approveResult, error: approveError } = await admin.rpc("approve_cli_auth_code_atomic", {
+      p_user_id: user.id,
+      p_code: parsed.data.code,
+      p_expires_at: expiresAt,
+    })
 
-    if (error) {
+    if (approveError) {
+      if (isMissingFunctionError(approveError, "approve_cli_auth_code_atomic")) {
+        return NextResponse.json(
+          { error: "CLI auth approve guard is not available yet. Run the latest database migration first." },
+          { status: 503 }
+        )
+      }
+      return NextResponse.json(
+        { error: "Failed to create token" },
+        { status: 500 }
+      )
+    }
+
+    if (approveResult === "code_in_use") {
+      return NextResponse.json(
+        { error: "Another CLI login request is already pending for this account. Complete it or wait for expiry." },
+        { status: 409 }
+      )
+    }
+
+    if (approveResult !== "updated") {
       return NextResponse.json(
         { error: "Failed to create token" },
         { status: 500 }

--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.test.ts
@@ -514,20 +514,17 @@ describe("/api/orgs/[orgId]/invites DELETE", () => {
 
       if (table === "org_invites") {
         return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                maybeSingle: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: null,
-                }),
-              }),
-            }),
-          })),
           delete: vi.fn(() => ({
             eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockResolvedValue({
-                error: { message: "DB write failed" },
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockReturnValue({
+                  select: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: null,
+                      error: { message: "DB write failed" },
+                    }),
+                  }),
+                }),
               }),
             }),
           })),
@@ -547,6 +544,77 @@ describe("/api/orgs/[orgId]/invites DELETE", () => {
     expect(response.status).toBe(500)
     await expect(response.json()).resolves.toMatchObject({
       error: "Failed to revoke invite",
+    })
+  })
+
+  it("returns 409 when invite was already accepted", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } })
+
+    let orgInviteSelectCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "org_members") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { role: "owner" },
+                  error: null,
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      if (table === "org_invites") {
+        orgInviteSelectCount += 1
+        if (orgInviteSelectCount === 1) {
+          return {
+            delete: vi.fn(() => ({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  is: vi.fn().mockReturnValue({
+                    select: vi.fn().mockReturnValue({
+                      maybeSingle: vi.fn().mockResolvedValue({
+                        data: null,
+                        error: null,
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+            })),
+          }
+        }
+
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: { accepted_at: "2026-03-02T18:00:00.000Z" },
+                  error: null,
+                }),
+              }),
+            }),
+          })),
+        }
+      }
+
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(), single: vi.fn(), maybeSingle: vi.fn() })),
+      }
+    })
+
+    const response = await DELETE(
+      new Request("https://example.com/api/orgs/org-1/invites?inviteId=inv-1", { method: "DELETE" }),
+      { params: Promise.resolve({ orgId: "org-1" }) },
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invite was already accepted and cannot be revoked",
     })
   })
 })

--- a/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
+++ b/packages/web/src/app/api/orgs/[orgId]/invites/route.ts
@@ -369,18 +369,14 @@ export async function DELETE(
     return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 })
   }
 
-  const { data: inviteToRevoke } = await supabase
-    .from("org_invites")
-    .select("id, email, role")
-    .eq("id", inviteId)
-    .eq("org_id", orgId)
-    .maybeSingle()
-
-  const { error } = await supabase
+  const { data: revokedInvite, error } = await supabase
     .from("org_invites")
     .delete()
     .eq("id", inviteId)
     .eq("org_id", orgId)
+    .is("accepted_at", null)
+    .select("id, email, role")
+    .maybeSingle()
 
   if (error) {
     console.error("Failed to delete org invite row:", {
@@ -392,17 +388,45 @@ export async function DELETE(
     return NextResponse.json({ error: "Failed to revoke invite" }, { status: 500 })
   }
 
-  if (inviteToRevoke) {
+  if (!revokedInvite) {
+    const { data: inviteState, error: inviteStateError } = await supabase
+      .from("org_invites")
+      .select("accepted_at")
+      .eq("id", inviteId)
+      .eq("org_id", orgId)
+      .maybeSingle()
+
+    if (inviteStateError) {
+      console.error("Failed to resolve invite revoke state:", {
+        error: inviteStateError,
+        orgId,
+        userId: user.id,
+        inviteId,
+      })
+      return NextResponse.json({ error: "Failed to revoke invite" }, { status: 500 })
+    }
+
+    if (inviteState?.accepted_at) {
+      return NextResponse.json(
+        { error: "Invite was already accepted and cannot be revoked" },
+        { status: 409 }
+      )
+    }
+
+    return NextResponse.json({ error: "Invite not found" }, { status: 404 })
+  }
+
+  if (revokedInvite) {
     await logOrgAuditEvent({
       client: supabase,
       orgId,
       actorUserId: user.id,
       action: "org_invite_revoked",
       targetType: "invite",
-      targetId: inviteToRevoke.id,
-      targetLabel: inviteToRevoke.email,
+      targetId: revokedInvite.id,
+      targetLabel: revokedInvite.email,
       metadata: {
-        role: inviteToRevoke.role,
+        role: revokedInvite.role,
       },
     })
   }

--- a/packages/web/src/app/api/stripe/checkout/route.ts
+++ b/packages/web/src/app/api/stripe/checkout/route.ts
@@ -1,6 +1,7 @@
 import { authenticateRequest } from "@/lib/auth"
 import { getStripe } from "@/lib/stripe"
 import { NextResponse } from "next/server"
+import { setTimeout as delay } from "node:timers/promises"
 import { checkRateLimit, strictRateLimit } from "@/lib/rate-limit"
 import { parseBody, checkoutSchema } from "@/lib/validations"
 import { createAdminClient } from "@/lib/supabase/admin"
@@ -13,6 +14,189 @@ import {
 
 function jsonError(message: string, status: number, code: string) {
   return NextResponse.json({ error: message, code }, { status })
+}
+
+type StripeCustomerLockTarget =
+  | { ownerType: "user"; ownerKey: string; ownerUserId: string; ownerOrgId: null }
+  | { ownerType: "organization"; ownerKey: string; ownerUserId: null; ownerOrgId: string }
+
+const STRIPE_CUSTOMER_LOCK_STALE_MS = 15 * 60 * 1000
+const STRIPE_CUSTOMER_LOCK_WAIT_ATTEMPTS = 8
+const STRIPE_CUSTOMER_LOCK_WAIT_MS = 250
+
+function isUniqueViolation(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+  if (code === "23505") return true
+
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return message.includes("duplicate key")
+}
+
+function isMissingTableError(error: unknown, tableName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+
+  return (
+    message.includes(tableName.toLowerCase()) &&
+    (message.includes("does not exist") || message.includes("could not find the table"))
+  )
+}
+
+function buildStripeCustomerLockTarget(params: {
+  ownerType: "user" | "organization"
+  userId?: string
+  orgId?: string
+}): StripeCustomerLockTarget {
+  if (params.ownerType === "organization") {
+    if (!params.orgId) {
+      throw new Error("Organization id is required for stripe customer provisioning lock")
+    }
+    return {
+      ownerType: "organization",
+      ownerKey: `org:${params.orgId}`,
+      ownerUserId: null,
+      ownerOrgId: params.orgId,
+    }
+  }
+
+  if (!params.userId) {
+    throw new Error("User id is required for stripe customer provisioning lock")
+  }
+  return {
+    ownerType: "user",
+    ownerKey: `user:${params.userId}`,
+    ownerUserId: params.userId,
+    ownerOrgId: null,
+  }
+}
+
+async function clearStaleStripeCustomerLock(
+  admin: ReturnType<typeof createAdminClient>,
+  lockTarget: StripeCustomerLockTarget,
+): Promise<{ error: unknown }> {
+  const staleBeforeIso = new Date(Date.now() - STRIPE_CUSTOMER_LOCK_STALE_MS).toISOString()
+  const { error } = await admin
+    .from("stripe_customer_provision_locks")
+    .delete()
+    .eq("owner_key", lockTarget.ownerKey)
+    .lt("created_at", staleBeforeIso)
+
+  return { error }
+}
+
+async function acquireStripeCustomerLock(params: {
+  admin: ReturnType<typeof createAdminClient>
+  lockTarget: StripeCustomerLockTarget
+  actorUserId: string
+}): Promise<{ acquired: boolean; error: unknown }> {
+  const { admin, lockTarget, actorUserId } = params
+
+  const staleCleanup = await clearStaleStripeCustomerLock(admin, lockTarget)
+  if (staleCleanup.error) {
+    return { acquired: false, error: staleCleanup.error }
+  }
+
+  const { data, error } = await admin
+    .from("stripe_customer_provision_locks")
+    .insert({
+      owner_key: lockTarget.ownerKey,
+      owner_type: lockTarget.ownerType,
+      owner_user_id: lockTarget.ownerUserId,
+      owner_org_id: lockTarget.ownerOrgId,
+      locked_by_user_id: actorUserId,
+    })
+    .select("owner_key")
+    .maybeSingle()
+
+  if (error) {
+    if (isUniqueViolation(error)) {
+      return { acquired: false, error: null }
+    }
+    return { acquired: false, error }
+  }
+
+  return { acquired: Boolean(data), error: null }
+}
+
+async function releaseStripeCustomerLock(params: {
+  admin: ReturnType<typeof createAdminClient>
+  lockTarget: StripeCustomerLockTarget
+  actorUserId: string
+}): Promise<void> {
+  const { admin, lockTarget, actorUserId } = params
+
+  const { error } = await admin
+    .from("stripe_customer_provision_locks")
+    .delete()
+    .eq("owner_key", lockTarget.ownerKey)
+    .eq("locked_by_user_id", actorUserId)
+
+  if (error && !isMissingTableError(error, "stripe_customer_provision_locks")) {
+    console.warn("Failed to release stripe customer provisioning lock:", {
+      lockOwnerKey: lockTarget.ownerKey,
+      actorUserId,
+      error,
+    })
+  }
+}
+
+async function waitForUserCustomerId(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string
+): Promise<string | null> {
+  for (let attempt = 0; attempt < STRIPE_CUSTOMER_LOCK_WAIT_ATTEMPTS; attempt += 1) {
+    const { data: refreshed, error } = await admin
+      .from("users")
+      .select("stripe_customer_id")
+      .eq("id", userId)
+      .single()
+
+    if (error) {
+      console.error("Failed while waiting for user stripe customer id:", error)
+      return null
+    }
+
+    const customerId = refreshed?.stripe_customer_id ?? null
+    if (customerId) return customerId
+
+    await delay(STRIPE_CUSTOMER_LOCK_WAIT_MS)
+  }
+
+  return null
+}
+
+async function waitForOrganizationCustomerId(
+  admin: ReturnType<typeof createAdminClient>,
+  orgId: string
+): Promise<string | null> {
+  for (let attempt = 0; attempt < STRIPE_CUSTOMER_LOCK_WAIT_ATTEMPTS; attempt += 1) {
+    const { data: refreshed, error } = await admin
+      .from("organizations")
+      .select("stripe_customer_id")
+      .eq("id", orgId)
+      .single()
+
+    if (error) {
+      console.error("Failed while waiting for organization stripe customer id:", error)
+      return null
+    }
+
+    const customerId = refreshed?.stripe_customer_id ?? null
+    if (customerId) return customerId
+
+    await delay(STRIPE_CUSTOMER_LOCK_WAIT_MS)
+  }
+
+  return null
 }
 
 async function getOrCreateUserCustomerId(
@@ -34,7 +218,46 @@ async function getOrCreateUserCustomerId(
   let customerId = profile?.stripe_customer_id
   if (customerId) return customerId
 
+  const lockTarget = buildStripeCustomerLockTarget({
+    ownerType: "user",
+    userId,
+  })
+
+  const lockResult = await acquireStripeCustomerLock({
+    admin,
+    lockTarget,
+    actorUserId: userId,
+  })
+
+  if (lockResult.error) {
+    if (!isMissingTableError(lockResult.error, "stripe_customer_provision_locks")) {
+      console.error("Failed to acquire user stripe customer lock:", {
+        userId,
+        error: lockResult.error,
+      })
+      return null
+    }
+  }
+
+  if (!lockResult.error && !lockResult.acquired) {
+    return await waitForUserCustomerId(admin, userId)
+  }
+
   try {
+    const { data: refreshedProfile, error: refreshedProfileError } = await admin
+      .from("users")
+      .select("stripe_customer_id, email")
+      .eq("id", userId)
+      .single()
+
+    if (refreshedProfileError) {
+      console.error("Failed to refresh user billing customer before create:", refreshedProfileError)
+      return null
+    }
+
+    customerId = refreshedProfile?.stripe_customer_id ?? null
+    if (customerId) return customerId
+
     const customerEmail = profile?.email || email || undefined
     const customer = await getStripe().customers.create(
       {
@@ -47,27 +270,40 @@ async function getOrCreateUserCustomerId(
     )
     customerId = customer.id
 
-    await admin
+    const persistResult = await admin
       .from("users")
       .update({ stripe_customer_id: customerId })
       .eq("id", userId)
+      .is("stripe_customer_id", null)
+      .select("stripe_customer_id")
+      .maybeSingle()
+
+    if (persistResult.error) {
+      console.error("Failed to persist user stripe customer id:", persistResult.error)
+    }
   } catch (error) {
     console.error("Failed to create Stripe customer for user:", error)
-    const { data: refreshed } = await admin
-      .from("users")
-      .select("stripe_customer_id")
-      .eq("id", userId)
-      .single()
-
-    customerId = refreshed?.stripe_customer_id
+  } finally {
+    await releaseStripeCustomerLock({
+      admin,
+      lockTarget,
+      actorUserId: userId,
+    })
   }
 
-  return customerId ?? null
+  const { data: refreshed } = await admin
+    .from("users")
+    .select("stripe_customer_id")
+    .eq("id", userId)
+    .single()
+
+  return refreshed?.stripe_customer_id ?? customerId ?? null
 }
 
 async function getOrCreateOrganizationCustomerId(
   admin: ReturnType<typeof createAdminClient>,
-  orgId: string
+  orgId: string,
+  actorUserId: string
 ): Promise<string | null> {
   const { data: org, error: orgError } = await admin
     .from("organizations")
@@ -83,10 +319,50 @@ async function getOrCreateOrganizationCustomerId(
   let customerId = org?.stripe_customer_id
   if (customerId) return customerId
 
+  const lockTarget = buildStripeCustomerLockTarget({
+    ownerType: "organization",
+    orgId,
+  })
+
+  const lockResult = await acquireStripeCustomerLock({
+    admin,
+    lockTarget,
+    actorUserId,
+  })
+
+  if (lockResult.error) {
+    if (!isMissingTableError(lockResult.error, "stripe_customer_provision_locks")) {
+      console.error("Failed to acquire org stripe customer lock:", {
+        orgId,
+        actorUserId,
+        error: lockResult.error,
+      })
+      return null
+    }
+  }
+
+  if (!lockResult.error && !lockResult.acquired) {
+    return await waitForOrganizationCustomerId(admin, orgId)
+  }
+
   try {
+    const { data: refreshedOrg, error: refreshedOrgError } = await admin
+      .from("organizations")
+      .select("stripe_customer_id, name")
+      .eq("id", orgId)
+      .single()
+
+    if (refreshedOrgError) {
+      console.error("Failed to refresh organization billing customer before create:", refreshedOrgError)
+      return null
+    }
+
+    customerId = refreshedOrg?.stripe_customer_id ?? null
+    if (customerId) return customerId
+
     const customer = await getStripe().customers.create(
       {
-        name: org?.name ?? undefined,
+        name: refreshedOrg?.name ?? org?.name ?? undefined,
         metadata: {
           workspace_owner_type: "organization",
           workspace_org_id: orgId,
@@ -98,22 +374,34 @@ async function getOrCreateOrganizationCustomerId(
     )
     customerId = customer.id
 
-    await admin
+    const persistResult = await admin
       .from("organizations")
       .update({ stripe_customer_id: customerId })
       .eq("id", orgId)
+      .is("stripe_customer_id", null)
+      .select("stripe_customer_id")
+      .maybeSingle()
+
+    if (persistResult.error) {
+      console.error("Failed to persist organization stripe customer id:", persistResult.error)
+    }
   } catch (error) {
     console.error("Failed to create Stripe customer for organization:", error)
-    const { data: refreshed } = await admin
-      .from("organizations")
-      .select("stripe_customer_id")
-      .eq("id", orgId)
-      .single()
-
-    customerId = refreshed?.stripe_customer_id
+  } finally {
+    await releaseStripeCustomerLock({
+      admin,
+      lockTarget,
+      actorUserId,
+    })
   }
 
-  return customerId ?? null
+  const { data: refreshed } = await admin
+    .from("organizations")
+    .select("stripe_customer_id")
+    .eq("id", orgId)
+    .single()
+
+  return refreshed?.stripe_customer_id ?? customerId ?? null
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -170,7 +458,7 @@ export async function POST(request: Request): Promise<Response> {
     if (!workspace.orgId) {
       return jsonError("Failed to resolve organization workspace", 500, "ORG_WORKSPACE_RESOLUTION_FAILED")
     }
-    customerId = await getOrCreateOrganizationCustomerId(admin, workspace.orgId)
+    customerId = await getOrCreateOrganizationCustomerId(admin, workspace.orgId, auth.userId)
   } else {
     customerId = await getOrCreateUserCustomerId(admin, auth.userId, auth.email)
   }

--- a/supabase/migrations/20260302200000_add_stripe_customer_locks_and_cli_approve_guard.sql
+++ b/supabase/migrations/20260302200000_add_stripe_customer_locks_and_cli_approve_guard.sql
@@ -1,0 +1,85 @@
+-- Add Stripe customer provisioning locks and atomic CLI approve guard.
+
+CREATE TABLE IF NOT EXISTS public.stripe_customer_provision_locks (
+  owner_key TEXT PRIMARY KEY,
+  owner_type TEXT NOT NULL CHECK (owner_type IN ('user', 'organization')),
+  owner_user_id UUID REFERENCES public.users(id) ON DELETE CASCADE,
+  owner_org_id UUID REFERENCES public.organizations(id) ON DELETE CASCADE,
+  locked_by_user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT stripe_customer_provision_locks_owner_check CHECK (
+    (owner_type = 'user' AND owner_user_id IS NOT NULL AND owner_org_id IS NULL)
+    OR
+    (owner_type = 'organization' AND owner_org_id IS NOT NULL AND owner_user_id IS NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_customer_provision_locks_created_at
+  ON public.stripe_customer_provision_locks (created_at);
+
+ALTER TABLE public.stripe_customer_provision_locks ENABLE ROW LEVEL SECURITY;
+
+DO $stripe_lock_policy$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'stripe_customer_provision_locks'
+      AND policyname = 'Service role full access stripe customer provision locks'
+  ) THEN
+    CREATE POLICY "Service role full access stripe customer provision locks"
+      ON public.stripe_customer_provision_locks FOR ALL
+      USING (auth.role() = 'service_role')
+      WITH CHECK (auth.role() = 'service_role');
+  END IF;
+END
+$stripe_lock_policy$;
+
+DO $approve_cli_auth$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.approve_cli_auth_code_atomic(
+      p_user_id UUID,
+      p_code TEXT,
+      p_expires_at TIMESTAMPTZ
+    ) RETURNS TEXT
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    DECLARE
+      v_current_code TEXT;
+      v_current_expires_at TIMESTAMPTZ;
+    BEGIN
+      SELECT cli_auth_code, cli_auth_expires_at
+      INTO v_current_code, v_current_expires_at
+      FROM public.users
+      WHERE id = p_user_id
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        RETURN 'user_not_found';
+      END IF;
+
+      IF v_current_code IS NOT NULL
+         AND v_current_code <> p_code
+         AND (v_current_expires_at IS NULL OR v_current_expires_at > now()) THEN
+        RETURN 'code_in_use';
+      END IF;
+
+      UPDATE public.users
+      SET
+        cli_auth_code = p_code,
+        cli_auth_expires_at = p_expires_at
+      WHERE id = p_user_id;
+
+      RETURN 'updated';
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.approve_cli_auth_code_atomic(UUID, TEXT, TIMESTAMPTZ) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.approve_cli_auth_code_atomic(UUID, TEXT, TIMESTAMPTZ) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.approve_cli_auth_code_atomic(UUID, TEXT, TIMESTAMPTZ) TO service_role';
+END
+$approve_cli_auth$;


### PR DESCRIPTION
## Summary
- add Stripe customer provisioning lock table to serialize user/org `stripe_customer_id` creation
- add lock acquire/release + stale-lock cleanup flow in checkout customer creation paths
- update checkout persistence to use conditional claim writes (`is stripe_customer_id null`) before final readback
- add atomic DB function for CLI approve code writes (`approve_cli_auth_code_atomic`)
- switch `/api/auth/cli` approve action to RPC-backed conflict-safe update (409 on active conflicting code)
- harden org invite revoke to delete pending invites only (`accepted_at IS NULL`) and return deterministic 409/404 states
- apply Supabase migration for new lock table + CLI approve function

## Validation
- `pnpm --filter @memories.sh/web exec vitest run src/app/api/stripe/checkout/__tests__/route.test.ts src/app/api/auth/cli/__tests__/route.test.ts 'src/app/api/orgs/[orgId]/invites/route.test.ts'`
- `pnpm --filter @memories.sh/web typecheck`
- `supabase db push --yes`
- `supabase migration list`

Fixes #394
Fixes #395
Fixes #398
Fixes #399

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes billing-related Stripe customer provisioning and adds new database primitives (lock table + SECURITY DEFINER RPC) that affect production data flows and require the migration to be applied correctly.
> 
> **Overview**
> Prevents duplicate/mismatched Stripe customers by introducing a DB-backed provisioning lock (`stripe_customer_provision_locks`) and updating checkout to acquire/release locks, wait for concurrent provisioning, and only persist `stripe_customer_id` with conditional updates before re-reading the final value.
> 
> Makes CLI auth approval conflict-safe by switching `/api/auth/cli` approve to the new `approve_cli_auth_code_atomic` RPC (returns `409` on active conflicting codes) and returning `503` when the migration/function isn’t available.
> 
> Hardens org invite revocation by only deleting unaccepted invites (`accepted_at IS NULL`) and returning deterministic `409` (already accepted) vs `404` (not found), with updated tests.
> 
> Adds a Supabase migration for the lock table (service-role-only RLS policy) and the atomic CLI approve function (service-role execute only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e932b49c878de6ea829c680e5508f780d89d3586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->