### PR TITLE
feat: add sdk/ skill entry point

### DIFF
--- a/sdk/SKILL.md
+++ b/sdk/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: memories-sdk
+description: "Build against the memories.sh SDK packages in application code. Use when working with `@memories.sh/core` or `@memories.sh/ai-sdk`, including: (1) Initializing `MemoriesClient`, (2) Reading, writing, searching, or editing memories from backend code, route handlers, workers, or scripts, (3) Integrating memories with the Vercel AI SDK via `memoriesMiddleware`, `memoriesTools`, `preloadContext`, or `createMemoriesOnFinish`, (4) Choosing and applying `tenantId` / `userId` / `projectId` scoping, (5) Managing SDK skill files or management APIs, or (6) Debugging memories SDK usage in TypeScript or JavaScript applications. Use `memories-cli` for CLI workflows, `memories-mcp` for MCP setup, and `memories-dev` for monorepo internals."
+---
+
+# memories-sdk
+
+Use the SDK packages when an application needs memories.sh programmatically. Prefer `@memories.sh/core` for direct typed API access and `@memories.sh/ai-sdk` only when the caller already uses the Vercel AI SDK.
+
+## Workflow
+
+1. Pick the integration surface:
+   - Use `@memories.sh/core` for backend routes, workers, cron jobs, and non-AI-SDK agents.
+   - Use `@memories.sh/ai-sdk` for `generateText`, `streamText`, middleware, or tool loops built on `ai`.
+   - If the task is about the CLI or MCP configuration, switch to `memories-cli` or `memories-mcp`.
+2. Set scope before writing code:
+   - Keep `MEMORIES_API_KEY` server-side.
+   - `tenantId` selects the tenant or workspace database.
+   - `userId` narrows memory to a user inside that tenant.
+   - `projectId` narrows reads and writes to a product area, repo, or feature slice.
+3. Use the narrowest pattern that solves the task:
+   - Direct CRUD or context lookup: `MemoriesClient`
+   - Automatic prompt injection: `memoriesMiddleware`
+   - Agent loops with explicit memory tools: `memoriesTools` and `memoriesSystemPrompt`
+   - Fetch once and reuse: `preloadContext`
+   - Persist after completion: `createMemoriesOnFinish`
+4. Verify the integration:
+   - Confirm the same scope is used on both reads and writes.
+   - Catch `MemoriesClientError`.
+   - Do not expose the API key to browser-only code.
+
+## Quick Start
+
+### `@memories.sh/core`
+
+```ts
+import { MemoriesClient } from "@memories.sh/core"
+
+const client = new MemoriesClient({
+  apiKey: process.env.MEMORIES_API_KEY,
+  tenantId: "acme-prod",
+  userId: "user_123",
+})
+
+const context = await client.context.get({
+  query: "billing architecture",
+  projectId: "dashboard",
+  mode: "all",
+  strategy: "hybrid",
+  limit: 8,
+})
+
+await client.memories.add({
+  content: "Enterprise billing uses Stripe invoices.",
+  type: "fact",
+  projectId: "dashboard",
+  tags: ["billing"],
+})
+```
+
+### `@memories.sh/ai-sdk`
+
+```ts
+import { generateText, stepCountIs, wrapLanguageModel } from "ai"
+import { openai } from "@ai-sdk/openai"
+import {
+  memoriesMiddleware,
+  memoriesSystemPrompt,
+  memoriesTools,
+} from "@memories.sh/ai-sdk"
+
+const model = wrapLanguageModel({
+  model: openai("gpt-4o"),
+  middleware: memoriesMiddleware({
+    tenantId: "acme-prod",
+    userId: "user_123",
+    projectId: "dashboard",
+  }),
+})
+
+const result = await generateText({
+  model,
+  system: memoriesSystemPrompt(),
+  tools: memoriesTools({
+    tenantId: "acme-prod",
+    userId: "user_123",
+    projectId: "dashboard",
+  }),
+  stopWhen: stepCountIs(5),
+  prompt: "Summarize prior decisions about billing.",
+})
+
+console.log(result.text)
+```
+
+## Decision Guide
+
+- Need direct typed access from your own backend code: use `MemoriesClient`
+- Need automatic context injection into prompts or messages: use `memoriesMiddleware`
+- Need the model to read or write memory explicitly through tools: use `memoriesTools`
+- Need to manage stored skill files or procedure fragments: use `client.skills.*` or the AI SDK skill-file tools
+- Need tenant, key, or embedding usage administration: use `client.management.*`
+- Need internals of the memories monorepo or server endpoints: use `memories-dev`
+
+## Reference Files
+
+- `references/core.md`: direct client methods, transport choices, errors, management APIs, and skill-file APIs
+- `references/ai-sdk.md`: middleware, tools, preload, post-finish persistence, and query extraction patterns
+- `references/scoping.md`: tenant/user/project scoping rules, server-side safety, and debugging checklist

