### PR TITLE
fix: harden billing redirect validation

### DIFF
--- a/packages/web/src/app/api/stripe/checkout/__tests__/route.test.ts
+++ b/packages/web/src/app/api/stripe/checkout/__tests__/route.test.ts
@@ -85,6 +85,27 @@ describe("/api/stripe/checkout", () => {
     expect(response.status).toBe(403)
   })
 
+  it("returns 400 when billing input is invalid", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "user@example.com" })
+    mockResolveWorkspaceContext.mockResolvedValue({
+      ownerType: "user",
+      orgId: null,
+      orgRole: null,
+      plan: "free",
+      hasDatabase: true,
+      canProvision: true,
+      canManageBilling: true,
+      turso_db_url: "libsql://user.turso.io",
+      turso_db_token: "token",
+      turso_db_name: "user-db",
+      userId: "user-1",
+    })
+
+    const response = await POST(makeRequest({ billing: "invalid" }))
+    expect(response.status).toBe(400)
+    expect(mockCheckoutSessionCreate).not.toHaveBeenCalled()
+  })
+
   it("creates org checkout session using organization customer + team metadata", async () => {
     mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "owner@example.com" })
     mockResolveWorkspaceContext.mockResolvedValue({
@@ -250,6 +271,48 @@ describe("/api/stripe/checkout", () => {
         ]),
       })
     )
+  })
+
+  it("returns 500 when Stripe checkout session has no redirect URL", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "user@example.com" })
+    mockResolveWorkspaceContext.mockResolvedValue({
+      ownerType: "user",
+      orgId: null,
+      orgRole: null,
+      plan: "free",
+      hasDatabase: true,
+      canProvision: true,
+      canManageBilling: true,
+      turso_db_url: "libsql://user.turso.io",
+      turso_db_token: "token",
+      turso_db_name: "user-db",
+      userId: "user-1",
+    })
+    mockCheckoutSessionCreate.mockResolvedValue({ url: null })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { stripe_customer_id: "cus_user_123", email: "user@example.com" },
+                error: null,
+              }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }
+      }
+      return {}
+    })
+
+    const response = await POST(makeRequest({ billing: "monthly" }))
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.code).toBe("CHECKOUT_SESSION_MISSING_URL")
   })
 
   it("returns 500 when organization customer lookup fails", async () => {

--- a/packages/web/src/app/api/stripe/checkout/route.ts
+++ b/packages/web/src/app/api/stripe/checkout/route.ts
@@ -522,6 +522,16 @@ export async function POST(request: Request): Promise<Response> {
         })
       : await getStripe().checkout.sessions.create(sessionPayload)
 
+    if (!session.url) {
+      console.error("Stripe checkout session missing redirect URL:", {
+        ownerType: workspace.ownerType,
+        orgId: workspace.orgId ?? null,
+        requestedPlan,
+        billing,
+      })
+      return jsonError("Failed to create checkout session", 500, "CHECKOUT_SESSION_MISSING_URL")
+    }
+
     return NextResponse.json({ url: session.url })
   } catch (error) {
     console.error("Failed to create checkout session:", error)

--- a/packages/web/src/app/api/stripe/portal/__tests__/route.test.ts
+++ b/packages/web/src/app/api/stripe/portal/__tests__/route.test.ts
@@ -168,6 +168,45 @@ describe("/api/stripe/portal", () => {
     )
   })
 
