### PR TITLE
fix(mcp): accept explicit project_id on read tools

### DIFF
--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -68,6 +68,7 @@ Use this at the start of tasks to understand project conventions and recall past
       inactivity_threshold_minutes: z.number().int().positive().optional().describe("Inactivity threshold in minutes for time-trigger checks"),
       task_completed: z.boolean().optional().describe("Semantic completion hint to trigger checkpointing after task completion"),
       include_session_summary: z.boolean().optional().describe("Reserved for future snapshot/session summary hydration"),
+      project_id: z.string().optional().describe("Explicit project id to read from (e.g., github.com/org/repo). Overrides the server's auto-detected project scope."),
     },
     async ({
       query,
@@ -80,10 +81,11 @@ Use this at the start of tasks to understand project conventions and recall past
       last_activity_at,
       inactivity_threshold_minutes,
       task_completed,
+      project_id,
     }) => {
       try {
         const { rules, memories } = await getContext(query, {
-          projectId: projectId ?? undefined,
+          projectId: project_id?.trim() ? project_id.trim() : (projectId ?? undefined),
           limit,
           mode,
         });
@@ -446,14 +448,15 @@ Use category to group related memories (e.g., "api", "testing").`,
       type: z.enum(["rule", "decision", "fact", "note", "skill"]).optional().describe("Filter by a single memory type"),
       types: z.array(z.enum(["rule", "decision", "fact", "note", "skill"])).optional().describe("Filter by memory types"),
       layer: z.enum(["rule", "working", "long_term"]).optional().describe("Filter by a single memory layer"),
+      project_id: z.string().optional().describe("Explicit project id to read from (e.g., github.com/org/repo). Overrides the server's auto-detected project scope."),
     },
-    async ({ query, limit, type, types, layer }) => {
+    async ({ query, limit, type, types, layer, project_id }) => {
       try {
         const resolvedTypes = types?.length ? types : (type ? [type] : undefined);
         const layers = layer ? [layer] : undefined;
         const memories = await searchMemories(query, {
           limit,
-          projectId: projectId ?? undefined,
+          projectId: project_id?.trim() ? project_id.trim() : (projectId ?? undefined),
           types: resolvedTypes,
           layers,
         });
@@ -486,10 +489,12 @@ Use category to group related memories (e.g., "api", "testing").`,
   server.tool(
     "get_rules",
     "Get all active rules for the current project. Rules are coding standards, preferences, and constraints that should always be followed.",
-    {},
-    async () => {
+    {
+      project_id: z.string().optional().describe("Explicit project id to read from (e.g., github.com/org/repo). Overrides the server's auto-detected project scope."),
+    },
+    async ({ project_id }) => {
       try {
-        const rules = await getRules({ projectId: projectId ?? undefined });
+        const rules = await getRules({ projectId: project_id?.trim() ? project_id.trim() : (projectId ?? undefined) });
 
         if (rules.length === 0) {
           return {
@@ -530,8 +535,9 @@ Use category to group related memories (e.g., "api", "testing").`,
       type: z.enum(["rule", "decision", "fact", "note", "skill"]).optional().describe("Filter by a single memory type"),
       types: z.array(z.enum(["rule", "decision", "fact", "note", "skill"])).optional().describe("Filter by memory types"),
       layer: z.enum(["rule", "working", "long_term"]).optional().describe("Filter by a single memory layer"),
+      project_id: z.string().optional().describe("Explicit project id to read from (e.g., github.com/org/repo). Overrides the server's auto-detected project scope."),
     },
-    async ({ limit, tags, type, types, layer }) => {
+    async ({ limit, tags, type, types, layer, project_id }) => {
       try {
         const normalizedTags = Array.isArray(tags)
           ? tags
@@ -543,7 +549,7 @@ Use category to group related memories (e.g., "api", "testing").`,
         const memories = await listMemories({
           limit,
           tags: normalizedTags,
-          projectId: projectId ?? undefined,
+          projectId: project_id?.trim() ? project_id.trim() : (projectId ?? undefined),
           types: resolvedTypes,
           layers,
         });


### PR DESCRIPTION
## Summary

`get_context`, `get_rules`, `list_memories`, and `search_memories` only ever resolve project scope from a closure variable set once at MCP server startup (the working directory's git remote at launch time). There is no way to override it per call — unlike `add_memory`, which already accepts an explicit `project_id`.

The underlying store functions (`getContext`, `getRules`, `listMemories`, `searchMemories`) already accept a `projectId` option via `QueryMemoryOpts` — only the MCP tool schemas and handlers failed to expose and pass it through. This adds an optional `project_id` parameter to each of the four tools' schemas, following the same pattern already used by `add_memory`, `bulk_forget_memories`, and the reminder tools.

Without this fix, any memory written with an explicit `project_id` (e.g. from a directory outside the target repo) becomes unreachable through every MCP read path, since the server can only ever query its own launch-time scope.

## Testing

Built the patched CLI locally (`pnpm install && pnpm --filter @memories.sh/cli build`) and ran a live MCP session (`serve` over stdio) from an unrelated directory:
- Without `project_id`: correctly saw only global memories (server started in "global only, not in a git repo" mode).
- With an explicit `project_id` pointing at an unrelated project's memories: correctly returned the full expected set, project + global.

`tsc --noEmit` passes (also verified via the repo's own pre-commit hook).

## Scope

This PR only touches the four read tools. Other tools were checked too:
- `add_memory`, `bulk_forget_memories`, `add_reminder`, `list_reminders`, `run_due_reminders`, `start_memory_stream` already accept `project_id`.
- `edit_memory` and single-record operations (`forget_memory`, `enable/disable/delete_reminder`) act by `id` and are scope-agnostic in practice — no patch needed there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/memories/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787239564&installation_model_id=20495&pr_number=469&repository=webrenew%2Fmemories&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Fmemories%2Fpull%2F469&signature=a060b291021faad495a89eaf44cc0d12a6995651f6bfefd7e87d2d987bdc7991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->