### PR TITLE
Codex/sdk project provisioning

### DIFF
--- a/packages/web/src/components/dashboard/SdkProjectsSection.tsx
+++ b/packages/web/src/components/dashboard/SdkProjectsSection.tsx
@@ -159,6 +159,12 @@ export function SdkProjectsSection({
     setCreatedKey(null)
     setCopiedKey(false)
     try {
+      const parsedExpiry = generateApiKey ? new Date(expiryInput) : null
+      if (generateApiKey && (!parsedExpiry || Number.isNaN(parsedExpiry.getTime()))) {
+        throw new Error("Expiry must be a valid date and time.")
+      }
+      const expiresAt = parsedExpiry ? parsedExpiry.toISOString() : undefined
+
       setError(null)
       const response = await fetch("/api/sdk-projects", {
         method: "POST",
@@ -168,7 +174,7 @@ export function SdkProjectsSection({
           tenantId,
           description,
           generateApiKey,
-          expiresAt: generateApiKey ? expiryInput : undefined,
+          expiresAt,
         }),
       })
       const payload = await response.json().catch(() => null)

--- a/supabase/migrations/20260309153000_add_sdk_projects_table.sql
+++ b/supabase/migrations/20260309153000_add_sdk_projects_table.sql
@@ -50,8 +50,8 @@ BEGIN
   ) THEN
     CREATE POLICY "Service role full access sdk_projects"
       ON public.sdk_projects
-      USING (auth.role() = 'service_role')
-      WITH CHECK (auth.role() = 'service_role');
+      USING ((SELECT auth.role()) = 'service_role')
+      WITH CHECK ((SELECT auth.role()) = 'service_role');
   END IF;
 END;
 $$;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches database RLS policy logic and API payload formatting; mistakes could impact access control or expiry handling for newly created keys.
> 
> **Overview**
> Improves SDK project creation by validating the `datetime-local` expiry input when `generateApiKey` is enabled and sending a normalized ISO-8601 `expiresAt` value (or omitting it) to `/api/sdk-projects`.
> 
> Updates the `sdk_projects` RLS policy in the migration to check the service role via `(SELECT auth.role()) = 'service_role'` for both `USING` and `WITH CHECK`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e287345a217f3e1eccfc8cf3f0f4d72c694112b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->