+  it("returns 500 when billing portal session has no redirect URL", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "user@example.com" })
+    mockResolveWorkspaceContext.mockResolvedValue({
+      ownerType: "user",
+      orgId: null,
+      orgRole: null,
+      plan: "pro",
+      hasDatabase: true,
+      canProvision: true,
+      canManageBilling: true,
+      turso_db_url: "libsql://user.turso.io",
+      turso_db_token: "token",
+      turso_db_name: "user-db",
+      userId: "user-1",
+    })
+    mockPortalCreate.mockResolvedValue({ url: null })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { stripe_customer_id: "cus_user_123" },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+      return {}
+    })
+
+    const response = await POST(makeRequest())
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.code).toBe("BILLING_PORTAL_MISSING_URL")
+  })
+
   it("returns 500 when organization billing customer lookup fails", async () => {
     mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "owner@example.com" })
     mockResolveWorkspaceContext.mockResolvedValue({

--- a/packages/web/src/app/api/stripe/portal/route.ts
+++ b/packages/web/src/app/api/stripe/portal/route.ts
@@ -73,6 +73,15 @@ export async function POST(request: Request): Promise<Response> {
       return_url: `${origin}/app/billing`,
     })
 
+    if (!session.url) {
+      console.error("Stripe billing portal session missing redirect URL:", {
+        ownerType: workspace.ownerType,
+        orgId: workspace.orgId ?? null,
+        customerId,
+      })
+      return jsonError("Failed to open billing portal", 500, "BILLING_PORTAL_MISSING_URL")
+    }
+
     return NextResponse.json({ url: session.url })
   } catch (error) {
     console.error("Failed to create billing portal session:", error)

--- a/packages/web/src/lib/__tests__/validations.test.ts
+++ b/packages/web/src/lib/__tests__/validations.test.ts
@@ -320,8 +320,13 @@ describe("checkoutSchema", () => {
     expect(result.success).toBe(true)
   })
 
-  it("should default to annual on invalid value", () => {
+  it("should reject invalid billing values", () => {
     const result = checkoutSchema.safeParse({ billing: "invalid" })
+    expect(result.success).toBe(false)
+  })
+
+  it("should default to annual when billing is omitted", () => {
+    const result = checkoutSchema.safeParse({})
     expect(result.success).toBe(true)
     if (result.success) expect(result.data.billing).toBe("annual")
   })

--- a/packages/web/src/lib/validations.ts
+++ b/packages/web/src/lib/validations.ts
@@ -99,7 +99,7 @@ export const acceptInviteSchema = z.object({
 // --- Stripe Checkout ---
 
 export const checkoutSchema = z.object({
-  billing: z.enum(["monthly", "annual"]).catch("annual"),
+  billing: z.enum(["monthly", "annual"]).default("annual"),
   plan: z.enum(["individual", "team", "growth"]).optional(),
   requestId: z.string().uuid().optional(),
 })


### PR DESCRIPTION
## Summary
- reject invalid checkout billing values instead of silently coercing them to annual
- return a safe 500 when Stripe checkout sessions are created without a redirect URL
- return a safe 500 when Stripe billing portal sessions are created without a redirect URL

## Validation
- pnpm --filter @memories.sh/web exec vitest run src/app/api/stripe/checkout/__tests__/route.test.ts src/app/api/stripe/portal/__tests__/route.test.ts src/lib/__tests__/validations.test.ts
- pnpm --filter @memories.sh/web typecheck
- pnpm --filter @memories.sh/web exec eslint src/app/api/stripe/checkout/route.ts src/app/api/stripe/portal/route.ts src/app/api/stripe/checkout/__tests__/route.test.ts src/app/api/stripe/portal/__tests__/route.test.ts src/lib/validations.ts src/lib/__tests__/validations.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe checkout/portal flows and changes how invalid billing inputs are handled, which could affect upgrade UX if clients send unexpected values. Changes are defensive and well-covered by new tests, reducing runtime risk.
> 
> **Overview**
> Tightens billing input validation by changing `checkoutSchema` to **reject invalid `billing` values** (instead of silently coercing) while still defaulting to `annual` when omitted.
> 
> Hardens Stripe redirect handling by returning a controlled **500** with new error codes when Stripe returns a checkout or billing-portal session without a `url` (and logs relevant context). Tests are expanded to cover invalid billing input and missing session URL scenarios for both `/api/stripe/checkout` and `/api/stripe/portal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2584398f4b1387a7860d321dfc7fbd96f34552a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->