### PR TITLE
[codex] fix email logo visibility

### DIFF
--- a/packages/web/src/lib/resend.ts
+++ b/packages/web/src/lib/resend.ts
@@ -3,6 +3,11 @@ import { getTeamInviteExpiryLabel } from "./team-invites"
 import { getAppUrl, getResendApiKey, getResendFromEmail } from "@/lib/env"
 
 let resend: Resend | null = null
+const EMAIL_LOGO_URL = "https://memories.sh/favicon-96x96.png"
+const EMAIL_LOGO_HTML = `
+      <div style="display: inline-block; background-color: #fafafa; border-radius: 14px; padding: 10px;">
+        <img src="${EMAIL_LOGO_URL}" alt="memories.sh" width="48" height="48" style="display: block; border: 0; outline: none; text-decoration: none;">
+      </div>`
 
 export function getResend(): Resend {
   if (!resend) {
@@ -53,7 +58,7 @@ export async function sendBillingPaymentFailedEmail({
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #0a0a0a; color: #fafafa; margin: 0; padding: 40px 20px;">
   <div style="max-width: 520px; margin: 0 auto;">
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://memories.sh/memories.svg" alt="memories.sh" width="40" height="40" style="filter: invert(1);">
+${EMAIL_LOGO_HTML}
     </div>
 
     <div style="background-color: #171717; border: 1px solid #262626; padding: 32px;">
@@ -142,7 +147,7 @@ export async function sendTeamInviteEmail({
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #0a0a0a; color: #fafafa; margin: 0; padding: 40px 20px;">
   <div style="max-width: 480px; margin: 0 auto;">
     <div style="text-align: center; margin-bottom: 32px;">
-      <img src="https://memories.sh/memories.svg" alt="memories.sh" width="40" height="40" style="filter: invert(1);">
+${EMAIL_LOGO_HTML}
     </div>
     
     <div style="background-color: #171717; border: 1px solid #262626; padding: 32px;">


### PR DESCRIPTION
## Summary

- replace filtered SVG logo usage in transactional email templates with the PNG favicon
- render the logo on a light badge so it remains visible in dark email clients
- applies to both billing payment-failed and team invite emails

## Root Cause

The email templates depended on `filter: invert(1)` against an SVG with dark fills. Some email clients do not render that filter reliably, making the logo effectively invisible on the dark email background.

## Validation

- `pnpm -C packages/web lint`
- `pnpm -C packages/web typecheck`
- sent corrected Resend test email to `charles@webrenew.io`; Resend reported `delivered` for id `10ee82ea-1617-4b91-a57c-65a7f3cab8b5`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/memories/pr/456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784400685&installation_id=129242532&pr_number=456&repository=webrenew%2Fmemories&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Fmemories%2Fpull%2F456&signature=98d0e6cc86db292e487b0d9aebd659a599a923ae9f0330a30fc77dc87a58d75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->