### PR TITLE
improve: harden Stripe webhook event handling

### DIFF
--- a/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -227,6 +227,61 @@ describe("POST /api/stripe/webhook", () => {
     expect(mockOrganizationsEq).toHaveBeenCalledWith("id", "org-1")
   })
 
+  it("handles customer.subscription.created for org subscriptions", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_sub_created_1",
+      created: 1_709_000_009,
+      type: "customer.subscription.created",
+      data: {
+        object: {
+          id: "sub_team_created_123",
+          customer: "cus_org_123",
+          status: "active",
+          metadata: { type: "team_seats", org_id: "org-1" },
+          items: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockOrganizationsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscription_status: "active",
+        stripe_customer_id: "cus_org_123",
+        stripe_subscription_id: "sub_team_created_123",
+        plan: "team",
+      })
+    )
+    expect(mockOrganizationsEq).toHaveBeenCalledWith("id", "org-1")
+  })
+
+  it("supports expanded Stripe customer payloads on subscription updates", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_sub_update_expanded_customer_1",
+      created: 1_709_000_010,
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_team_123",
+          customer: { id: "cus_org_123" },
+          status: "past_due",
+          metadata: { type: "team_seats", org_id: "org-1" },
+          items: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockOrganizationsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscription_status: "past_due",
+        stripe_customer_id: "cus_org_123",
+      })
+    )
+  })
+
   it("returns 200 for unhandled event type", async () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_unhandled_1",
@@ -237,6 +292,7 @@ describe("POST /api/stripe/webhook", () => {
 
     const response = await POST(makeWebhookRequest("{}"))
     expect(response.status).toBe(200)
+    expect(mockRpc).not.toHaveBeenCalled()
   })
 
   it("returns 200 and skips writes when event is duplicate", async () => {

--- a/packages/web/src/app/api/stripe/webhook/route.ts
+++ b/packages/web/src/app/api/stripe/webhook/route.ts
@@ -12,11 +12,26 @@ import {
 
 type StripeBillingPlan = "individual" | "team" | "growth"
 type WebhookScope = { type: "customer" | "organization" | "user"; key: string }
+type ManagedWebhookEventType =
+  | "checkout.session.completed"
+  | "customer.subscription.created"
+  | "customer.subscription.updated"
+  | "customer.subscription.deleted"
+  | "invoice.payment_failed"
+  | "invoice.marked_uncollectible"
 
 const MANAGED_PRICE_IDS = getStripeManagedPriceIds()
 const INDIVIDUAL_PRICE_IDS = getStripeIndividualPriceIds()
 const TEAM_PRICE_IDS = getStripeTeamSeatPriceIds()
 const GROWTH_PRICE_IDS = getStripeGrowthPriceIds()
+const MANAGED_WEBHOOK_EVENT_TYPES = new Set<ManagedWebhookEventType>([
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+  "invoice.payment_failed",
+  "invoice.marked_uncollectible",
+])
 
 function hasManagedPrice(items: { price?: { id: string } | null }[]): boolean {
   return items.some((item) => item.price?.id && MANAGED_PRICE_IDS.has(item.price.id))
@@ -74,6 +89,18 @@ function normalizeEventCreatedAt(created: number): string {
   return new Date(created * 1000).toISOString()
 }
 
+function isManagedWebhookEventType(type: string): type is ManagedWebhookEventType {
+  return MANAGED_WEBHOOK_EVENT_TYPES.has(type as ManagedWebhookEventType)
+}
+
+function extractCustomerId(customer: Stripe.Customer | Stripe.DeletedCustomer | string | null | undefined): string | null {
+  if (typeof customer === "string") return customer
+  if (customer && typeof customer === "object" && "id" in customer && typeof customer.id === "string") {
+    return customer.id
+  }
+  return null
+}
+
 function deriveWebhookScope(event: Stripe.Event): WebhookScope | null {
   switch (event.type) {
     case "checkout.session.completed": {
@@ -88,16 +115,17 @@ function deriveWebhookScope(event: Stripe.Event): WebhookScope | null {
       if (userId) return { type: "user", key: userId }
       return null
     }
+    case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted": {
       const subscription = event.data.object as Stripe.Subscription
-      const customerId = typeof subscription.customer === "string" ? subscription.customer : null
+      const customerId = extractCustomerId(subscription.customer)
       return customerId ? { type: "customer", key: customerId } : null
     }
     case "invoice.payment_failed":
     case "invoice.marked_uncollectible": {
       const invoice = event.data.object as Stripe.Invoice
-      const customerId = typeof invoice.customer === "string" ? invoice.customer : null
+      const customerId = extractCustomerId(invoice.customer)
       return customerId ? { type: "customer", key: customerId } : null
     }
     default:
@@ -214,6 +242,10 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 })
   }
 
+  if (!isManagedWebhookEventType(event.type)) {
+    return NextResponse.json({ received: true })
+  }
+
   const supabase = createAdminClient()
   const scope = deriveWebhookScope(event)
   const claimStatus = await claimWebhookEvent(supabase, event, scope)
@@ -274,9 +306,14 @@ export async function POST(request: Request): Promise<Response> {
       break
     }
 
+    case "customer.subscription.created":
     case "customer.subscription.updated": {
       const subscription = event.data.object
-      const customerId = subscription.customer as string
+      const customerId = extractCustomerId(subscription.customer)
+      if (!customerId) {
+        console.error("Subscription event missing customer identifier:", subscription.id)
+        break
+      }
 
       // Only act on subscriptions for our managed prices.
       if (!hasManagedPrice(subscription.items.data)) break
@@ -324,7 +361,11 @@ export async function POST(request: Request): Promise<Response> {
 
     case "customer.subscription.deleted": {
       const subscription = event.data.object
-      const customerId = subscription.customer as string
+      const customerId = extractCustomerId(subscription.customer)
+      if (!customerId) {
+        console.error("Subscription delete event missing customer identifier:", subscription.id)
+        break
+      }
 
       // Only act on subscriptions for our managed prices.
       if (!hasManagedPrice(subscription.items.data)) break
@@ -353,7 +394,11 @@ export async function POST(request: Request): Promise<Response> {
 
     case "invoice.payment_failed": {
       const invoice = event.data.object as Stripe.Invoice
-      const customerId = invoice.customer as string
+      const customerId = extractCustomerId(invoice.customer)
+      if (!customerId) {
+        console.error("Invoice payment_failed event missing customer identifier:", invoice.id)
+        break
+      }
       const subscriptionId = (invoice as { subscription?: string | null }).subscription
 
       // Only act on invoices for our managed prices.
@@ -392,7 +437,11 @@ export async function POST(request: Request): Promise<Response> {
 
     case "invoice.marked_uncollectible": {
       const invoice = event.data.object as Stripe.Invoice
-      const customerId = invoice.customer as string
+      const customerId = extractCustomerId(invoice.customer)
+      if (!customerId) {
+        console.error("Invoice marked_uncollectible event missing customer identifier:", invoice.id)
+        break
+      }
       const subscriptionId = (invoice as { subscription?: string | null }).subscription
 
       // Only act on invoices for our managed prices.


### PR DESCRIPTION
## Summary
- reduce webhook overhead by skipping DB claim-guard RPC for unhandled Stripe event types
- harden customer-id extraction to support expanded Stripe objects instead of assuming only string IDs
- handle `customer.subscription.created` alongside updates to apply billing state immediately

## Validation
- pnpm --filter @memories.sh/web exec vitest run src/app/api/stripe/webhook/__tests__/route.test.ts
- pnpm --filter @memories.sh/web typecheck
- pnpm --filter @memories.sh/web exec eslint src/app/api/stripe/webhook/route.ts src/app/api/stripe/webhook/__tests__/route.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe billing webhook flows and gating logic; mistakes could lead to missed billing state updates or skipped ordering-guard claims, though changes are scoped and covered by tests.
> 
> **Overview**
> Stripe webhook processing now **early-returns for unhandled event types** so the DB claim-guard RPC is only invoked for a small allowlist of managed billing events.
> 
> Adds `customer.subscription.created` handling (alongside `updated`) so org/user billing state is applied immediately, and introduces `extractCustomerId` to support both string and expanded object forms of `customer` across subscription/invoice events (with explicit logging when missing). Tests are updated to cover the new subscription-created path, expanded customer payloads, and ensuring unhandled events do not call the claim RPC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e6c0c93cf6106da23e5cdc04a4e6ff5dd6f79b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->