### PR TITLE
fix: require paid plan for cloud database provisioning

### DIFF
--- a/packages/web/src/app/api/db/provision/__tests__/route.test.ts
+++ b/packages/web/src/app/api/db/provision/__tests__/route.test.ts
@@ -34,9 +34,13 @@ vi.mock("@/lib/rate-limit", () => ({
   checkPreAuthApiRateLimit: mockCheckPreAuthApiRateLimit,
 }))
 
-vi.mock("@/lib/workspace", () => ({
-  resolveWorkspaceContext: mockResolveWorkspaceContext,
-}))
+vi.mock("@/lib/workspace", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/workspace")>()
+  return {
+    ...actual,
+    resolveWorkspaceContext: mockResolveWorkspaceContext,
+  }
+})
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
@@ -96,6 +100,55 @@ describe("/api/db/provision", () => {
     expect(response.status).toBe(401)
   })
 
+  it("returns existing URL for grandfathered free user with database", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "free@example.com" })
+    mockResolveWorkspaceContext.mockResolvedValue({
+      ownerType: "user",
+      userId: "user-1",
+      orgId: null,
+      orgRole: null,
+      plan: "free",
+      hasDatabase: true,
+      canProvision: true,
+      canManageBilling: true,
+      turso_db_url: "libsql://existing.turso.io",
+      turso_db_token: "existing-token",
+      turso_db_name: "existing-db",
+    })
+
+    const response = await POST(new Request("https://example.com/api/db/provision", { method: "POST" }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.url).toBe("libsql://existing.turso.io")
+    expect(body.provisioned).toBe(false)
+    expect(mockCreateDatabase).not.toHaveBeenCalled()
+  })
+
+  it("returns 403 when workspace plan is free", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "free@example.com" })
+    mockResolveWorkspaceContext.mockResolvedValue({
+      ownerType: "user",
+      userId: "user-1",
+      orgId: null,
+      orgRole: null,
+      plan: "free",
+      hasDatabase: false,
+      canProvision: true,
+      canManageBilling: true,
+      turso_db_url: null,
+      turso_db_token: null,
+      turso_db_name: null,
+    })
+
+    const response = await POST(new Request("https://example.com/api/db/provision", { method: "POST" }))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.code).toBe("UPGRADE_REQUIRED")
+    expect(mockCreateDatabase).not.toHaveBeenCalled()
+  })
+
   it("returns 403 when org role is member", async () => {
     mockAuthenticateRequest.mockResolvedValue({ userId: "user-1", email: "member@example.com" })
     mockResolveWorkspaceContext.mockResolvedValue({
@@ -103,7 +156,7 @@ describe("/api/db/provision", () => {
       userId: "user-1",
       orgId: "org-1",
       orgRole: "member",
-      plan: "pro",
+      plan: "individual",
       hasDatabase: false,
       canProvision: false,
       canManageBilling: false,
@@ -126,7 +179,7 @@ describe("/api/db/provision", () => {
       userId: "user-1",
       orgId: "org-1",
       orgRole: "admin",
-      plan: "pro",
+      plan: "individual",
       hasDatabase: false,
       canProvision: true,
       canManageBilling: false,
@@ -181,7 +234,7 @@ describe("/api/db/provision", () => {
       userId: "user-1",
       orgId: "org-1",
       orgRole: "admin",
-      plan: "pro",
+      plan: "individual",
       hasDatabase: false,
       canProvision: true,
       canManageBilling: false,

--- a/packages/web/src/app/api/db/provision/route.ts
+++ b/packages/web/src/app/api/db/provision/route.ts
@@ -4,7 +4,7 @@ import { createDatabase, createDatabaseToken, deleteDatabase, initSchema } from 
 import { NextResponse } from "next/server"
 import { setTimeout as delay } from "node:timers/promises"
 import { checkPreAuthApiRateLimit, checkRateLimit, strictRateLimit } from "@/lib/rate-limit"
-import { resolveWorkspaceContext } from "@/lib/workspace"
+import { isPaidWorkspacePlan, resolveWorkspaceContext } from "@/lib/workspace"
 import { getTursoOrgSlug } from "@/lib/env"
 
 type SaveCredentialsResult =
@@ -298,6 +298,13 @@ export async function POST(request: Request): Promise<Response> {
       url: context.turso_db_url,
       provisioned: false,
     })
+  }
+
+  if (!isPaidWorkspacePlan(context.plan)) {
+    return NextResponse.json(
+      { error: "Cloud database requires a paid plan", code: "UPGRADE_REQUIRED" },
+      { status: 403 }
+    )
   }
 
   if (!context.canProvision) {

--- a/packages/web/src/app/app/graph-explorer/page.tsx
+++ b/packages/web/src/app/app/graph-explorer/page.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { createClient as createTurso } from "@libsql/client"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
+import { UpgradeRequiredScreen } from "@/components/dashboard/UpgradeRequiredScreen"
+import { isPaidWorkspacePlan, normalizeWorkspacePlan } from "@/lib/workspace"
 import { MemoryGraphSection } from "@/components/dashboard/MemoryGraphSection"
 import { resolveActiveMemoryContext } from "@/lib/active-memory-context"
 import { ensureMemoryUserIdSchema } from "@/lib/memory-service/scope"
@@ -21,6 +23,10 @@ export default async function GraphExplorerPage(): Promise<React.JSX.Element | n
 
   const context = await resolveActiveMemoryContext(supabase, user.id)
   const hasTurso = context?.turso_db_url && context?.turso_db_token
+
+  if (!hasTurso && !isPaidWorkspacePlan(normalizeWorkspacePlan(context?.plan))) {
+    return <UpgradeRequiredScreen />
+  }
 
   if (!hasTurso) {
     return <ProvisioningScreen />

--- a/packages/web/src/app/app/page.tsx
+++ b/packages/web/src/app/app/page.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { createClient as createTurso } from "@libsql/client"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
+import { UpgradeRequiredScreen } from "@/components/dashboard/UpgradeRequiredScreen"
+import { isPaidWorkspacePlan, normalizeWorkspacePlan } from "@/lib/workspace"
 import { MemoriesSection } from "@/components/dashboard/MemoriesSection"
 import { IntegrationHealthSection } from "@/components/dashboard/IntegrationHealthSection"
 import { GithubCaptureQueueSection } from "@/components/dashboard/GithubCaptureQueueSection"
@@ -47,6 +49,10 @@ export default async function MemoriesPage(): Promise<React.JSX.Element | null> 
 
   const context = await resolveActiveMemoryContext(supabase, user.id)
   const hasTurso = context?.turso_db_url && context?.turso_db_token
+
+  if (!hasTurso && !isPaidWorkspacePlan(normalizeWorkspacePlan(context?.plan))) {
+    return <UpgradeRequiredScreen />
+  }
 
   if (!hasTurso) {
     return <ProvisioningScreen />

--- a/packages/web/src/app/app/stats/page.tsx
+++ b/packages/web/src/app/app/stats/page.tsx
@@ -2,7 +2,9 @@ import React from "react"
 import { createClient } from "@/lib/supabase/server"
 import { LazyStatsCharts } from "./stats-charts-lazy"
 import { ProvisioningScreen } from "@/components/dashboard/ProvisioningScreen"
+import { UpgradeRequiredScreen } from "@/components/dashboard/UpgradeRequiredScreen"
 import { resolveActiveMemoryContext } from "@/lib/active-memory-context"
+import { isPaidWorkspacePlan, normalizeWorkspacePlan } from "@/lib/workspace"
 
 export const metadata = {
   title: "Stats",
@@ -59,6 +61,10 @@ export default async function StatsPage(): Promise<React.JSX.Element | null> {
 
   const context = await resolveActiveMemoryContext(supabase, user.id)
   const hasTurso = context?.turso_db_url && context?.turso_db_token
+
+  if (!hasTurso && !isPaidWorkspacePlan(normalizeWorkspacePlan(context?.plan))) {
+    return <UpgradeRequiredScreen />
+  }
 
   if (!hasTurso) {
     return <ProvisioningScreen />

--- a/packages/web/src/components/dashboard/UpgradeRequiredScreen.tsx
+++ b/packages/web/src/components/dashboard/UpgradeRequiredScreen.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import Link from "next/link"
+import { Sparkles } from "@/components/icons/app/Sparkles"
+
+export function UpgradeRequiredScreen(): React.JSX.Element {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
+      <div className="w-16 h-16 rounded-full bg-muted/50 border border-border flex items-center justify-center mb-6">
+        <Sparkles className="w-7 h-7 text-muted-foreground" />
+      </div>
+      <h1 className="text-2xl font-bold tracking-tight mb-3">
+        Cloud memory requires a paid plan
+      </h1>
+      <p className="text-muted-foreground max-w-md mb-8 leading-relaxed">
+        Upgrade to get cloud sync, a web dashboard, and access to your memories from any device.
+      </p>
+      <Link
+        href="/app/upgrade"
+        className="inline-flex items-center gap-3 px-6 py-3 bg-primary text-primary-foreground hover:opacity-90 transition-all duration-300"
+      >
+        <span className="text-xs font-bold uppercase tracking-[0.15em]">
+          View Plans
+        </span>
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `isPaidWorkspacePlan` billing gate to `POST /api/db/provision` — free users now get a 403 with `UPGRADE_REQUIRED` code instead of a provisioned Turso database
- Dashboard pages (`/app`, `/app/stats`, `/app/graph-explorer`) show an `UpgradeRequiredScreen` for free users without a database, linking to `/app/upgrade`
- Existing free users with grandfathered databases are unaffected — the `hasDatabase` early-return runs before the plan check

## Context

The provision route had no billing check, so any authenticated user who visited the dashboard would auto-provision a Turso database on our org's plan. 11 free users got databases this way. This PR closes the gap going forward without disrupting existing users.

## Test plan

- [x] New test: free user without DB → 403 `UPGRADE_REQUIRED`
- [x] New test: grandfathered free user with existing DB → 200 with URL
- [x] Existing tests pass (admin provision, cleanup on failure)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing enforcement for Turso provisioning and dashboard access; risk is mainly around inadvertently blocking eligible users or misclassifying legacy plan names via `normalizeWorkspacePlan`/`isPaidWorkspacePlan`. No schema or auth mechanism changes beyond returning new 403 responses and rendering a new upgrade screen.
> 
> **Overview**
> Adds a **paid-plan gate** to `POST /api/db/provision`: if the workspace has no existing DB and the plan is not paid, the endpoint now returns `403` with code `UPGRADE_REQUIRED` instead of provisioning a Turso database (grandfathered workspaces with an existing DB still early-return their URL).
> 
> Updates `/app`, `/app/stats`, and `/app/graph-explorer` to show a new `UpgradeRequiredScreen` (linking to `/app/upgrade`) for unpaid workspaces without a Turso connection, and extends provisioning route tests to cover both the upgrade-required path and the grandfathered existing-DB path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0e034443c8bd958ba4f5da6538be50deadbaa07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->