--- a/sdk/references/ai-sdk.md
+++ b/sdk/references/ai-sdk.md
@@ -1,0 +1,157 @@
+# `@memories.sh/ai-sdk`
+
+Read this file when the task is about Vercel AI SDK integration.
+
+## Install
+
+```bash
+npm install @memories.sh/ai-sdk ai
+```
+
+Requires Node.js >= 20.
+
+If you do not pass a preconfigured `client`, the helper options need a valid `tenantId`.
+
+## Pattern Selection
+
+- Use `memoriesMiddleware()` when you want automatic prompt enrichment before generation.
+- Use `memoriesTools()` when you want the model to call memory tools explicitly during an agent loop.
+- Use both only when that behavior is intentional. Middleware injects context up front; tools let the model fetch or mutate memory later.
+- Use `preloadContext()` when multiple helpers in the same request should share one fetched context.
+- Use `createMemoriesOnFinish()` only when you have an explicit policy for what should be persisted after completion.
+
+## Middleware
+
+```ts
+import { wrapLanguageModel } from "ai"
+import { openai } from "@ai-sdk/openai"
+import { memoriesMiddleware } from "@memories.sh/ai-sdk"
+
+const model = wrapLanguageModel({
+  model: openai("gpt-4o"),
+  middleware: memoriesMiddleware({
+    tenantId: "acme-prod",
+    userId: "user_123",
+    projectId: "dashboard",
+    limit: 8,
+    includeRules: true,
+    mode: "all",
+    strategy: "hybrid",
+  }),
+})
+```
+
+Behavior:
+- Extracts a query from `prompt` or the latest user message
+- Calls `client.context.get(...)`
+- Builds a memory block with rules, memories, and skill files
+- Prepends that block to the `system` prompt
+
+Customize query extraction with `extractQuery`, or use the built-in `defaultExtractQuery`.
+
+## Tools
+
+```ts
+import { generateText, stepCountIs } from "ai"
+import { openai } from "@ai-sdk/openai"
+import { memoriesSystemPrompt, memoriesTools } from "@memories.sh/ai-sdk"
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  system: memoriesSystemPrompt({
+    persona: "support assistant",
+  }),
+  tools: memoriesTools({
+    tenantId: "acme-prod",
+    userId: "user_123",
+    projectId: "dashboard",
+  }),
+  stopWhen: stepCountIs(5),
+  prompt: "Find prior billing decisions and store any new durable facts.",
+})
+```
+
+Tool bundle methods:
+- `getContext`
+- `storeMemory`
+- `searchMemories`
+- `listMemories`
+- `forgetMemory`
+- `editMemory`
+- `upsertSkillFile`
+- `listSkillFiles`
+- `deleteSkillFile`
+- `bulkForgetMemories`
+- `vacuumMemories`
+
+Use the individual tool factories when you only want a subset of tools.
+
+## Preload Context
+
+Use `preloadContext()` when you want to fetch memory once and pass it into middleware:
+
+```ts
+import { preloadContext, memoriesMiddleware } from "@memories.sh/ai-sdk"
+
+const preloaded = await preloadContext({
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "dashboard",
+  query: "enterprise auth",
+})
+
+const middleware = memoriesMiddleware({
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "dashboard",
+  preloaded,
+})
+```
+
+## Post-Response Persistence
+
+`createMemoriesOnFinish()` is intentionally conservative:
+- Default mode is `tool-calls-only`, which does nothing by itself
+- To persist extracted memories automatically, set `mode: "auto-extract"` and provide `extractMemories`
+
+```ts
+import { createMemoriesOnFinish } from "@memories.sh/ai-sdk"
+
+const onFinish = createMemoriesOnFinish({
+  tenantId: "acme-prod",
+  projectId: "dashboard",
+  mode: "auto-extract",
+  extractMemories(payload) {
+    const summary = typeof payload === "object" && payload !== null ? payload : null
+    if (!summary) return []
+    return [
+      {
+        content: "Customer wants invoice net terms on enterprise plan.",
+        type: "fact",
+        tags: ["billing", "sales"],
+      },
+    ]
+  },
+})
+```
+
+Do not invent automatic extraction rules. If the user has not defined a persistence policy, prefer explicit tool calls.
+
+## Using a Preconfigured Client
+
+Pass your own `MemoriesClient` when you already centralize auth, base URL, or scope construction:
+
+```ts
+import { MemoriesClient } from "@memories.sh/core"
+import { memoriesMiddleware } from "@memories.sh/ai-sdk"
+
+const client = new MemoriesClient({
+  apiKey: process.env.MEMORIES_API_KEY,
+  tenantId: "acme-prod",
+  userId: "user_123",
+})
+
+const middleware = memoriesMiddleware({ client })
+```
+
+This is the cleanest way to keep app-specific scope logic in one place.

