### PR TITLE
improve: harden expanded Stripe webhook payload handling

### DIFF
--- a/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -136,6 +136,47 @@ describe("POST /api/stripe/webhook", () => {
     })
   })
 
+  it("supports expanded Stripe customer payloads on checkout completion", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_org_checkout_expanded_customer_1",
+      created: 1_709_000_001,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_org_expanded_customer_123",
+          customer: { id: "cus_org_123" },
+          subscription: "sub_org_123",
+          metadata: {
+            workspace_owner_type: "organization",
+            workspace_org_id: "org-1",
+            supabase_user_id: "user-1",
+          },
+        },
+      },
+    })
+    mockListLineItems.mockResolvedValue({
+      data: [{ price: { id: "price_team_monthly" } }],
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockOrganizationsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_customer_id: "cus_org_123",
+        stripe_subscription_id: "sub_org_123",
+        subscription_status: "active",
+        plan: "team",
+      })
+    )
+    expect(mockRpc).toHaveBeenCalledWith("claim_stripe_webhook_event", {
+      p_event_id: "evt_org_checkout_expanded_customer_1",
+      p_event_type: "checkout.session.completed",
+      p_event_created_at: new Date(1_709_000_001 * 1000).toISOString(),
+      p_scope_type: "customer",
+      p_scope_key: "cus_org_123",
+    })
+  })
+
   it("updates user plan on personal checkout completion", async () => {
     mockConstructEvent.mockReturnValue({
       id: "evt_user_checkout_1",
@@ -280,6 +321,85 @@ describe("POST /api/stripe/webhook", () => {
         stripe_customer_id: "cus_org_123",
       })
     )
+  })
+
+  it("uses expanded invoice subscriptions for payment failures without Stripe re-fetch", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_failed_expanded_subscription_1",
+      created: 1_709_000_011,
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_team_failed_123",
+          customer: null,
+          subscription: {
+            id: "sub_team_123",
+            customer: "cus_org_123",
+            metadata: { type: "team_seats", org_id: "org-1" },
+            items: { data: [{ price: { id: "price_team_monthly" } }] },
+          },
+          lines: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockRetrieveSubscription).not.toHaveBeenCalled()
+    expect(mockOrganizationsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscription_status: "past_due",
+        stripe_customer_id: "cus_org_123",
+        stripe_subscription_id: "sub_team_123",
+        plan: "past_due",
+      })
+    )
+    expect(mockRpc).toHaveBeenCalledWith("claim_stripe_webhook_event", {
+      p_event_id: "evt_invoice_failed_expanded_subscription_1",
+      p_event_type: "invoice.payment_failed",
+      p_event_created_at: new Date(1_709_000_011 * 1000).toISOString(),
+      p_scope_type: "customer",
+      p_scope_key: "cus_org_123",
+    })
+  })
+
+  it("uses expanded invoice subscriptions for uncollectible invoices without Stripe re-fetch", async () => {
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_uncollectible_expanded_subscription_1",
+      created: 1_709_000_012,
+      type: "invoice.marked_uncollectible",
+      data: {
+        object: {
+          id: "in_team_uncollectible_123",
+          customer: null,
+          subscription: {
+            id: "sub_team_123",
+            customer: { id: "cus_org_123" },
+            metadata: { type: "team_seats", org_id: "org-1" },
+            items: { data: [{ price: { id: "price_team_monthly" } }] },
+          },
+          lines: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockRetrieveSubscription).not.toHaveBeenCalled()
+    expect(mockOrganizationsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscription_status: "cancelled",
+        stripe_customer_id: "cus_org_123",
+        plan: "free",
+      })
+    )
+    expect(mockRpc).toHaveBeenCalledWith("claim_stripe_webhook_event", {
+      p_event_id: "evt_invoice_uncollectible_expanded_subscription_1",
+      p_event_type: "invoice.marked_uncollectible",
+      p_event_created_at: new Date(1_709_000_012 * 1000).toISOString(),
+      p_scope_type: "customer",
+      p_scope_key: "cus_org_123",
+    })
   })
 
   it("returns 200 for unhandled event type", async () => {

--- a/packages/web/src/app/api/stripe/webhook/route.ts
+++ b/packages/web/src/app/api/stripe/webhook/route.ts
@@ -101,11 +101,51 @@ function extractCustomerId(customer: Stripe.Customer | Stripe.DeletedCustomer | 
   return null
 }
 
+function extractExpandedSubscription(
+  subscription: Stripe.Subscription | string | null | undefined
+): Stripe.Subscription | null {
+  if (subscription && typeof subscription === "object" && "id" in subscription) {
+    return subscription
+  }
+  return null
+}
+
+function extractSubscriptionId(subscription: Stripe.Subscription | string | null | undefined): string | null {
+  if (typeof subscription === "string") return subscription
+  if (subscription && typeof subscription === "object" && "id" in subscription && typeof subscription.id === "string") {
+    return subscription.id
+  }
+  return null
+}
+
+async function resolveSubscriptionReference(
+  subscription: Stripe.Subscription | string | null | undefined,
+  context: string
+): Promise<Stripe.Subscription | null> {
+  const expandedSubscription = extractExpandedSubscription(subscription)
+  if (expandedSubscription) {
+    return expandedSubscription
+  }
+
+  const subscriptionId = extractSubscriptionId(subscription)
+  if (!subscriptionId) {
+    return null
+  }
+
+  try {
+    return await getStripe().subscriptions.retrieve(subscriptionId)
+  } catch (error) {
+    console.error(`Failed to retrieve subscription for ${context}:`, error)
+    return null
+  }
+}
+
 function deriveWebhookScope(event: Stripe.Event): WebhookScope | null {
   switch (event.type) {
     case "checkout.session.completed": {
       const session = event.data.object as Stripe.Checkout.Session
-      const customerId = typeof session.customer === "string" ? session.customer : null
+      const subscription = extractExpandedSubscription(session.subscription)
+      const customerId = extractCustomerId(session.customer) ?? extractCustomerId(subscription?.customer)
       if (customerId) return { type: "customer", key: customerId }
 
       const orgId = session.metadata?.workspace_org_id
@@ -125,7 +165,9 @@ function deriveWebhookScope(event: Stripe.Event): WebhookScope | null {
     case "invoice.payment_failed":
     case "invoice.marked_uncollectible": {
       const invoice = event.data.object as Stripe.Invoice
-      const customerId = extractCustomerId(invoice.customer)
+      const invoiceSubscription = (invoice as { subscription?: Stripe.Subscription | string | null }).subscription
+      const subscription = extractExpandedSubscription(invoiceSubscription)
+      const customerId = extractCustomerId(invoice.customer) ?? extractCustomerId(subscription?.customer)
       return customerId ? { type: "customer", key: customerId } : null
     }
     default:
@@ -277,14 +319,9 @@ export async function POST(request: Request): Promise<Response> {
 
       const ownerType = session.metadata?.workspace_owner_type
       const orgId = session.metadata?.workspace_org_id
-      const sessionSubscription = session.subscription
-      const subscriptionId =
-        typeof sessionSubscription === "string"
-          ? sessionSubscription
-          : sessionSubscription && typeof sessionSubscription === "object"
-            ? sessionSubscription.id
-            : null
-      const customerId = typeof session.customer === "string" ? session.customer : null
+      const subscriptionId = extractSubscriptionId(session.subscription)
+      const expandedSubscription = extractExpandedSubscription(session.subscription)
+      const customerId = extractCustomerId(session.customer) ?? extractCustomerId(expandedSubscription?.customer)
 
       if (ownerType === "organization" && orgId) {
         ok = await updateOrgSubscriptionStatus(supabase, orgId, "active", {
@@ -394,12 +431,14 @@ export async function POST(request: Request): Promise<Response> {
 
     case "invoice.payment_failed": {
       const invoice = event.data.object as Stripe.Invoice
-      const customerId = extractCustomerId(invoice.customer)
+      const invoiceSubscription = (invoice as { subscription?: Stripe.Subscription | string | null }).subscription
+      const subscription = await resolveSubscriptionReference(invoiceSubscription, "invoice")
+      const customerId = extractCustomerId(invoice.customer) ?? extractCustomerId(subscription?.customer)
       if (!customerId) {
         console.error("Invoice payment_failed event missing customer identifier:", invoice.id)
         break
       }
-      const subscriptionId = (invoice as { subscription?: string | null }).subscription
+      const subscriptionId = subscription?.id ?? extractSubscriptionId(invoiceSubscription)
 
       // Only act on invoices for our managed prices.
       if (!invoice.lines?.data || !hasManagedPrice(invoice.lines.data as { price?: { id: string } | null }[])) break
@@ -407,25 +446,26 @@ export async function POST(request: Request): Promise<Response> {
       let handled = false
 
       // Check if this is for an organization subscription.
-      if (subscriptionId && typeof subscriptionId === "string") {
+      if (subscription) {
         try {
-          const subscription = await getStripe().subscriptions.retrieve(subscriptionId)
           const orgId = subscription.metadata.org_id
           if (orgId && typeof orgId === "string") {
             const subscriptionPlan = parseMetadataBillingPlan(subscription.metadata) ??
               detectBillingPlanFromItems(subscription.items.data)
             ok = await updateOrgSubscriptionStatus(supabase, orgId, "past_due", {
               stripeCustomerId: customerId,
-              stripeSubscriptionId: subscriptionId,
+              stripeSubscriptionId: subscription.id,
               activePlan: planForActiveOrgSubscription(subscriptionPlan),
             })
             handled = true
           } else if (isTeamSubscription(subscription.metadata)) {
-            console.error("Team subscription missing org_id for invoice:", subscriptionId)
+            console.error("Team subscription missing org_id for invoice:", subscription.id)
           }
         } catch (e) {
           console.error("Failed to retrieve subscription for invoice:", e)
         }
+      } else if (subscriptionId) {
+        console.error("Invoice subscription could not be resolved:", subscriptionId)
       }
 
       // Individual subscription (only if not handled as team)
@@ -437,12 +477,14 @@ export async function POST(request: Request): Promise<Response> {
 
     case "invoice.marked_uncollectible": {
       const invoice = event.data.object as Stripe.Invoice
-      const customerId = extractCustomerId(invoice.customer)
+      const invoiceSubscription = (invoice as { subscription?: Stripe.Subscription | string | null }).subscription
+      const subscription = await resolveSubscriptionReference(invoiceSubscription, "invoice")
+      const customerId = extractCustomerId(invoice.customer) ?? extractCustomerId(subscription?.customer)
       if (!customerId) {
         console.error("Invoice marked_uncollectible event missing customer identifier:", invoice.id)
         break
       }
-      const subscriptionId = (invoice as { subscription?: string | null }).subscription
+      const subscriptionId = subscription?.id ?? extractSubscriptionId(invoiceSubscription)
 
       // Only act on invoices for our managed prices.
       if (!invoice.lines?.data || !hasManagedPrice(invoice.lines.data as { price?: { id: string } | null }[])) break
@@ -450,9 +492,8 @@ export async function POST(request: Request): Promise<Response> {
       let handled = false
 
       // Check if this is for an organization subscription.
-      if (subscriptionId && typeof subscriptionId === "string") {
+      if (subscription) {
         try {
-          const subscription = await getStripe().subscriptions.retrieve(subscriptionId)
           const orgId = subscription.metadata.org_id
           if (orgId && typeof orgId === "string") {
             const subscriptionPlan = parseMetadataBillingPlan(subscription.metadata) ??
@@ -463,11 +504,13 @@ export async function POST(request: Request): Promise<Response> {
             })
             handled = true
           } else if (isTeamSubscription(subscription.metadata)) {
-            console.error("Team subscription missing org_id for invoice:", subscriptionId)
+            console.error("Team subscription missing org_id for invoice:", subscription.id)
           }
         } catch (e) {
           console.error("Failed to retrieve subscription for invoice:", e)
         }
+      } else if (subscriptionId) {
+        console.error("Invoice subscription could not be resolved:", subscriptionId)
       }
 
       // Individual subscription (only if not handled as team)


### PR DESCRIPTION
## Summary
- support expanded checkout customer payloads for guard scoping and billing persistence
- support expanded invoice subscription payloads, including customer fallback when invoice.customer is absent
- avoid redundant Stripe subscription fetches when the invoice already contains the subscription object

## Validation
- pnpm --filter @memories.sh/web exec vitest run src/app/api/stripe/webhook/__tests__/route.test.ts
- pnpm --filter @memories.sh/web typecheck
- pnpm --filter @memories.sh/web exec eslint src/app/api/stripe/webhook/route.ts src/app/api/stripe/webhook/__tests__/route.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe webhook billing updates and scope-derivation logic; mistakes could mis-associate customers or set incorrect subscription status/plan. Changes are mostly defensive and covered by new tests, reducing but not eliminating risk.
> 
> **Overview**
> **Hardens Stripe webhook handling for expanded payloads.** Webhook scope derivation and checkout completion processing now accept expanded `customer`/`subscription` objects (not just string IDs) and fall back to `subscription.customer` when needed.
> 
> **Improves invoice failure/uncollectible handling.** `invoice.*` events now use an expanded `invoice.subscription` object when present (skipping a Stripe `subscriptions.retrieve` call), otherwise they fetch it; customer identification also falls back to the subscription when `invoice.customer` is missing. Tests add coverage for these expanded-payload scenarios and verify no redundant subscription re-fetch occurs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d5affea6264f4f9c1d36af87d94aef99e619f9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->