### PR TITLE
[codex] send payment failed billing emails

### DIFF
--- a/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/packages/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -7,8 +7,15 @@ const {
   mockRpc,
   mockUsersUpdate,
   mockUsersEq,
+  mockUsersSelect,
+  mockUsersMaybeSingle,
   mockOrganizationsUpdate,
   mockOrganizationsEq,
+  mockOrganizationsSelect,
+  mockOrganizationsMaybeSingle,
+  mockOrgMembersSelect,
+  mockOrgMembersMaybeSingle,
+  mockSendBillingPaymentFailedEmail,
 } = vi.hoisted(() => ({
   mockConstructEvent: vi.fn(),
   mockListLineItems: vi.fn(),
@@ -16,9 +23,25 @@ const {
   mockRpc: vi.fn(),
   mockUsersUpdate: vi.fn(),
   mockUsersEq: vi.fn(),
+  mockUsersSelect: vi.fn(),
+  mockUsersMaybeSingle: vi.fn(),
   mockOrganizationsUpdate: vi.fn(),
   mockOrganizationsEq: vi.fn(),
+  mockOrganizationsSelect: vi.fn(),
+  mockOrganizationsMaybeSingle: vi.fn(),
+  mockOrgMembersSelect: vi.fn(),
+  mockOrgMembersMaybeSingle: vi.fn(),
+  mockSendBillingPaymentFailedEmail: vi.fn(),
 }))
+
+function createMaybeSingleBuilder(maybeSingle: () => unknown) {
+  const builder = {
+    eq: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    maybeSingle,
+  }
+  return builder
+}
 
 vi.mock("@/lib/stripe", () => ({
   getStripe: vi.fn(() => ({
@@ -28,15 +51,22 @@ vi.mock("@/lib/stripe", () => ({
   })),
 }))
 
+vi.mock("@/lib/resend", () => ({
+  sendBillingPaymentFailedEmail: mockSendBillingPaymentFailedEmail,
+}))
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
     rpc: mockRpc,
     from: vi.fn((table: string) => {
       if (table === "users") {
-        return { update: mockUsersUpdate }
+        return { update: mockUsersUpdate, select: mockUsersSelect }
       }
       if (table === "organizations") {
-        return { update: mockOrganizationsUpdate }
+        return { update: mockOrganizationsUpdate, select: mockOrganizationsSelect }
+      }
+      if (table === "org_members") {
+        return { select: mockOrgMembersSelect }
       }
       return {
         update: vi.fn().mockReturnValue({
@@ -63,11 +93,28 @@ function makeWebhookRequest(body: string, signature = "sig_test"): Request {
 describe("POST /api/stripe/webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    delete process.env.RESEND_API_KEY
     mockRpc.mockResolvedValue({ data: "claimed", error: null })
     mockUsersEq.mockResolvedValue({ error: null })
     mockOrganizationsEq.mockResolvedValue({ error: null })
     mockUsersUpdate.mockReturnValue({ eq: mockUsersEq })
     mockOrganizationsUpdate.mockReturnValue({ eq: mockOrganizationsEq })
+    mockUsersMaybeSingle.mockResolvedValue({
+      data: { email: "owner@example.com", name: "Owner" },
+      error: null,
+    })
+    mockOrganizationsMaybeSingle.mockResolvedValue({
+      data: { name: "Acme", owner_id: "owner-1" },
+      error: null,
+    })
+    mockOrgMembersMaybeSingle.mockResolvedValue({
+      data: { user_id: "owner-1" },
+      error: null,
+    })
+    mockUsersSelect.mockImplementation(() => createMaybeSingleBuilder(mockUsersMaybeSingle))
+    mockOrganizationsSelect.mockImplementation(() => createMaybeSingleBuilder(mockOrganizationsMaybeSingle))
+    mockOrgMembersSelect.mockImplementation(() => createMaybeSingleBuilder(mockOrgMembersMaybeSingle))
+    mockSendBillingPaymentFailedEmail.mockResolvedValue(undefined)
     mockRetrieveSubscription.mockResolvedValue({
       id: "sub_team_123",
       metadata: { type: "team_seats", org_id: "org-1" },
@@ -361,6 +408,101 @@ describe("POST /api/stripe/webhook", () => {
       p_scope_type: "customer",
       p_scope_key: "cus_org_123",
     })
+  })
+
+  it("emails the organization owner when an organization invoice payment fails", async () => {
+    process.env.RESEND_API_KEY = "re_test"
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_failed_email_org_1",
+      created: 1_709_000_013,
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_team_failed_email_123",
+          customer: null,
+          subscription: {
+            id: "sub_team_123",
+            customer: "cus_org_123",
+            metadata: { type: "team_seats", org_id: "org-1" },
+            items: { data: [{ price: { id: "price_team_monthly" } }] },
+          },
+          lines: { data: [{ price: { id: "price_team_monthly" } }] },
+        },
+      },
+    })
+    mockOrganizationsMaybeSingle.mockResolvedValue({
+      data: { name: "Acme", owner_id: "owner-1" },
+      error: null,
+    })
+    mockUsersMaybeSingle.mockResolvedValue({
+      data: { email: "owner@example.com", name: "Casey Owner" },
+      error: null,
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockSendBillingPaymentFailedEmail).toHaveBeenCalledWith({
+      to: "owner@example.com",
+      recipientName: "Casey Owner",
+      workspaceName: "Acme workspace",
+      invoiceId: "in_team_failed_email_123",
+      idempotencyKey: "stripe-payment-failed/evt_invoice_failed_email_org_1",
+    })
+  })
+
+  it("emails the paying user when a personal invoice payment fails", async () => {
+    process.env.RESEND_API_KEY = "re_test"
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_failed_email_user_1",
+      created: 1_709_000_014,
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_user_failed_email_123",
+          customer: "cus_user_123",
+          subscription: null,
+          lines: { data: [{ price: { id: "price_individual_monthly" } }] },
+        },
+      },
+    })
+    mockUsersMaybeSingle.mockResolvedValue({
+      data: { email: "user@example.com", name: null },
+      error: null,
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockUsersUpdate).toHaveBeenCalledWith({ plan: "past_due" })
+    expect(mockUsersEq).toHaveBeenCalledWith("stripe_customer_id", "cus_user_123")
+    expect(mockSendBillingPaymentFailedEmail).toHaveBeenCalledWith({
+      to: "user@example.com",
+      recipientName: "user",
+      workspaceName: "your personal memories.sh workspace",
+      invoiceId: "in_user_failed_email_123",
+      idempotencyKey: "stripe-payment-failed/evt_invoice_failed_email_user_1",
+    })
+  })
+
+  it("keeps Stripe webhook processing successful when payment failure email delivery fails", async () => {
+    process.env.RESEND_API_KEY = "re_test"
+    mockSendBillingPaymentFailedEmail.mockRejectedValueOnce(new Error("resend down"))
+    mockConstructEvent.mockReturnValue({
+      id: "evt_invoice_failed_email_error_1",
+      created: 1_709_000_015,
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_user_failed_email_error_123",
+          customer: "cus_user_123",
+          subscription: null,
+          lines: { data: [{ price: { id: "price_individual_monthly" } }] },
+        },
+      },
+    })
+
+    const response = await POST(makeWebhookRequest("{}"))
+    expect(response.status).toBe(200)
+    expect(mockSendBillingPaymentFailedEmail).toHaveBeenCalled()
   })
 
   it("uses expanded invoice subscriptions for uncollectible invoices without Stripe re-fetch", async () => {

--- a/packages/web/src/app/api/stripe/webhook/route.ts
+++ b/packages/web/src/app/api/stripe/webhook/route.ts
@@ -8,10 +8,17 @@ import {
   getStripeManagedPriceIds,
   getStripeTeamSeatPriceIds,
   getStripeWebhookSecret,
+  hasResendApiKey,
 } from "@/lib/env"
+import { sendBillingPaymentFailedEmail } from "@/lib/resend"
 
 type StripeBillingPlan = "individual" | "team" | "growth"
 type WebhookScope = { type: "customer" | "organization" | "user"; key: string }
+type BillingPaymentFailedContact = {
+  to: string
+  recipientName: string | null
+  workspaceName: string
+}
 type ManagedWebhookEventType =
   | "checkout.session.completed"
   | "customer.subscription.created"
@@ -264,6 +271,161 @@ async function updateOrgSubscriptionStatus(
   return true
 }
 
+function displayNameFromContact(contact: { email?: string | null; name?: string | null }): string | null {
+  if (contact.name?.trim()) return contact.name.trim()
+  if (!contact.email) return null
+  const [localPart] = contact.email.split("@")
+  return localPart || null
+}
+
+async function loadUserPaymentFailedContact(
+  supabase: ReturnType<typeof createAdminClient>,
+  customerId: string
+): Promise<BillingPaymentFailedContact | null> {
+  const { data: user, error } = await supabase
+    .from("users")
+    .select("email, name")
+    .eq("stripe_customer_id", customerId)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to load payment-failed user contact:", { customerId, error })
+    return null
+  }
+
+  if (!user?.email) {
+    console.warn("Skipping payment-failed email because user contact is missing:", { customerId })
+    return null
+  }
+
+  return {
+    to: user.email,
+    recipientName: displayNameFromContact(user),
+    workspaceName: "your personal memories.sh workspace",
+  }
+}
+
+async function loadOrgOwnerUserId(
+  supabase: ReturnType<typeof createAdminClient>,
+  orgId: string
+): Promise<string | null> {
+  const { data: membership, error } = await supabase
+    .from("org_members")
+    .select("user_id")
+    .eq("org_id", orgId)
+    .eq("role", "owner")
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to load payment-failed org owner membership:", { orgId, error })
+    return null
+  }
+
+  return typeof membership?.user_id === "string" ? membership.user_id : null
+}
+
+async function loadOrgPaymentFailedContact(
+  supabase: ReturnType<typeof createAdminClient>,
+  orgId: string
+): Promise<BillingPaymentFailedContact | null> {
+  const { data: org, error: orgError } = await supabase
+    .from("organizations")
+    .select("name, owner_id")
+    .eq("id", orgId)
+    .maybeSingle()
+
+  if (orgError) {
+    console.error("Failed to load payment-failed organization contact:", { orgId, error: orgError })
+    return null
+  }
+
+  const ownerUserId =
+    typeof org?.owner_id === "string" && org.owner_id.length > 0
+      ? org.owner_id
+      : await loadOrgOwnerUserId(supabase, orgId)
+
+  if (!ownerUserId) {
+    console.warn("Skipping payment-failed email because organization owner is missing:", { orgId })
+    return null
+  }
+
+  const { data: owner, error: ownerError } = await supabase
+    .from("users")
+    .select("email, name")
+    .eq("id", ownerUserId)
+    .maybeSingle()
+
+  if (ownerError) {
+    console.error("Failed to load payment-failed organization owner contact:", {
+      orgId,
+      ownerUserId,
+      error: ownerError,
+    })
+    return null
+  }
+
+  if (!owner?.email) {
+    console.warn("Skipping payment-failed email because organization owner email is missing:", {
+      orgId,
+      ownerUserId,
+    })
+    return null
+  }
+
+  return {
+    to: owner.email,
+    recipientName: displayNameFromContact(owner),
+    workspaceName: org?.name ? `${org.name} workspace` : "your organization workspace",
+  }
+}
+
+async function maybeSendPaymentFailedEmail({
+  supabase,
+  eventId,
+  customerId,
+  invoiceId,
+  orgId,
+}: {
+  supabase: ReturnType<typeof createAdminClient>
+  eventId: string
+  customerId: string
+  invoiceId: string
+  orgId: string | null
+}): Promise<void> {
+  if (!hasResendApiKey()) {
+    console.warn("Skipping payment-failed email because RESEND_API_KEY is not configured:", {
+      eventId,
+      customerId,
+      invoiceId,
+      orgId,
+    })
+    return
+  }
+
+  const contact = orgId
+    ? await loadOrgPaymentFailedContact(supabase, orgId)
+    : await loadUserPaymentFailedContact(supabase, customerId)
+
+  if (!contact) return
+
+  try {
+    await sendBillingPaymentFailedEmail({
+      ...contact,
+      invoiceId,
+      idempotencyKey: `stripe-payment-failed/${eventId}`,
+    })
+  } catch (error) {
+    console.error("Failed to send payment-failed billing email:", {
+      eventId,
+      customerId,
+      invoiceId,
+      orgId,
+      error,
+    })
+  }
+}
+
 export async function POST(request: Request): Promise<Response> {
   const body = await request.text()
   const signature = request.headers.get("stripe-signature")
@@ -457,6 +619,15 @@ export async function POST(request: Request): Promise<Response> {
               stripeSubscriptionId: subscription.id,
               activePlan: planForActiveOrgSubscription(subscriptionPlan),
             })
+            if (ok) {
+              await maybeSendPaymentFailedEmail({
+                supabase,
+                eventId: event.id,
+                customerId,
+                invoiceId: invoice.id,
+                orgId,
+              })
+            }
             handled = true
           } else if (isTeamSubscription(subscription.metadata)) {
             console.error("Team subscription missing org_id for invoice:", subscription.id)
@@ -471,6 +642,15 @@ export async function POST(request: Request): Promise<Response> {
       // Individual subscription (only if not handled as team)
       if (!handled) {
         ok = await updateUserPlan(supabase, { stripe_customer_id: customerId }, { plan: "past_due" })
+        if (ok) {
+          await maybeSendPaymentFailedEmail({
+            supabase,
+            eventId: event.id,
+            customerId,
+            invoiceId: invoice.id,
+            orgId: null,
+          })
+        }
       }
       break
     }

--- a/packages/web/src/lib/resend.ts
+++ b/packages/web/src/lib/resend.ts
@@ -1,6 +1,6 @@
 import { Resend } from "resend"
 import { getTeamInviteExpiryLabel } from "./team-invites"
-import { getResendApiKey, getResendFromEmail } from "@/lib/env"
+import { getAppUrl, getResendApiKey, getResendFromEmail } from "@/lib/env"
 
 let resend: Resend | null = null
 
@@ -9,6 +9,105 @@ export function getResend(): Resend {
     resend = new Resend(getResendApiKey())
   }
   return resend
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;")
+}
+
+export async function sendBillingPaymentFailedEmail({
+  to,
+  recipientName,
+  workspaceName,
+  invoiceId,
+  idempotencyKey,
+}: {
+  to: string
+  recipientName?: string | null
+  workspaceName: string
+  invoiceId?: string | null
+  idempotencyKey: string
+}): Promise<void> {
+  const billingUrl = `${getAppUrl()}/app/billing`
+  const fromEmail = getResendFromEmail()
+  const greeting = recipientName?.trim() ? `Hi ${recipientName.trim()},` : "Hi,"
+  const invoiceLine = invoiceId ? `\n\nInvoice: ${invoiceId}` : ""
+
+  const { error } = await getResend().emails.send(
+    {
+      from: fromEmail,
+      to,
+      subject: "Action needed: update your memories.sh payment method",
+      html: `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #0a0a0a; color: #fafafa; margin: 0; padding: 40px 20px;">
+  <div style="max-width: 520px; margin: 0 auto;">
+    <div style="text-align: center; margin-bottom: 32px;">
+      <img src="https://memories.sh/memories.svg" alt="memories.sh" width="40" height="40" style="filter: invert(1);">
+    </div>
+
+    <div style="background-color: #171717; border: 1px solid #262626; padding: 32px;">
+      <h1 style="font-size: 20px; font-weight: 600; margin: 0 0 16px;">
+        Payment method needs attention
+      </h1>
+
+      <p style="color: #d4d4d8; margin: 0 0 16px; line-height: 1.6;">
+        ${escapeHtml(greeting)}
+      </p>
+
+      <p style="color: #a3a3a3; margin: 0 0 24px; line-height: 1.6;">
+        We couldn't process the latest payment for
+        <strong style="color: #fafafa;">${escapeHtml(workspaceName)}</strong>.
+        Your workspace is marked past due until the payment method is updated.
+      </p>
+
+      <a href="${escapeHtml(billingUrl)}" style="display: block; background-color: #fafafa; color: #0a0a0a; text-decoration: none; padding: 14px 24px; text-align: center; font-weight: 600; font-size: 14px;">
+        Update Payment Method
+      </a>
+
+      <p style="color: #525252; font-size: 12px; margin: 24px 0 0; line-height: 1.6;">
+        If you already updated your payment method in Stripe, you can ignore this email.
+        ${invoiceId ? `Invoice: ${escapeHtml(invoiceId)}.` : ""}
+      </p>
+    </div>
+
+    <p style="color: #525252; font-size: 12px; text-align: center; margin-top: 24px;">
+      memories.sh - Memory layer for AI coding agents
+    </p>
+  </div>
+</body>
+</html>
+      `,
+      text: `
+${greeting}
+
+We couldn't process the latest payment for ${workspaceName}. Your workspace is marked past due until the payment method is updated.
+
+Update your payment method: ${billingUrl}${invoiceLine}
+
+If you already updated your payment method in Stripe, you can ignore this email.
+      `.trim(),
+      tags: [
+        { name: "email_type", value: "billing_payment_failed" },
+        { name: "source", value: "stripe_webhook" },
+      ],
+    },
+    { idempotencyKey }
+  )
+
+  if (error) {
+    throw new Error(error.message)
+  }
 }
 
 export async function sendTeamInviteEmail({


### PR DESCRIPTION
## Summary

- send a billing payment-failed email from the Stripe `invoice.payment_failed` webhook after the past-due state is persisted
- resolve organization failures to the organization owner and personal failures to the paying user
- make Resend delivery idempotent by Stripe event and log email/config failures without failing webhook processing

## Root Cause

The webhook marked users or organizations as `past_due`, but there was no customer-facing notification path for failed invoice payments.

## Validation

- `pnpm -C packages/web test src/app/api/stripe/webhook/__tests__/route.test.ts`
- `pnpm -C packages/web typecheck`
- `pnpm -C packages/web lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/memories/pr/455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784392049&installation_id=129242532&pr_number=455&repository=webrenew%2Fmemories&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Fmemories%2Fpull%2F455&signature=975a0c40851348cb8fa54d49e341dc28f0cba42cb3bd3309781bf6b5c9e3e336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->