--- a/sdk/references/core.md
+++ b/sdk/references/core.md
@@ -1,0 +1,164 @@
+# `@memories.sh/core`
+
+Read this file when the task is about direct SDK usage from backend code, route handlers, workers, scripts, or tests.
+
+## Install
+
+```bash
+npm install @memories.sh/core
+```
+
+Requires Node.js >= 20.
+
+## Client Construction
+
+```ts
+import { MemoriesClient } from "@memories.sh/core"
+
+const client = new MemoriesClient({
+  apiKey: process.env.MEMORIES_API_KEY,
+  baseUrl: "https://memories.sh", // optional
+  tenantId: "acme-prod",
+  userId: "user_123",
+  transport: "sdk_http", // optional; auto-detected by default
+})
+```
+
+`apiKey` can be omitted if `MEMORIES_API_KEY` is set.
+
+Default transport is `auto`:
+- `sdk_http` is the normal choice and calls `/api/sdk/v1/*`
+- `mcp` uses JSON-RPC against `/api/mcp`
+
+Only force `mcp` when the integration explicitly needs MCP transport semantics.
+
+## Core Methods
+
+### Context
+
+Use `client.context.get()` when you need rules, memories, conflicts, skill files, or compaction/session hints in one response.
+
+```ts
+const context = await client.context.get({
+  query: "enterprise auth",
+  tenantId: "acme-prod",
+  userId: "user_123",
+  projectId: "dashboard",
+  mode: "all",
+  strategy: "hybrid",
+  limit: 10,
+  includeRules: true,
+  includeSkillFiles: true,
+  graphDepth: 1,
+  graphLimit: 6,
+})
+```
+
+Important options:
+- `mode`: `all`, `working`, `long_term`, `rules_only`
+- `strategy`: `lexical`, `semantic`, `hybrid`
+- `graphDepth` / `graphLimit`: only use when relationship expansion matters
+- `sessionId`, `budgetTokens`, `turnCount`, `turnBudget`, `lastActivityAt`, `inactivityThresholdMinutes`: use for lifecycle-aware callers
+
+### Memory CRUD
+
+```ts
+await client.memories.add({
+  content: "SSO is enterprise-only.",
+  type: "fact",
+  tags: ["auth", "pricing"],
+  category: "sales",
+  projectId: "dashboard",
+})
+
+const matches = await client.memories.search("SSO", {
+  strategy: "hybrid",
+  projectId: "dashboard",
+  limit: 5,
+})
+
+const items = await client.memories.list({
+  type: "fact",
+  tags: "auth,pricing",
+  projectId: "dashboard",
+})
+
+await client.memories.edit("mem_123", {
+  content: "SSO and SCIM are enterprise-only.",
+})
+
+await client.memories.forget("mem_123")
+```
+
+Also available:
+- `client.memories.bulkForget(filters, { dryRun })`
+- `client.memories.vacuum()`
+
+### Skill Files
+
+Use skill-file APIs when the app stores reusable procedure files or generated skill fragments in memories.
+
+```ts
+await client.skills.upsertFile({
+  path: "sales/objection-handling.md",
+  content: "# Objection Handling\n...",
+  procedureKey: "sales-objection-handling",
+  tenantId: "acme-prod",
+})
+
+const files = await client.skills.listFiles({
+  tenantId: "acme-prod",
+  query: "sales",
+  limit: 20,
+})
+
+await client.skills.deleteFile({
+  path: "sales/objection-handling.md",
+  tenantId: "acme-prod",
+})
+```
+
+Also available:
+- `client.skills.promoteFromSession(...)`
+
+### Management APIs
+
+Use management methods only for tenant administration or account-level operations:
+- `client.management.keys.get()`
+- `client.management.keys.create({ expiresAt })`
+- `client.management.keys.revoke()`
+- `client.management.tenants.list()`
+- `client.management.tenants.upsert(input)`
+- `client.management.tenants.disable(tenantId)`
+- `client.management.embeddings.list(options)`
+- `client.management.embeddings.usage(options)`
+
+## Error Handling
+
+Catch `MemoriesClientError` and branch on typed metadata:
+
+```ts
+import { MemoriesClientError } from "@memories.sh/core"
+
+try {
+  await client.memories.search("checkout failure")
+} catch (error) {
+  if (error instanceof MemoriesClientError) {
+    console.error(error.type, error.errorCode, error.status, error.retryable)
+  }
+  throw error
+}
+```
+
+Typical causes:
+- `auth_error`: missing or invalid API key
+- `validation_error`: invalid input or missing required fields
+- `rate_limit_error`: backoff and retry
+- `network_error`: transport or connectivity issue
+
+## Good Defaults
+
+- Use `strategy: "hybrid"` unless the user explicitly wants lexical-only behavior
+- Use stable IDs for `tenantId`, `userId`, and `projectId`
+- Keep the SDK on the server side
+- Reuse a single `MemoriesClient` per request or worker context instead of recreating it in inner loops

