### PR TITLE
fix: harden Stripe webhook idempotency and event ordering

### DIFF
--- a/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const {
   mockConstructEvent,
   mockListLineItems,
   mockRetrieveSubscription,
+  mockRpc,
   mockUsersUpdate,
   mockUsersEq,
   mockOrganizationsUpdate,
@@ -12,6 +13,7 @@ const {
   mockConstructEvent: vi.fn(),
   mockListLineItems: vi.fn(),
   mockRetrieveSubscription: vi.fn(),
+  mockRpc: vi.fn(),
   mockUsersUpdate: vi.fn(),
   mockUsersEq: vi.fn(),
   mockOrganizationsUpdate: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock("@/lib/stripe", () => ({
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
+    rpc: mockRpc,
     from: vi.fn((table: string) => {
       if (table === "users") {
         return { update: mockUsersUpdate }
@@ -60,6 +63,7 @@ function makeWebhookRequest(body: string, signature = "sig_test"): Request {
 describe("POST /api/stripe/webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockRpc.mockResolvedValue({ data: "claimed", error: null })
     mockUsersEq.mockResolvedValue({ error: null })
     mockOrganizationsEq.mockResolvedValue({ error: null })
     mockUsersUpdate.mockReturnValue({ eq: mockUsersEq })
@@ -91,6 +95,8 @@ describe("POST /api/stripe/webhook", () => {
 
   it("updates organization billing on org checkout completion", async () => {
     mockConstructEvent.mockReturnValue({
+      id: "evt_org_checkout_1",
+      created: 1_709_000_001,
       type: "checkout.session.completed",
       data: {
         object: {
@@ -121,10 +127,19 @@ describe("POST /api/stripe/webhook", () => {
     )
     expect(mockOrganizationsEq).toHaveBeenCalledWith("id", "org-1")
     expect(mockUsersUpdate).not.toHaveBeenCalled()
+    expect(mockRpc).toHaveBeenCalledWith("claim_stripe_webhook_event", {
+      p_event_id: "evt_org_checkout_1",
+      p_event_type: "checkout.session.completed",
+      p_event_created_at: new Date(1_709_000_001 * 1000).toISOString(),
+      p_scope_type: "customer",
+      p_scope_key: "cus_org_123",
+    })
   })
 
   it("updates user plan on personal checkout completion", async () => {
     mockConstructEvent.mockReturnValue({
+      id: "evt_user_checkout_1",
+      created: 1_709_000_002,
       type: "checkout.session.completed",
       data: {
         object: {
@@ -154,6 +169,8 @@ describe("POST /api/stripe/webhook", () => {
 
   it("maps growth checkout completion to growth plan", async () => {
     mockConstructEvent.mockReturnValue({
+      id: "evt_user_growth_1",
+      created: 1_709_000_003,
       type: "checkout.session.completed",
       data: {
         object: {
@@ -183,6 +200,8 @@ describe("POST /api/stripe/webhook", () => {
 
   it("updates team subscription status with org billing identifiers", async () => {
     mockConstructEvent.mockReturnValue({
+      id: "evt_sub_update_1",
+      created: 1_709_000_004,
       type: "customer.subscription.updated",
       data: {
         object: {
@@ -210,11 +229,88 @@ describe("POST /api/stripe/webhook", () => {
 
   it("returns 200 for unhandled event type", async () => {
     mockConstructEvent.mockReturnValue({
+      id: "evt_unhandled_1",
+      created: 1_709_000_005,
       type: "payment_intent.created",
       data: { object: {} },
     })
 
     const response = await POST(makeWebhookRequest("{}"))
     expect(response.status).toBe(200)
+  })
+
+  it("returns 200 and skips writes when event is duplicate", async () => {
+    mockRpc.mockResolvedValue({ data: "duplicate", error: null })
+    mockConstructEvent.mockReturnValue({
+      id: "evt_dup_1",
+      created: 1_709_000_006,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_org_dup",
+          customer: "cus_org_123",
+          subscription: "sub_org_123",
+          metadata: {
+            workspace_owner_type: "organization",
+            workspace_org_id: "org-1",
+          },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockListLineItems).not.toHaveBeenCalled()
+    expect(mockUsersUpdate).not.toHaveBeenCalled()
+    expect(mockOrganizationsUpdate).not.toHaveBeenCalled()
+  })
+
+  it("returns 200 and skips writes when event is stale", async () => {
+    mockRpc.mockResolvedValue({ data: "stale", error: null })
+    mockConstructEvent.mockReturnValue({
+      id: "evt_stale_1",
+      created: 1_709_000_007,
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_team_123",
+          customer: "cus_org_123",
+          status: "past_due",
+          metadata: { type: "team_seats", org_id: "org-1" },
+          items: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockOrganizationsUpdate).not.toHaveBeenCalled()
+    expect(mockUsersUpdate).not.toHaveBeenCalled()
+  })
+
+  it("returns 503 when webhook guard migration is missing", async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'function public.claim_stripe_webhook_event does not exist' },
+    })
+    mockConstructEvent.mockReturnValue({
+      id: "evt_missing_guard_1",
+      created: 1_709_000_008,
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_team_123",
+          customer: "cus_org_123",
+          status: "active",
+          metadata: { type: "team_seats", org_id: "org-1" },
+          items: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(503)
+    expect(mockOrganizationsUpdate).not.toHaveBeenCalled()
+    expect(mockUsersUpdate).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/app/api/stripe/webhook/route.ts
+++ b/packages/web/src/app/api/stripe/webhook/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/env"
 
 type StripeBillingPlan = "individual" | "team" | "growth"
+type WebhookScope = { type: "customer" | "organization" | "user"; key: string }
 
 const MANAGED_PRICE_IDS = getStripeManagedPriceIds()
 const INDIVIDUAL_PRICE_IDS = getStripeIndividualPriceIds()
@@ -52,6 +53,86 @@ function planForActiveUserSubscription(plan: StripeBillingPlan | null): "individ
 
 function planForActiveOrgSubscription(plan: StripeBillingPlan | null): "team" | "growth" {
   return plan === "growth" ? "growth" : "team"
+}
+
+function isMissingFunctionError(error: unknown, functionName: string): boolean {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "").toLowerCase()
+      : ""
+  const fn = functionName.toLowerCase()
+
+  return (
+    message.includes(fn) &&
+    (message.includes("does not exist") ||
+      message.includes("function") ||
+      message.includes("could not find"))
+  )
+}
+
+function normalizeEventCreatedAt(created: number): string {
+  return new Date(created * 1000).toISOString()
+}
+
+function deriveWebhookScope(event: Stripe.Event): WebhookScope | null {
+  switch (event.type) {
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session
+      const customerId = typeof session.customer === "string" ? session.customer : null
+      if (customerId) return { type: "customer", key: customerId }
+
+      const orgId = session.metadata?.workspace_org_id
+      if (orgId) return { type: "organization", key: orgId }
+
+      const userId = session.metadata?.supabase_user_id
+      if (userId) return { type: "user", key: userId }
+      return null
+    }
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      const subscription = event.data.object as Stripe.Subscription
+      const customerId = typeof subscription.customer === "string" ? subscription.customer : null
+      return customerId ? { type: "customer", key: customerId } : null
+    }
+    case "invoice.payment_failed":
+    case "invoice.marked_uncollectible": {
+      const invoice = event.data.object as Stripe.Invoice
+      const customerId = typeof invoice.customer === "string" ? invoice.customer : null
+      return customerId ? { type: "customer", key: customerId } : null
+    }
+    default:
+      return null
+  }
+}
+
+async function claimWebhookEvent(
+  supabase: ReturnType<typeof createAdminClient>,
+  event: Stripe.Event,
+  scope: WebhookScope | null
+): Promise<"claimed" | "duplicate" | "stale" | "missing_function" | "error"> {
+  const functionName = "claim_stripe_webhook_event"
+  const { data: claimResult, error: claimError } = await supabase.rpc(functionName, {
+    p_event_id: event.id,
+    p_event_type: event.type,
+    p_event_created_at: normalizeEventCreatedAt(event.created),
+    p_scope_type: scope?.type ?? null,
+    p_scope_key: scope?.key ?? null,
+  })
+
+  if (claimError) {
+    if (isMissingFunctionError(claimError, functionName)) {
+      return "missing_function"
+    }
+    console.error("Failed to claim Stripe webhook event:", claimError)
+    return "error"
+  }
+
+  if (claimResult === "duplicate" || claimResult === "stale" || claimResult === "claimed") {
+    return claimResult
+  }
+
+  console.error("Unexpected Stripe webhook claim result:", claimResult)
+  return "error"
 }
 
 async function updateUserPlan(
@@ -100,7 +181,7 @@ async function updateOrgSubscriptionStatus(
   } else if (options.stripeSubscriptionId) {
     updates.stripe_subscription_id = options.stripeSubscriptionId
   }
-  
+
   const { error } = await supabase
     .from("organizations")
     .update(updates)
@@ -134,6 +215,21 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const supabase = createAdminClient()
+  const scope = deriveWebhookScope(event)
+  const claimStatus = await claimWebhookEvent(supabase, event, scope)
+  if (claimStatus === "missing_function") {
+    return NextResponse.json(
+      { error: "Stripe webhook ordering guard is not available yet. Run the latest database migration first." },
+      { status: 503 }
+    )
+  }
+  if (claimStatus === "duplicate" || claimStatus === "stale") {
+    return NextResponse.json({ received: true })
+  }
+  if (claimStatus !== "claimed") {
+    return NextResponse.json({ error: "Webhook guard check failed" }, { status: 500 })
+  }
+
   let ok = true
 
   switch (event.type) {

--- a/supabase/migrations/20260302203000_add_stripe_webhook_claim_guard.sql
+++ b/supabase/migrations/20260302203000_add_stripe_webhook_claim_guard.sql
@@ -1,0 +1,127 @@
+-- Add Stripe webhook idempotency and ordering guards.
+
+CREATE TABLE IF NOT EXISTS public.stripe_webhook_events (
+  event_id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  stripe_created_at TIMESTAMPTZ NOT NULL,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.stripe_webhook_scopes (
+  scope_type TEXT NOT NULL,
+  scope_key TEXT NOT NULL,
+  last_event_id TEXT NOT NULL,
+  last_event_created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (scope_type, scope_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_created_at
+  ON public.stripe_webhook_events (stripe_created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_scopes_updated_at
+  ON public.stripe_webhook_scopes (updated_at DESC);
+
+ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.stripe_webhook_scopes ENABLE ROW LEVEL SECURITY;
+
+DO $stripe_webhook_policy$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'stripe_webhook_events'
+      AND policyname = 'Service role full access stripe webhook events'
+  ) THEN
+    CREATE POLICY "Service role full access stripe webhook events"
+      ON public.stripe_webhook_events FOR ALL
+      USING (auth.role() = 'service_role')
+      WITH CHECK (auth.role() = 'service_role');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'stripe_webhook_scopes'
+      AND policyname = 'Service role full access stripe webhook scopes'
+  ) THEN
+    CREATE POLICY "Service role full access stripe webhook scopes"
+      ON public.stripe_webhook_scopes FOR ALL
+      USING (auth.role() = 'service_role')
+      WITH CHECK (auth.role() = 'service_role');
+  END IF;
+END
+$stripe_webhook_policy$;
+
+DO $claim_stripe_webhook_event$
+BEGIN
+  EXECUTE $create_fn$
+    CREATE OR REPLACE FUNCTION public.claim_stripe_webhook_event(
+      p_event_id TEXT,
+      p_event_type TEXT,
+      p_event_created_at TIMESTAMPTZ,
+      p_scope_type TEXT DEFAULT NULL,
+      p_scope_key TEXT DEFAULT NULL
+    ) RETURNS TEXT
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $fn$
+    BEGIN
+      IF p_event_id IS NULL OR p_event_type IS NULL OR p_event_created_at IS NULL THEN
+        RETURN 'invalid';
+      END IF;
+
+      INSERT INTO public.stripe_webhook_events (event_id, event_type, stripe_created_at)
+      VALUES (p_event_id, p_event_type, p_event_created_at)
+      ON CONFLICT (event_id) DO NOTHING;
+
+      IF NOT FOUND THEN
+        RETURN 'duplicate';
+      END IF;
+
+      IF p_scope_type IS NULL OR p_scope_key IS NULL THEN
+        RETURN 'claimed';
+      END IF;
+
+      INSERT INTO public.stripe_webhook_scopes (
+        scope_type,
+        scope_key,
+        last_event_id,
+        last_event_created_at,
+        updated_at
+      )
+      VALUES (
+        p_scope_type,
+        p_scope_key,
+        p_event_id,
+        p_event_created_at,
+        now()
+      )
+      ON CONFLICT (scope_type, scope_key) DO UPDATE
+      SET
+        last_event_id = EXCLUDED.last_event_id,
+        last_event_created_at = EXCLUDED.last_event_created_at,
+        updated_at = now()
+      WHERE
+        EXCLUDED.last_event_created_at > public.stripe_webhook_scopes.last_event_created_at
+        OR (
+          EXCLUDED.last_event_created_at = public.stripe_webhook_scopes.last_event_created_at
+          AND EXCLUDED.last_event_id > public.stripe_webhook_scopes.last_event_id
+        );
+
+      IF NOT FOUND THEN
+        RETURN 'stale';
+      END IF;
+
+      RETURN 'claimed';
+    END;
+    $fn$;
+  $create_fn$;
+
+  EXECUTE 'ALTER FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ, TEXT, TEXT) SET search_path = public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ, TEXT, TEXT) FROM PUBLIC, anon, authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ, TEXT, TEXT) TO service_role';
+END
+$claim_stripe_webhook_event$;


### PR DESCRIPTION
## Summary
- add DB-backed webhook claim guard for Stripe event idempotency (`event_id` ledger)
- add per-scope ordering watermark to drop stale out-of-order billing events
- gate webhook processing through `claim_stripe_webhook_event` and short-circuit duplicate/stale events
- add webhook tests for duplicate/stale short-circuit and missing migration behavior

## Validation
- pnpm --filter @memories.sh/web exec vitest run src/app/api/stripe/webhook/__tests__/route.test.ts
- pnpm --filter @memories.sh/web typecheck
- pnpm --filter @memories.sh/web exec eslint src/app/api/stripe/webhook/route.ts src/app/api/stripe/webhook/__tests__/route.test.ts
- supabase db push --yes
- supabase migration list

Fixes #396
Fixes #397

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Stripe webhook billing updates and adds new Supabase tables/RPC that gate all webhook processing; any bug or missing migration could cause dropped/blocked subscription state changes.
> 
> **Overview**
> Stripe webhook processing is now gated through a Supabase RPC (`claim_stripe_webhook_event`) that records each event for **idempotency** and maintains a per-scope watermark to **drop stale/out-of-order events** before any DB writes.
> 
> A new Supabase migration adds `stripe_webhook_events`, `stripe_webhook_scopes`, and the `claim_stripe_webhook_event` SECURITY DEFINER function (service-role only); the API returns `503` when the function is missing and short-circuits `duplicate`/`stale` events. Tests were updated to mock `rpc`, assert claim parameters, and cover duplicate/stale skip behavior and missing-migration handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e32dc93704e509309a60dab79458e4c44ec8c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->