### PR TITLE
[codex] Filter injected Sentry host errors

### DIFF
--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { filterClientSentryBreadcrumb, filterClientSentryEvent } from "@/lib/sentry/client-filters";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -7,6 +8,8 @@ Sentry.init({
   tracesSampleRate: 0,
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
+  beforeBreadcrumb: filterClientSentryBreadcrumb,
+  beforeSend: filterClientSentryEvent,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/packages/web/src/lib/sentry/client-filters.test.ts
+++ b/packages/web/src/lib/sentry/client-filters.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+
+import { filterClientSentryBreadcrumb, filterClientSentryEvent } from "./client-filters"
+
+const nullTagNameValue = "Cannot read properties of null (reading 'tagName')"
+
+describe("client Sentry filters", () => {
+  it("drops null tagName errors thrown by the injected browser host listener hook", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: nullTagNameValue,
+            stacktrace: {
+              frames: [
+                { function: "tw._handleVisibilityChange", filename: "https://memories.sh/_next/static/chunks/app.js" },
+                { function: "top.addEventListener", filename: "<anonymous>" },
+                { function: "addEL_hook", filename: "<anonymous>" },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    expect(filterClientSentryEvent(event)).toBeNull()
+  })
+
+  it("drops null tagName errors when the injected host only appears in breadcrumbs", () => {
+    const event = {
+      exception: {
+        values: [{ type: "TypeError", value: nullTagNameValue }],
+      },
+      breadcrumbs: [
+        {
+          category: "console",
+          message: "[jshost]\twindow.onpopstate\tencoded\t\tencoded",
+          data: { logger: "console" },
+        },
+      ],
+    }
+
+    expect(filterClientSentryEvent(event)).toBeNull()
+  })
+
+  it("drops null tagName errors when injected host evidence is only in the Sentry hint", () => {
+    const event = {
+      exception: {
+        values: [{ type: "TypeError", value: nullTagNameValue }],
+      },
+    }
+    const originalException = new TypeError(nullTagNameValue)
+    originalException.stack = `TypeError: ${nullTagNameValue}
+    at addEL_hook (<anonymous>:675:29)
+    at top.addEventListener (<anonymous>:695:9)`
+
+    expect(filterClientSentryEvent(event, { originalException })).toBeNull()
+  })
+
+  it("keeps same-message app errors without injected host evidence", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: nullTagNameValue,
+            stacktrace: {
+              frames: [
+                { function: "renderLabel", filename: "https://memories.sh/_next/static/chunks/app.js" },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    expect(filterClientSentryEvent(event)).toBe(event)
+  })
+
+  it("drops injected host console breadcrumbs", () => {
+    const breadcrumb = {
+      category: "console",
+      message: "[jshost]\teval\tZG9jdW1lbnQuYm9keQ==\tMjU1NDMy",
+      data: { logger: "console" },
+    }
+
+    expect(filterClientSentryBreadcrumb(breadcrumb)).toBeNull()
+  })
+
+  it("drops rrweb console breadcrumbs caused by the same listener hook", () => {
+    const breadcrumb = {
+      category: "console",
+      message: "TypeError: Cannot read properties of null (reading 'tagName')",
+      data: {
+        logger: "console",
+        arguments: [
+          {
+            message: nullTagNameValue,
+            stack: `TypeError: ${nullTagNameValue}
+    at addEL_hook (<anonymous>:675:29)
+    at top.addEventListener (<anonymous>:695:9)
+    at rK.startRecording (https://memories.sh/_next/static/chunks/replay.js:2:5903)`,
+          },
+        ],
+      },
+    }
+
+    expect(filterClientSentryBreadcrumb(breadcrumb)).toBeNull()
+  })
+
+  it("keeps ordinary console breadcrumbs", () => {
+    const breadcrumb = {
+      category: "console",
+      message: "Loaded dashboard",
+      data: { logger: "console" },
+    }
+
+    expect(filterClientSentryBreadcrumb(breadcrumb)).toBe(breadcrumb)
+  })
+})

--- a/packages/web/src/lib/sentry/client-filters.ts
+++ b/packages/web/src/lib/sentry/client-filters.ts
@@ -1,0 +1,122 @@
+type SentryLikeStackFrame = {
+  abs_path?: string
+  filename?: string
+  function?: string
+}
+
+type SentryLikeException = {
+  stacktrace?: {
+    frames?: SentryLikeStackFrame[]
+  }
+  type?: string
+  value?: string
+}
+
+type SentryLikeBreadcrumb = {
+  category?: string
+  data?: Record<string, unknown>
+  message?: string
+}
+
+type SentryLikeErrorEvent = {
+  breadcrumbs?: SentryLikeBreadcrumb[]
+  exception?: {
+    values?: SentryLikeException[]
+  }
+  message?: string
+}
+
+const INJECTED_HOST_PREFIX = "[jshost]"
+const NULL_TAG_NAME_MESSAGE = "Cannot read properties of null (reading 'tagName')"
+
+function valueToSearchText(value: unknown): string {
+  if (typeof value === "string") {
+    return value
+  }
+
+  if (value instanceof Error) {
+    return `${value.name} ${value.message} ${value.stack ?? ""}`
+  }
+
+  if (value && typeof value === "object") {
+    const errorLike = value as { message?: unknown; name?: unknown; stack?: unknown }
+    return [errorLike.name, errorLike.message, errorLike.stack].filter(Boolean).join(" ")
+  }
+
+  return ""
+}
+
+function breadcrumbText(breadcrumb: SentryLikeBreadcrumb): string {
+  const args = breadcrumb.data?.arguments
+  const argText = Array.isArray(args) ? args.map(valueToSearchText).join(" ") : valueToSearchText(args)
+
+  return [breadcrumb.message, argText, valueToSearchText(breadcrumb.data?.logger)].filter(Boolean).join(" ")
+}
+
+function isInjectedHostBreadcrumb(breadcrumb: SentryLikeBreadcrumb): boolean {
+  const text = breadcrumbText(breadcrumb)
+
+  return (
+    breadcrumb.category === "console" &&
+    (text.includes(INJECTED_HOST_PREFIX) ||
+      (text.includes(NULL_TAG_NAME_MESSAGE) && text.includes("addEL_hook")) ||
+      text.includes("GETJSURL"))
+  )
+}
+
+function frameText(frame: SentryLikeStackFrame): string {
+  return [frame.function, frame.filename, frame.abs_path].filter(Boolean).join(" ")
+}
+
+function hasInjectedHostFrame(event: SentryLikeErrorEvent): boolean {
+  const frames =
+    event.exception?.values?.flatMap((exception) => exception.stacktrace?.frames ?? []) ?? []
+  const text = frames.map(frameText).join(" ")
+
+  return text.includes("addEL_hook") || text.includes("scriptPath (<anonymous>") || text.includes("GETJSURL")
+}
+
+function hasInjectedHostHint(hint?: unknown): boolean {
+  const text = valueToSearchText((hint as { originalException?: unknown } | undefined)?.originalException)
+
+  return text.includes("addEL_hook") || text.includes(INJECTED_HOST_PREFIX) || text.includes("GETJSURL")
+}
+
+function exceptionText(event: SentryLikeErrorEvent, hint?: unknown): string {
+  const exceptionValues = event.exception?.values ?? []
+  const eventText = [
+    event.message,
+    ...exceptionValues.flatMap((exception) => [exception.type, exception.value]),
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  return `${eventText} ${valueToSearchText((hint as { originalException?: unknown } | undefined)?.originalException)}`
+}
+
+function isInjectedHostNullTagNameError(event: SentryLikeErrorEvent, hint?: unknown): boolean {
+  const text = exceptionText(event, hint)
+
+  if (!text.includes(NULL_TAG_NAME_MESSAGE)) {
+    return false
+  }
+
+  return (
+    hasInjectedHostFrame(event) ||
+    hasInjectedHostHint(hint) ||
+    event.breadcrumbs?.some(isInjectedHostBreadcrumb) === true
+  )
+}
+
+export function filterClientSentryBreadcrumb<T extends SentryLikeBreadcrumb>(
+  breadcrumb: T
+): T | null {
+  return isInjectedHostBreadcrumb(breadcrumb) ? null : breadcrumb
+}
+
+export function filterClientSentryEvent<T extends SentryLikeErrorEvent>(
+  event: T,
+  hint?: unknown
+): T | null {
+  return isInjectedHostNullTagNameError(event, hint) ? null : event
+}


### PR DESCRIPTION
## Summary

- filters the injected `[jshost]` / `addEL_hook` null `tagName` crash from client Sentry events
- drops the related noisy console breadcrumbs before they attach to real events
- keeps same-message app errors reportable unless injected-host evidence is present

## Root Cause

The Sentry event came from a foreign inline browser/session host hook wrapping `top.addEventListener`, not from app code. It crashed while Sentry/Next/rrweb registered navigation and visibility listeners, then our client config captured the injected failure and its base64 `[jshost]` breadcrumbs.

## Validation

- `pnpm --filter @memories.sh/web test -- src/lib/sentry/client-filters.test.ts`
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm --filter @memories.sh/web lint`
- `pnpm --filter @memories.sh/web build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/memories/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->