### PR TITLE
[codex] Address Sentry filter review follow-up

### DIFF
--- a/packages/web/src/lib/sentry/client-filters.test.ts
+++ b/packages/web/src/lib/sentry/client-filters.test.ts
@@ -1,12 +1,17 @@
+import type { Breadcrumb, ErrorEvent } from "@sentry/nextjs"
 import { describe, expect, it } from "vitest"
 
 import { filterClientSentryBreadcrumb, filterClientSentryEvent } from "./client-filters"
 
 const nullTagNameValue = "Cannot read properties of null (reading 'tagName')"
 
+function errorEvent(event: Omit<ErrorEvent, "type">): ErrorEvent {
+  return { type: undefined, ...event }
+}
+
 describe("client Sentry filters", () => {
   it("drops null tagName errors thrown by the injected browser host listener hook", () => {
-    const event = {
+    const event = errorEvent({
       exception: {
         values: [
           {
@@ -22,13 +27,13 @@ describe("client Sentry filters", () => {
           },
         ],
       },
-    }
+    })
 
-    expect(filterClientSentryEvent(event)).toBeNull()
+    expect(filterClientSentryEvent(event, {})).toBeNull()
   })
 
   it("drops null tagName errors when the injected host only appears in breadcrumbs", () => {
-    const event = {
+    const event = errorEvent({
       exception: {
         values: [{ type: "TypeError", value: nullTagNameValue }],
       },
@@ -39,17 +44,17 @@ describe("client Sentry filters", () => {
           data: { logger: "console" },
         },
       ],
-    }
+    })
 
-    expect(filterClientSentryEvent(event)).toBeNull()
+    expect(filterClientSentryEvent(event, {})).toBeNull()
   })
 
   it("drops null tagName errors when injected host evidence is only in the Sentry hint", () => {
-    const event = {
+    const event = errorEvent({
       exception: {
         values: [{ type: "TypeError", value: nullTagNameValue }],
       },
-    }
+    })
     const originalException = new TypeError(nullTagNameValue)
     originalException.stack = `TypeError: ${nullTagNameValue}
     at addEL_hook (<anonymous>:675:29)
@@ -59,7 +64,7 @@ describe("client Sentry filters", () => {
   })
 
   it("keeps same-message app errors without injected host evidence", () => {
-    const event = {
+    const event = errorEvent({
       exception: {
         values: [
           {
@@ -73,13 +78,47 @@ describe("client Sentry filters", () => {
           },
         ],
       },
-    }
+    })
 
-    expect(filterClientSentryEvent(event)).toBe(event)
+    expect(filterClientSentryEvent(event, {})).toBe(event)
+  })
+
+  it("drops GETJSURL null tagName errors from stack frames", () => {
+    const event = errorEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: nullTagNameValue,
+            stacktrace: {
+              frames: [
+                { function: "scriptPath", filename: "<anonymous>" },
+                { function: "GETJSURL", filename: "<anonymous>" },
+              ],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(filterClientSentryEvent(event, {})).toBeNull()
+  })
+
+  it("drops GETJSURL null tagName errors from Sentry hint evidence", () => {
+    const event = errorEvent({
+      exception: {
+        values: [{ type: "TypeError", value: nullTagNameValue }],
+      },
+    })
+    const originalException = new TypeError(nullTagNameValue)
+    originalException.stack = `Error: GETJSURL
+    at scriptPath (<anonymous>:174:17)`
+
+    expect(filterClientSentryEvent(event, { originalException })).toBeNull()
   })
 
   it("drops injected host console breadcrumbs", () => {
-    const breadcrumb = {
+    const breadcrumb: Breadcrumb = {
       category: "console",
       message: "[jshost]\teval\tZG9jdW1lbnQuYm9keQ==\tMjU1NDMy",
       data: { logger: "console" },
@@ -89,7 +128,7 @@ describe("client Sentry filters", () => {
   })
 
   it("drops rrweb console breadcrumbs caused by the same listener hook", () => {
-    const breadcrumb = {
+    const breadcrumb: Breadcrumb = {
       category: "console",
       message: "TypeError: Cannot read properties of null (reading 'tagName')",
       data: {
@@ -109,8 +148,18 @@ describe("client Sentry filters", () => {
     expect(filterClientSentryBreadcrumb(breadcrumb)).toBeNull()
   })
 
+  it("drops GETJSURL console breadcrumbs", () => {
+    const breadcrumb: Breadcrumb = {
+      category: "console",
+      message: "Error: GETJSURL at addEL_hook",
+      data: { logger: "console" },
+    }
+
+    expect(filterClientSentryBreadcrumb(breadcrumb)).toBeNull()
+  })
+
   it("keeps ordinary console breadcrumbs", () => {
-    const breadcrumb = {
+    const breadcrumb: Breadcrumb = {
       category: "console",
       message: "Loaded dashboard",
       data: { logger: "console" },

--- a/packages/web/src/lib/sentry/client-filters.ts
+++ b/packages/web/src/lib/sentry/client-filters.ts
@@ -1,30 +1,4 @@
-type SentryLikeStackFrame = {
-  abs_path?: string
-  filename?: string
-  function?: string
-}
-
-type SentryLikeException = {
-  stacktrace?: {
-    frames?: SentryLikeStackFrame[]
-  }
-  type?: string
-  value?: string
-}
-
-type SentryLikeBreadcrumb = {
-  category?: string
-  data?: Record<string, unknown>
-  message?: string
-}
-
-type SentryLikeErrorEvent = {
-  breadcrumbs?: SentryLikeBreadcrumb[]
-  exception?: {
-    values?: SentryLikeException[]
-  }
-  message?: string
-}
+import type { Breadcrumb, BreadcrumbHint, ErrorEvent, EventHint, StackFrame } from "@sentry/nextjs"
 
 const INJECTED_HOST_PREFIX = "[jshost]"
 const NULL_TAG_NAME_MESSAGE = "Cannot read properties of null (reading 'tagName')"
@@ -46,14 +20,14 @@ function valueToSearchText(value: unknown): string {
   return ""
 }
 
-function breadcrumbText(breadcrumb: SentryLikeBreadcrumb): string {
+function breadcrumbText(breadcrumb: Breadcrumb): string {
   const args = breadcrumb.data?.arguments
   const argText = Array.isArray(args) ? args.map(valueToSearchText).join(" ") : valueToSearchText(args)
 
   return [breadcrumb.message, argText, valueToSearchText(breadcrumb.data?.logger)].filter(Boolean).join(" ")
 }
 
-function isInjectedHostBreadcrumb(breadcrumb: SentryLikeBreadcrumb): boolean {
+function isInjectedHostBreadcrumb(breadcrumb: Breadcrumb): boolean {
   const text = breadcrumbText(breadcrumb)
 
   return (
@@ -64,11 +38,11 @@ function isInjectedHostBreadcrumb(breadcrumb: SentryLikeBreadcrumb): boolean {
   )
 }
 
-function frameText(frame: SentryLikeStackFrame): string {
+function frameText(frame: StackFrame): string {
   return [frame.function, frame.filename, frame.abs_path].filter(Boolean).join(" ")
 }
 
-function hasInjectedHostFrame(event: SentryLikeErrorEvent): boolean {
+function hasInjectedHostFrame(event: ErrorEvent): boolean {
   const frames =
     event.exception?.values?.flatMap((exception) => exception.stacktrace?.frames ?? []) ?? []
   const text = frames.map(frameText).join(" ")
@@ -76,13 +50,13 @@ function hasInjectedHostFrame(event: SentryLikeErrorEvent): boolean {
   return text.includes("addEL_hook") || text.includes("scriptPath (<anonymous>") || text.includes("GETJSURL")
 }
 
-function hasInjectedHostHint(hint?: unknown): boolean {
-  const text = valueToSearchText((hint as { originalException?: unknown } | undefined)?.originalException)
+function hasInjectedHostHint(hint: EventHint): boolean {
+  const text = valueToSearchText(hint.originalException)
 
   return text.includes("addEL_hook") || text.includes(INJECTED_HOST_PREFIX) || text.includes("GETJSURL")
 }
 
-function exceptionText(event: SentryLikeErrorEvent, hint?: unknown): string {
+function exceptionText(event: ErrorEvent, hint: EventHint): string {
   const exceptionValues = event.exception?.values ?? []
   const eventText = [
     event.message,
@@ -91,16 +65,18 @@ function exceptionText(event: SentryLikeErrorEvent, hint?: unknown): string {
     .filter(Boolean)
     .join(" ")
 
-  return `${eventText} ${valueToSearchText((hint as { originalException?: unknown } | undefined)?.originalException)}`
+  return [eventText, valueToSearchText(hint.originalException)].filter(Boolean).join(" ")
 }
 
-function isInjectedHostNullTagNameError(event: SentryLikeErrorEvent, hint?: unknown): boolean {
+function isInjectedHostNullTagNameError(event: ErrorEvent, hint: EventHint): boolean {
   const text = exceptionText(event, hint)
 
   if (!text.includes(NULL_TAG_NAME_MESSAGE)) {
     return false
   }
 
+  // exceptionText gates on the normalized event/originalException message.
+  // The checks below separately prove the stack or breadcrumb came from the injected host hook.
   return (
     hasInjectedHostFrame(event) ||
     hasInjectedHostHint(hint) ||
@@ -108,15 +84,13 @@ function isInjectedHostNullTagNameError(event: SentryLikeErrorEvent, hint?: unkn
   )
 }
 
-export function filterClientSentryBreadcrumb<T extends SentryLikeBreadcrumb>(
-  breadcrumb: T
-): T | null {
+export function filterClientSentryBreadcrumb(
+  breadcrumb: Breadcrumb,
+  _hint?: BreadcrumbHint
+): Breadcrumb | null {
   return isInjectedHostBreadcrumb(breadcrumb) ? null : breadcrumb
 }
 
-export function filterClientSentryEvent<T extends SentryLikeErrorEvent>(
-  event: T,
-  hint?: unknown
-): T | null {
+export function filterClientSentryEvent(event: ErrorEvent, hint: EventHint): ErrorEvent | null {
   return isInjectedHostNullTagNameError(event, hint) ? null : event
 }


### PR DESCRIPTION
## Summary

- follow-up to #435 for the Mogplex review comments that landed after the original PR was merged
- uses Sentry callback types for `beforeSend` and `beforeBreadcrumb` filters
- adds GETJSURL coverage for frame, hint, and breadcrumb signal paths
- documents the message gate vs injected-host evidence split and removes the trailing-space construction

## Validation

- `pnpm --filter @memories.sh/web test -- src/lib/sentry/client-filters.test.ts`
- `pnpm --filter @memories.sh/web typecheck`
- `pnpm --filter @memories.sh/web lint`
- `pnpm --filter @memories.sh/web build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/memories/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->