--- a/sdk/references/scoping.md
+++ b/sdk/references/scoping.md
@@ -1,0 +1,85 @@
+# Scoping and Safety
+
+Read this file when the task involves multi-tenant design, auth boundaries, or debugging empty or incorrect memory results.
+
+## Scope Mapping
+
+Use stable identifiers:
+- `tenantId`: workspace, organization, account, or customer database
+- `userId`: end user inside that tenant
+- `projectId`: feature area, repo, assistant, or product surface
+
+Good mappings:
+- SaaS app: `tenantId = workspace.id`, `userId = currentUser.id`, `projectId = "support-agent"`
+- Internal copilots: `tenantId = company slug`, `userId = employee id`, `projectId = repo slug`
+- Single-project automation: `tenantId = org`, `projectId = job name`, omit `userId` if memory is shared
+
+Bad mappings:
+- Random per-request IDs
+- Human-readable values that change frequently
+- Mixing different `projectId` values between writes and reads for the same feature
+
+## Server-Side Rules
+
+- Keep `MEMORIES_API_KEY` on the server
+- Do not instantiate `MemoriesClient` in browser-only components
+- If the frontend needs memory-backed actions, call your own backend route or server action
+- Centralize scope construction so reads and writes stay aligned
+
+## Empty Context Checklist
+
+If `context.get()` returns little or no useful data, check:
+
+1. Wrong scope:
+   - `tenantId`, `userId`, or `projectId` differs from the values used when the memory was stored
+2. Wrong retrieval mode:
+   - `rules_only` returns no non-rule memories
+3. Wrong strategy:
+   - try `hybrid` before assuming the memory is missing
+4. Wrong environment:
+   - `baseUrl` points at a different deployment than the one where data was written
+5. No durable data yet:
+   - confirm the application actually persisted memories
+
+## Common Debugging Pattern
+
+When behavior is unclear, reduce the integration to a minimal round trip:
+
+```ts
+const client = new MemoriesClient({
+  apiKey: process.env.MEMORIES_API_KEY,
+  tenantId: "acme-prod",
+  userId: "user_123",
+})
+
+await client.memories.add({
+  content: "Round-trip test memory",
+  type: "note",
+  projectId: "debug",
+})
+
+const result = await client.context.get({
+  query: "Round-trip test memory",
+  projectId: "debug",
+  strategy: "hybrid",
+})
+```
+
+If this works, the bug is usually in scope construction or the surrounding app flow, not the SDK itself.
+
+## Choosing `projectId`
+
+Use `projectId` when:
+- the same tenant has multiple assistants or products
+- you want one feature to ignore another feature's memory
+- the user explicitly wants repo- or feature-scoped memory
+
+Skip `projectId` when:
+- memory should be shared across the entire tenant
+- the user expects a single global memory space per tenant
+
+## Transport Notes
+
+- Default to `sdk_http`
+- Use `mcp` only for integrations that specifically rely on MCP transport behavior
+- If you override `baseUrl`, make sure it matches the deployment that owns the target tenant data


### PR DESCRIPTION
## Summary
- Adds `sdk/` directory at repo root with SKILL.md and references so `npx skills add webrenew/memories/sdk` resolves correctly
- Mirrors content from `skills/memories-sdk/`

## Test plan
- [ ] Run `npx skills add webrenew/memories/sdk` and verify skill installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new documentation/skill metadata under `sdk/` and does not change runtime code paths.
> 
> **Overview**
> Adds a new root-level `sdk/` skill entry point (`sdk/SKILL.md`) intended to make `npx skills add .../sdk` resolve correctly.
> 
> Includes new reference docs under `sdk/references/` covering `@memories.sh/core`, `@memories.sh/ai-sdk`, and scoping/safety guidance, with example usage patterns and integration decision points.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5df2d72114cf33c211314c9ab5497a24f5d5853e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->